### PR TITLE
Topic 78 - Move onReady and onDisconnect to Communicator / Cleanup lifecycle listeners

### DIFF
--- a/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
+++ b/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
@@ -59,7 +59,7 @@ public abstract class AbstractObsE2ETest {
   protected static void connectToObs() {
     remote = OBSRemoteController.builder()
         .lifecycle()
-        .onControllerError(((controller, reasonThrowable) -> {
+        .onControllerError(((reasonThrowable) -> {
           System.out.println("An error occurred: " + reasonThrowable.getReason());
           reasonThrowable.getThrowable().printStackTrace();
         }))

--- a/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
+++ b/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
@@ -59,7 +59,7 @@ public abstract class AbstractObsE2ETest {
   protected static void connectToObs() {
     remote = OBSRemoteController.builder()
         .lifecycle()
-        .onError(((controller, reasonThrowable) -> {
+        .onControllerError(((controller, reasonThrowable) -> {
           System.out.println("An error occurred: " + reasonThrowable.getReason());
           reasonThrowable.getThrowable().printStackTrace();
         }))

--- a/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteAuthE2eIT.java
+++ b/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteAuthE2eIT.java
@@ -110,16 +110,16 @@ class ObsRemoteAuthE2eIT {
   void testConnectAndDisconnectToSecuredServerWithCorrectPassword() throws Exception {
 
     AtomicReference<String> failReason = new AtomicReference<>();
-    AtomicReference<Boolean> connectorIdentified = new AtomicReference<>(false);
+    AtomicReference<Boolean> connectorReadyReference = new AtomicReference<>(false);
 
     // Given we have a websocket client and annotated websocket communicator
     OBSCommunicator communicator = OBSCommunicator.builder()
         .password(PASSWORD)
         // And given we have registered callbacks to disconnect once connected & identified
         .lifecycle()
-        .onIdentified((comm, identified) -> {
+        .onReady((comm) -> {
           System.out.println("(Test) Authenticated successfully");
-          connectorIdentified.set(true);
+          connectorReadyReference.set(true);
         })
         .onHello((comm, hello) -> {
           if (hello.getAuthentication() == null) {
@@ -142,7 +142,7 @@ class ObsRemoteAuthE2eIT {
       fail(failReason.get());
     }
     // And the client should have been identified
-    if (!connectorIdentified.get()) {
+    if (!connectorReadyReference.get()) {
       fail("Did not successfully identify the communicator");
     }
   }

--- a/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteAuthE2eIT.java
+++ b/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteAuthE2eIT.java
@@ -31,10 +31,10 @@ class ObsRemoteAuthE2eIT {
         .password(null)
         // Given we register a callback on close
         .lifecycle()
-        .onClose((comm, webSocketCloseCode) -> {
+        .onClose((webSocketCloseCode) -> {
           webSocketCloseCodeAtomicReference.set(webSocketCloseCode);
         })
-        .onHello((comm, hello) -> {
+        .onHello((hello) -> {
           if (hello.getAuthentication() == null) {
             failReason.set("Authentication wasn't enabled");
           }
@@ -73,10 +73,10 @@ class ObsRemoteAuthE2eIT {
         .password(PASSWORD + "gibberish")
         // Given we register a callback on error
         .lifecycle()
-        .onClose((comm, webSocketCloseCode) -> {
+        .onClose((webSocketCloseCode) -> {
           webSocketCloseCodeAtomicReference.set(webSocketCloseCode);
         })
-        .onHello((comm, hello) -> {
+        .onHello((hello) -> {
           if (hello.getAuthentication() == null) {
             failReason.set("Authentication wasn't enabled");
           }
@@ -117,11 +117,11 @@ class ObsRemoteAuthE2eIT {
         .password(PASSWORD)
         // And given we have registered callbacks to disconnect once connected & identified
         .lifecycle()
-        .onReady((comm) -> {
+        .onReady(() -> {
           System.out.println("(Test) Authenticated successfully");
           connectorReadyReference.set(true);
         })
-        .onHello((comm, hello) -> {
+        .onHello((hello) -> {
           if (hello.getAuthentication() == null) {
             failReason.set("Authentication wasn't enabled");
           }

--- a/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteLifecycleE2eIT.java
+++ b/src/endToEndSecuredTest/java/io/obswebsocket/community/client/test/ObsRemoteLifecycleE2eIT.java
@@ -33,11 +33,11 @@ public class ObsRemoteLifecycleE2eIT {
         .password(PASSWORD)
         // Given we register a callback on close
         .lifecycle()
-        .onConnect(((comm, session) -> sessionAtomicReference.set(session)))
-        .onClose((comm, webSocketCloseCode) -> {
+        .onConnect(((session) -> sessionAtomicReference.set(session)))
+        .onClose((webSocketCloseCode) -> {
           webSocketCloseCodeAtomicReference.set(webSocketCloseCode);
         })
-        .onHello((comm, hello) -> {
+        .onHello((hello) -> {
           if (hello.getAuthentication() == null) {
             failReason.set("Authentication wasn't enabled");
           }

--- a/src/endToEndUnsecuredTest/java/io/obswebsocket/community/client/test/OBSRemoteControllerUnsecuredIT.java
+++ b/src/endToEndUnsecuredTest/java/io/obswebsocket/community/client/test/OBSRemoteControllerUnsecuredIT.java
@@ -20,11 +20,11 @@ public class OBSRemoteControllerUnsecuredIT {
         .password(null)
         // And given we have registered callbacks to disconnect once connected & identified
         .lifecycle()
-        .onReady((comm) -> {
+        .onReady(() -> {
           System.out.println("(Test) Authenticated successfully");
           connectorReady.set(true);
         })
-        .onHello((comm, hello) -> {
+        .onHello((hello) -> {
           if (hello.getAuthentication() != null) {
             failReason.set("Authentication needs to be disabled for this test");
           }

--- a/src/endToEndUnsecuredTest/java/io/obswebsocket/community/client/test/OBSRemoteControllerUnsecuredIT.java
+++ b/src/endToEndUnsecuredTest/java/io/obswebsocket/community/client/test/OBSRemoteControllerUnsecuredIT.java
@@ -13,16 +13,16 @@ public class OBSRemoteControllerUnsecuredIT {
   void testConnectAndDisconnectToUnsecuredServer() throws Exception {
 
     AtomicReference<String> failReason = new AtomicReference<>();
-    AtomicReference<Boolean> connectorIdentified = new AtomicReference<>(false);
+    AtomicReference<Boolean> connectorReady = new AtomicReference<>(false);
 
     // Given we have a websocket client and annotated websocket communicator
     OBSCommunicator communicator = OBSCommunicator.builder()
         .password(null)
         // And given we have registered callbacks to disconnect once connected & identified
         .lifecycle()
-        .onIdentified((comm, identified) -> {
+        .onReady((comm) -> {
           System.out.println("(Test) Authenticated successfully");
-          connectorIdentified.set(true);
+          connectorReady.set(true);
         })
         .onHello((comm, hello) -> {
           if (hello.getAuthentication() != null) {
@@ -45,7 +45,7 @@ public class OBSRemoteControllerUnsecuredIT {
       fail(failReason.get());
     }
     // And the client should have been identified
-    if (!connectorIdentified.get()) {
+    if (!connectorReady.get()) {
       fail("Did not successfully identify the communicator");
     }
   }

--- a/src/integrationTest/java/io/obswebsocket/community/client/test/UnreachableObsIT.java
+++ b/src/integrationTest/java/io/obswebsocket/community/client/test/UnreachableObsIT.java
@@ -23,7 +23,7 @@ public class UnreachableObsIT {
         .port(4545)
         .connectionTimeout(1)
         .lifecycle()
-        .onError((controller, reasonThrowable) -> {
+        .onControllerError((controller, reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()
@@ -53,7 +53,7 @@ public class UnreachableObsIT {
         .port(4545)
         .connectionTimeout(300)
         .lifecycle()
-        .onError((controller, reasonThrowable) -> {
+        .onControllerError((controller, reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()
@@ -83,7 +83,7 @@ public class UnreachableObsIT {
             .toString()) // UUID is random and valid because it contains - instead of _
         .connectionTimeout(1)
         .lifecycle()
-        .onError((controller, reasonThrowable) -> {
+        .onControllerError((controller, reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()

--- a/src/integrationTest/java/io/obswebsocket/community/client/test/UnreachableObsIT.java
+++ b/src/integrationTest/java/io/obswebsocket/community/client/test/UnreachableObsIT.java
@@ -23,7 +23,7 @@ public class UnreachableObsIT {
         .port(4545)
         .connectionTimeout(1)
         .lifecycle()
-        .onControllerError((controller, reasonThrowable) -> {
+        .onControllerError((reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()
@@ -53,7 +53,7 @@ public class UnreachableObsIT {
         .port(4545)
         .connectionTimeout(300)
         .lifecycle()
-        .onControllerError((controller, reasonThrowable) -> {
+        .onControllerError((reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()
@@ -83,7 +83,7 @@ public class UnreachableObsIT {
             .toString()) // UUID is random and valid because it contains - instead of _
         .connectionTimeout(1)
         .lifecycle()
-        .onControllerError((controller, reasonThrowable) -> {
+        .onControllerError((reasonThrowable) -> {
           reasonThrowableReference.set(reasonThrowable);
         })
         .and()

--- a/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
@@ -111,7 +111,7 @@ public class OBSCommunicator {
   @OnWebSocketError
   public void onError(Session session, Throwable t) {
     this.communicatorLifecycleListener
-        .onError(this, new ReasonThrowable(
+        .onError(new ReasonThrowable(
             "Websocket error occurred with session " + session, t
         ));
     if (this.session != null) {
@@ -132,18 +132,18 @@ public class OBSCommunicator {
           reason
       ));
     }
-    this.communicatorLifecycleListener.onClose(this, webSocketCloseCode);
+    this.communicatorLifecycleListener.onClose(webSocketCloseCode);
     this.closeLatch.countDown();
-    this.communicatorLifecycleListener.onDisconnect(this);
+    this.communicatorLifecycleListener.onDisconnect();
   }
 
   @OnWebSocketConnect
   public void onConnect(Session session) {
     this.session = session;
     try {
-      this.communicatorLifecycleListener.onConnect(this, this.session);
+      this.communicatorLifecycleListener.onConnect(this.session);
     } catch (Throwable t) {
-      this.communicatorLifecycleListener.onError(this, new ReasonThrowable(
+      this.communicatorLifecycleListener.onError(new ReasonThrowable(
           "An error occurred while trying to get a session", t
       ));
     }
@@ -178,24 +178,24 @@ public class OBSCommunicator {
             break;
 
           default:
-            this.communicatorLifecycleListener.onError(this, new ReasonThrowable(
+            this.communicatorLifecycleListener.onError(new ReasonThrowable(
                 "Invalid response type received", null
             ));
         }
       } else {
         this.communicatorLifecycleListener
-            .onError(this, new ReasonThrowable(
+            .onError(new ReasonThrowable(
                 "Received message was deserializable but had unknown format", null
             ));
       }
     } catch (JsonSyntaxException jsonSyntaxException) {
       this.communicatorLifecycleListener
-          .onError(this, new ReasonThrowable(
+          .onError(new ReasonThrowable(
               "Message received was not valid json: " + msg, jsonSyntaxException
           ));
     } catch (Throwable t) {
       this.communicatorLifecycleListener
-          .onError(this, new ReasonThrowable(
+          .onError(new ReasonThrowable(
               "Failed to process message from websocket due to unexpected exception", t
           ));
     }
@@ -211,7 +211,7 @@ public class OBSCommunicator {
       obsEventListener.onEvent(event);
     } catch (Throwable t) {
       this.communicatorLifecycleListener
-          .onError(this, new ReasonThrowable(
+          .onError(new ReasonThrowable(
               "Failed to execute callback for Event: " + event.getEventType(), t
           ));
     }
@@ -226,7 +226,7 @@ public class OBSCommunicator {
     try {
       obsRequestListener.onRequestResponse(requestResponse);
     } catch (Throwable t) {
-      this.communicatorLifecycleListener.onError(this, new ReasonThrowable(
+      this.communicatorLifecycleListener.onError(new ReasonThrowable(
           "Failed to execute callback for RequestResponse: " + requestResponse.getRequestType(), t
       ));
     }
@@ -241,7 +241,7 @@ public class OBSCommunicator {
     try {
       obsRequestListener.onRequestBatchResponse(requestBatchResponse);
     } catch (Throwable t) {
-      this.communicatorLifecycleListener.onError(this, new ReasonThrowable(
+      this.communicatorLifecycleListener.onError(new ReasonThrowable(
           "Failed to execute callback for RequestBatchResponse: " + requestBatchResponse, t
       ));
     }
@@ -286,7 +286,7 @@ public class OBSCommunicator {
     }
 
     // Send the response
-    this.communicatorLifecycleListener.onHello(this, hello);
+    this.communicatorLifecycleListener.onHello(hello);
     this.sendMessage(identifyBuilder.build());
   }
 
@@ -296,7 +296,7 @@ public class OBSCommunicator {
    * @param identified {@link Identified}
    */
   public void onIdentified(Identified identified) {
-    this.communicatorLifecycleListener.onIdentified(this, identified);
+    this.communicatorLifecycleListener.onIdentified(identified);
 
     this.sendRequest(GetVersionRequest.builder().build(),
         (GetVersionResponse getVersionResponse) -> {
@@ -305,7 +305,7 @@ public class OBSCommunicator {
               getVersionResponse.getResponseData().getObsWebSocketVersion()));
         });
 
-    this.communicatorLifecycleListener.onReady(this);
+    this.communicatorLifecycleListener.onReady();
   }
 
   /**
@@ -316,7 +316,7 @@ public class OBSCommunicator {
   private void send(String message) {
     log.debug("Sent message     >>\n" + message);
     if (this.session == null) {
-      communicatorLifecycleListener.onError(this, new ReasonThrowable(
+      communicatorLifecycleListener.onError(new ReasonThrowable(
           "Could not send message; no session established",
           null
       ));

--- a/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
@@ -124,6 +124,7 @@ public class OBSCommunicator {
     }
     this.communicatorLifecycleListener.onClose(this, webSocketCloseCode);
     this.closeLatch.countDown();
+    this.communicatorLifecycleListener.onDisconnect(this);
   }
 
   @OnWebSocketConnect
@@ -294,6 +295,8 @@ public class OBSCommunicator {
               getVersionResponse.getResponseData().getObsVersion(),
               getVersionResponse.getResponseData().getObsWebSocketVersion()));
         });
+
+    this.communicatorLifecycleListener.onReady(this);
   }
 
   /**

--- a/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
@@ -29,6 +29,16 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 
+/**
+ * An annotated websocket listener that accepts callbacks for standard websocket callbacks
+ * (connect, message, close), callbacks specific to OBS Websocket (hello, identified, event, etc),
+ * and for lifecycle events specific to this client library (ready, disconnect). See
+ * ${@link CommunicatorLifecycleListener} for more information.
+ *
+ * This class is internal to this library and should not be used directly; please use
+ * ${@link OBSRemoteController} for requests and ${@link OBSRemoteController#builder()} to register
+ * lifecycle custom callbacks/listeners.
+ */
 @Slf4j
 @WebSocket(maxTextMessageSize = 1024 * 1024, maxIdleTime = 360000000)
 public class OBSCommunicator {
@@ -286,7 +296,6 @@ public class OBSCommunicator {
    * @param identified {@link Identified}
    */
   public void onIdentified(Identified identified) {
-    log.info("Identified by OBS, ready to accept requests");
     this.communicatorLifecycleListener.onIdentified(this, identified);
 
     this.sendRequest(GetVersionRequest.builder().build(),

--- a/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
@@ -82,8 +82,8 @@ public class OBSCommunicator {
     this.obsEventListener = obsEventListener;
   }
 
-  public static ObsCommunicatorBuilder builder() {
-    return new ObsCommunicatorBuilder();
+  public static OBSCommunicatorBuilder builder() {
+    return new OBSCommunicatorBuilder();
   }
 
   /**

--- a/src/main/java/io/obswebsocket/community/client/OBSCommunicatorBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSCommunicatorBuilder.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 /**
  * Internal builder for constructing instances of ${@link OBSCommunicator}.
  */
-public class ObsCommunicatorBuilder {
+public class OBSCommunicatorBuilder {
 
   private final static MessageTranslator TRANSLATOR;
 
@@ -28,10 +28,10 @@ public class ObsCommunicatorBuilder {
       this);
   private ConcurrentHashMap<Class<? extends Event>, Consumer> eventListeners = new ConcurrentHashMap<>();
 
-  public ObsCommunicatorBuilder() {
+  public OBSCommunicatorBuilder() {
   }
 
-  public ObsCommunicatorBuilder password(String password) {
+  public OBSCommunicatorBuilder password(String password) {
     this.password = password;
     return this;
   }
@@ -40,7 +40,7 @@ public class ObsCommunicatorBuilder {
     return communicatorLifecycleListenerBuilder;
   }
 
-  public <T extends Event> ObsCommunicatorBuilder registerEventListener(Class<T> eventClass,
+  public <T extends Event> OBSCommunicatorBuilder registerEventListener(Class<T> eventClass,
       Consumer<T> listener) {
     this.eventListeners.put(eventClass, listener);
     return this;

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -260,8 +260,6 @@ public class OBSRemoteController {
 
   private final ControllerLifecycleListener controllerLifecycleListener;
 
-  private boolean failed;
-
   /**
    * All-Args constructor, used by the builder or directly.
    *
@@ -319,9 +317,7 @@ public class OBSRemoteController {
 
       // Block on the connection succeeding
       connection.get(connectionTimeoutSeconds, TimeUnit.SECONDS);
-      this.failed = false;
     } catch (Throwable t) {
-      this.failed = true;
       // If the exception is caused by OBS being unavailable over the network
       // (or not installed or started), then call onError with helpful message
       if (
@@ -371,10 +367,6 @@ public class OBSRemoteController {
         );
       }
     }
-  }
-
-  public boolean isFailed() {
-    return this.failed;
   }
 
   public void await() throws InterruptedException {

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -327,8 +327,8 @@ public class OBSRemoteController {
               || (t instanceof ExecutionException && t.getCause() != null && t
               .getCause() instanceof UnknownHostException)
       ) {
-        this.controllerLifecycleListener.onError(this,
-            new ReasonThrowable("Could not contact OBS on: " + this.uri
+        this.controllerLifecycleListener.onError(
+          new ReasonThrowable("Could not contact OBS on: " + this.uri
                 + ", verify OBS is running, the plugin is installed, and it can be reached over the network",
                 t.getCause() == null
                     ? t
@@ -338,8 +338,8 @@ public class OBSRemoteController {
       }
       // Otherwise, something unexpected has happened during connect
       else {
-        this.controllerLifecycleListener.onError(this,
-            new ReasonThrowable("An unexpected exception occurred during connect", t)
+        this.controllerLifecycleListener.onError(
+          new ReasonThrowable("An unexpected exception occurred during connect", t)
         );
       }
     }
@@ -351,8 +351,8 @@ public class OBSRemoteController {
       log.debug("Closing connection.");
       this.communicator.awaitClose(connectionTimeoutSeconds, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
-      this.controllerLifecycleListener.onError(this,
-          new ReasonThrowable("Error during closing websocket connection", e)
+      this.controllerLifecycleListener.onError(
+        new ReasonThrowable("Error during closing websocket connection", e)
       );
     }
 
@@ -362,8 +362,8 @@ public class OBSRemoteController {
         log.debug("Stopping client.");
         this.webSocketClient.stop();
       } catch (Exception e) {
-        this.controllerLifecycleListener.onError(this,
-            new ReasonThrowable("Error during stopping websocket client", e)
+        this.controllerLifecycleListener.onError(
+          new ReasonThrowable("Error during stopping websocket client", e)
         );
       }
     }

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -313,10 +313,6 @@ public class OBSRemoteController {
       // Block on the connection succeeding
       connection.get(connectionTimeoutSeconds, TimeUnit.SECONDS);
       this.failed = false;
-
-      // technically this isn't ready until Identified...consider improving
-      // by registering to callback
-      this.controllerLifecycleListener.onReady(this);
     } catch (Throwable t) {
       this.failed = true;
       // If the exception is caused by OBS being unavailable over the network
@@ -362,8 +358,6 @@ public class OBSRemoteController {
       try {
         log.debug("Stopping client.");
         this.webSocketClient.stop();
-        // this technically should be registered to a communicator onClose listener
-        this.controllerLifecycleListener.onDisconnect(this);
       } catch (Exception e) {
         this.controllerLifecycleListener.onError(this,
             new ReasonThrowable("Error during stopping websocket client", e)

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -243,6 +243,13 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
+/**
+ * This is the main entrypoint for the client. It provides methods for making requests against OBS
+ * Websocket, and its builder (${@link ObsRemoteControllerBuilder} provides methods to register
+ * OBS Websocket event listeners and lifecycle callbacks for this client (see
+ * ${@link io.obswebsocket.community.client.listener.lifecycle.communicator.CommunicatorLifecycleListener}
+ * and ${@link ControllerLifecycleListener} for more information on these lifecycle callbacks).
+ */
 @Slf4j
 public class OBSRemoteController {
 

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -245,7 +245,7 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 /**
  * This is the main entrypoint for the client. It provides methods for making requests against OBS
- * Websocket, and its builder (${@link ObsRemoteControllerBuilder} provides methods to register
+ * Websocket, and its builder (${@link OBSRemoteControllerBuilder} provides methods to register
  * OBS Websocket event listeners and lifecycle callbacks for this client (see
  * ${@link io.obswebsocket.community.client.listener.lifecycle.communicator.CommunicatorLifecycleListener}
  * and ${@link ControllerLifecycleListener} for more information on these lifecycle callbacks).
@@ -298,8 +298,8 @@ public class OBSRemoteController {
     }
   }
 
-  public static ObsRemoteControllerBuilder builder() {
-    return new ObsRemoteControllerBuilder();
+  public static OBSRemoteControllerBuilder builder() {
+    return new OBSRemoteControllerBuilder();
   }
 
   public void connect() {
@@ -357,7 +357,7 @@ public class OBSRemoteController {
     }
 
     // stop the client if it isn't already stopped or stopping
-    if (!this.webSocketClient.isStopped() && !this.webSocketClient.isStopping()) {
+    if (!this.webSocketClient.isStopped() || !this.webSocketClient.isStopping()) {
       try {
         log.debug("Stopping client.");
         this.webSocketClient.stop();

--- a/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
@@ -9,11 +9,11 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 /**
  * The internal builder for creating ${@link OBSRemoteController} instances.
  */
-public class ObsRemoteControllerBuilder {
+public class OBSRemoteControllerBuilder {
 
   private ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder = new ControllerLifecycleListenerBuilder(
       this);
-  private ObsCommunicatorBuilder obsCommunicatorBuilder = new ObsCommunicatorBuilder();
+  private OBSCommunicatorBuilder obsCommunicatorBuilder = new OBSCommunicatorBuilder();
   private LifecycleListenerBuilderFacade lifecycleListenerBuilderFacade = new LifecycleListenerBuilderFacade(
     this,
     obsCommunicatorBuilder.lifecycle(),
@@ -31,33 +31,33 @@ public class ObsRemoteControllerBuilder {
     return new WebSocketClient();
   }
 
-  public ObsRemoteControllerBuilder host(String host) {
+  public OBSRemoteControllerBuilder host(String host) {
     this.host = host;
     return this;
   }
 
-  public ObsRemoteControllerBuilder port(int port) {
+  public OBSRemoteControllerBuilder port(int port) {
     this.port = port;
     return this;
   }
 
-  public ObsRemoteControllerBuilder password(String password) {
+  public OBSRemoteControllerBuilder password(String password) {
     obsCommunicatorBuilder.password(password);
     return this;
   }
 
-  public <T extends Event> ObsRemoteControllerBuilder registerEventListener(Class<T> eventClass,
+  public <T extends Event> OBSRemoteControllerBuilder registerEventListener(Class<T> eventClass,
       Consumer<T> listener) {
     this.obsCommunicatorBuilder.registerEventListener(eventClass, listener);
     return this;
   }
 
-  public ObsRemoteControllerBuilder connectionTimeout(int seconds) {
+  public OBSRemoteControllerBuilder connectionTimeout(int seconds) {
     this.connectionTimeoutSeconds = seconds;
     return this;
   }
 
-  public ObsRemoteControllerBuilder autoConnect(boolean autoConnect) {
+  public OBSRemoteControllerBuilder autoConnect(boolean autoConnect) {
     this.autoConnect = autoConnect;
     return this;
   }
@@ -66,7 +66,7 @@ public class ObsRemoteControllerBuilder {
     return lifecycleListenerBuilderFacade;
   }
 
-  public ObsRemoteControllerBuilder communicator(OBSCommunicator communicator) {
+  public OBSRemoteControllerBuilder communicator(OBSCommunicator communicator) {
     this.communicator = communicator;
     return this;
   }

--- a/src/main/java/io/obswebsocket/community/client/ObsCommunicatorBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/ObsCommunicatorBuilder.java
@@ -12,6 +12,9 @@ import io.obswebsocket.community.client.translator.MessageTranslator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+/**
+ * Internal builder for constructing instances of ${@link OBSCommunicator}.
+ */
 public class ObsCommunicatorBuilder {
 
   private final static MessageTranslator TRANSLATOR;

--- a/src/main/java/io/obswebsocket/community/client/ObsCommunicatorBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/ObsCommunicatorBuilder.java
@@ -23,18 +23,12 @@ public class ObsCommunicatorBuilder {
     TRANSLATOR = new GsonMessageTranslator();
   }
 
-  private ObsRemoteControllerBuilder obsRemoteControllerBuilder;
   private String password;
   private CommunicatorLifecycleListenerBuilder communicatorLifecycleListenerBuilder = new CommunicatorLifecycleListenerBuilder(
       this);
   private ConcurrentHashMap<Class<? extends Event>, Consumer> eventListeners = new ConcurrentHashMap<>();
 
   public ObsCommunicatorBuilder() {
-  }
-
-  public ObsCommunicatorBuilder(
-      ObsRemoteControllerBuilder obsRemoteControllerBuilder) {
-    this.obsRemoteControllerBuilder = obsRemoteControllerBuilder;
   }
 
   public ObsCommunicatorBuilder password(String password) {
@@ -50,15 +44,6 @@ public class ObsCommunicatorBuilder {
       Consumer<T> listener) {
     this.eventListeners.put(eventClass, listener);
     return this;
-  }
-
-  public ObsRemoteControllerBuilder and() {
-    if (obsRemoteControllerBuilder != null) {
-      return obsRemoteControllerBuilder;
-    } else {
-      throw new IllegalStateException(
-          "Trying to build Communicator directly, no RemoteControllerBuilder exists");
-    }
   }
 
   public OBSCommunicator build() {

--- a/src/main/java/io/obswebsocket/community/client/ObsRemoteControllerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/ObsRemoteControllerBuilder.java
@@ -13,7 +13,7 @@ public class ObsRemoteControllerBuilder {
 
   private ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder = new ControllerLifecycleListenerBuilder(
       this);
-  private ObsCommunicatorBuilder obsCommunicatorBuilder = new ObsCommunicatorBuilder(this);
+  private ObsCommunicatorBuilder obsCommunicatorBuilder = new ObsCommunicatorBuilder();
   private LifecycleListenerBuilderFacade lifecycleListenerBuilderFacade = new LifecycleListenerBuilderFacade(
     this,
     obsCommunicatorBuilder.lifecycle(),

--- a/src/main/java/io/obswebsocket/community/client/ObsRemoteControllerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/ObsRemoteControllerBuilder.java
@@ -1,17 +1,24 @@
 package io.obswebsocket.community.client;
 
+import io.obswebsocket.community.client.listener.lifecycle.LifecycleListenerBuilderFacade;
 import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListenerBuilder;
 import io.obswebsocket.community.client.message.event.Event;
 import java.util.function.Consumer;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
+/**
+ * The internal builder for creating ${@link OBSRemoteController} instances.
+ */
 public class ObsRemoteControllerBuilder {
 
   private ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder = new ControllerLifecycleListenerBuilder(
       this);
-
-  // TODO get rid of this nested communicator builder
   private ObsCommunicatorBuilder obsCommunicatorBuilder = new ObsCommunicatorBuilder(this);
+  private LifecycleListenerBuilderFacade lifecycleListenerBuilderFacade = new LifecycleListenerBuilderFacade(
+    this,
+    obsCommunicatorBuilder.lifecycle(),
+    controllerLifecycleListenerBuilder
+  );
   private OBSCommunicator communicator;
 
   private WebSocketClient webSocketClient = WEBSOCKET_CLIENT();
@@ -55,12 +62,8 @@ public class ObsRemoteControllerBuilder {
     return this;
   }
 
-  public ControllerLifecycleListenerBuilder lifecycle() {
-    return controllerLifecycleListenerBuilder;
-  }
-
-  public ObsCommunicatorBuilder communicator() {
-    return obsCommunicatorBuilder;
+  public LifecycleListenerBuilderFacade lifecycle() {
+    return lifecycleListenerBuilderFacade;
   }
 
   public ObsRemoteControllerBuilder communicator(OBSCommunicator communicator) {

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
@@ -28,48 +28,48 @@ public class LifecycleListenerBuilderFacade {
   }
 
   public LifecycleListenerBuilderFacade onConnect(
-    BiConsumer<OBSCommunicator, Session> onConnectCallback) {
+    Consumer<Session> onConnectCallback) {
     communicatorLifecycleListenerBuilder.onConnect(onConnectCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onHello(
-    BiConsumer<OBSCommunicator, Hello> onHelloCallback) {
+    Consumer<Hello> onHelloCallback) {
     communicatorLifecycleListenerBuilder.onHello(onHelloCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onIdentified(
-    BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback) {
+    Consumer<Identified> onIdentifiedCallback) {
     communicatorLifecycleListenerBuilder.onIdentified(onIdentifiedCallback);
     return this;
   }
 
-  public LifecycleListenerBuilderFacade onReady(Consumer<OBSCommunicator> onReadyCallback) {
+  public LifecycleListenerBuilderFacade onReady(Runnable onReadyCallback) {
     communicatorLifecycleListenerBuilder.onReady(onReadyCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onClose(
-    BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback) {
+    Consumer<WebSocketCloseCode> onCloseCallback) {
     communicatorLifecycleListenerBuilder.onClose(onCloseCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onDisconnect(
-    Consumer<OBSCommunicator> onDisconnectCallback) {
+    Runnable onDisconnectCallback) {
     communicatorLifecycleListenerBuilder.onDisconnect(onDisconnectCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onCommunicatorError(
-    BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback) {
+    Consumer<ReasonThrowable> onErrorCallback) {
     communicatorLifecycleListenerBuilder.onError(onErrorCallback);
     return this;
   }
 
   public LifecycleListenerBuilderFacade onControllerError(
-    BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback) {
+    Consumer<ReasonThrowable> onErrorCallback) {
     controllerLifecycleListenerBuilder.onError(onErrorCallback);
     return this;
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
@@ -1,0 +1,91 @@
+package io.obswebsocket.community.client.listener.lifecycle;
+
+import io.obswebsocket.community.client.OBSCommunicator;
+import io.obswebsocket.community.client.OBSRemoteController;
+import io.obswebsocket.community.client.ObsRemoteControllerBuilder;
+import io.obswebsocket.community.client.WebSocketCloseCode;
+import io.obswebsocket.community.client.listener.lifecycle.communicator.CommunicatorLifecycleListenerBuilder;
+import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListenerBuilder;
+import io.obswebsocket.community.client.message.authentication.Hello;
+import io.obswebsocket.community.client.message.authentication.Identified;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.eclipse.jetty.websocket.api.Session;
+
+public class LifecycleListenerBuilderFacade {
+
+  final ObsRemoteControllerBuilder obsRemoteControllerBuilder;
+  final CommunicatorLifecycleListenerBuilder communicatorLifecycleListenerBuilder;
+  final ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder;
+
+  public LifecycleListenerBuilderFacade(
+    ObsRemoteControllerBuilder obsRemoteControllerBuilder,
+    CommunicatorLifecycleListenerBuilder communicatorLifecycleListenerBuilder,
+    ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder) {
+    this.obsRemoteControllerBuilder = obsRemoteControllerBuilder;
+    this.communicatorLifecycleListenerBuilder = communicatorLifecycleListenerBuilder;
+    this.controllerLifecycleListenerBuilder = controllerLifecycleListenerBuilder;
+  }
+
+  public LifecycleListenerBuilderFacade onConnect(
+    BiConsumer<OBSCommunicator, Session> onConnectCallback) {
+    communicatorLifecycleListenerBuilder.onConnect(onConnectCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onHello(
+    BiConsumer<OBSCommunicator, Hello> onHelloCallback) {
+    communicatorLifecycleListenerBuilder.onHello(onHelloCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onIdentified(
+    BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback) {
+    communicatorLifecycleListenerBuilder.onIdentified(onIdentifiedCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onReady(Consumer<OBSCommunicator> onReadyCallback) {
+    communicatorLifecycleListenerBuilder.onReady(onReadyCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onClose(
+    BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback) {
+    communicatorLifecycleListenerBuilder.onClose(onCloseCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onDisconnect(
+    Consumer<OBSCommunicator> onDisconnectCallback) {
+    communicatorLifecycleListenerBuilder.onDisconnect(onDisconnectCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onCommunicatorError(
+    BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback) {
+    communicatorLifecycleListenerBuilder.onError(onErrorCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade onControllerError(
+    BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback) {
+    controllerLifecycleListenerBuilder.onError(onErrorCallback);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade withCommunicatorDefaultLogging(boolean defaultLogging) {
+    communicatorLifecycleListenerBuilder.withDefaultLogging(defaultLogging);
+    return this;
+  }
+
+  public LifecycleListenerBuilderFacade withControllerDefaultLogging(boolean defaultLogging) {
+    controllerLifecycleListenerBuilder.withDefaultLogging(defaultLogging);
+    return this;
+  }
+
+  public ObsRemoteControllerBuilder and() {
+    return obsRemoteControllerBuilder;
+  }
+
+}

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/LifecycleListenerBuilderFacade.java
@@ -1,25 +1,22 @@
 package io.obswebsocket.community.client.listener.lifecycle;
 
-import io.obswebsocket.community.client.OBSCommunicator;
-import io.obswebsocket.community.client.OBSRemoteController;
-import io.obswebsocket.community.client.ObsRemoteControllerBuilder;
+import io.obswebsocket.community.client.OBSRemoteControllerBuilder;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.communicator.CommunicatorLifecycleListenerBuilder;
 import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListenerBuilder;
 import io.obswebsocket.community.client.message.authentication.Hello;
 import io.obswebsocket.community.client.message.authentication.Identified;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.eclipse.jetty.websocket.api.Session;
 
 public class LifecycleListenerBuilderFacade {
 
-  final ObsRemoteControllerBuilder obsRemoteControllerBuilder;
+  final OBSRemoteControllerBuilder obsRemoteControllerBuilder;
   final CommunicatorLifecycleListenerBuilder communicatorLifecycleListenerBuilder;
   final ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder;
 
   public LifecycleListenerBuilderFacade(
-    ObsRemoteControllerBuilder obsRemoteControllerBuilder,
+    OBSRemoteControllerBuilder obsRemoteControllerBuilder,
     CommunicatorLifecycleListenerBuilder communicatorLifecycleListenerBuilder,
     ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder) {
     this.obsRemoteControllerBuilder = obsRemoteControllerBuilder;
@@ -84,7 +81,7 @@ public class LifecycleListenerBuilderFacade {
     return this;
   }
 
-  public ObsRemoteControllerBuilder and() {
+  public OBSRemoteControllerBuilder and() {
     return obsRemoteControllerBuilder;
   }
 

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListener.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.listener.lifecycle.communicator;
 
 import io.obswebsocket.community.client.OBSCommunicator;
+import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.message.authentication.Hello;
@@ -10,25 +11,55 @@ import lombok.Getter;
 import lombok.ToString;
 import org.eclipse.jetty.websocket.api.Session;
 
+/**
+ * A listener that is invoked by the ${@link io.obswebsocket.community.client.OBSCommunicator} on
+ * each respective event.
+ */
 public interface CommunicatorLifecycleListener {
 
+  /**
+   * Invoked when an initial connection has been established to OBS Websocket, before the client
+   * has been identified and permitted to make further requests.
+   */
   void onConnect(OBSCommunicator communicator, Session session);
 
+  /**
+   * Invoked when OBS Websocket has sent the initial information required to authenticate.
+   * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
+   */
   void onHello(OBSCommunicator communicator, Hello hello);
 
+  /**
+   * Invoked when OBS Websocket has accepted the client's auth response (Identify).
+   * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
+   */
   void onIdentified(OBSCommunicator communicator, Identified identified);
 
+  /**
+   * Invoked when the client is now ready to accept requests; it has been identified by OBS
+   * Websocket and any other startup activities have completed.
+   */
+  void onReady(OBSCommunicator communicator);
+
+  /**
+   * Invoked when OBS Websocket has closed the connection; this will occur either if authentication
+   * fails, an error has occurred, or the client was told by the user to close the connection.
+   * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
+   */
   void onClose(OBSCommunicator communicator, WebSocketCloseCode webSocketCloseCode);
 
+  /**
+   * Invoked when the client has fully disconnected from OBS Websocket, and reconnect can be
+   * attempted again.
+   */
+  void onDisconnect(OBSCommunicator communicator);
+
+  /**
+   * Invoked when an exceptional condition has occurred during client runtime, generally reserved
+   * for unexpected exceptions such as NullPointerException and the like.
+   * @param communicator
+   * @param reasonThrowable
+   */
   void onError(OBSCommunicator communicator, ReasonThrowable reasonThrowable);
-
-  @ToString
-  @Getter
-  @AllArgsConstructor
-  public static class CodeReason {
-
-    private final Integer code;
-    private final String reason;
-  }
 
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListener.java
@@ -21,45 +21,44 @@ public interface CommunicatorLifecycleListener {
    * Invoked when an initial connection has been established to OBS Websocket, before the client
    * has been identified and permitted to make further requests.
    */
-  void onConnect(OBSCommunicator communicator, Session session);
+  void onConnect(Session session);
 
   /**
    * Invoked when OBS Websocket has sent the initial information required to authenticate.
    * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
    */
-  void onHello(OBSCommunicator communicator, Hello hello);
+  void onHello(Hello hello);
 
   /**
    * Invoked when OBS Websocket has accepted the client's auth response (Identify).
    * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
    */
-  void onIdentified(OBSCommunicator communicator, Identified identified);
+  void onIdentified(Identified identified);
 
   /**
    * Invoked when the client is now ready to accept requests; it has been identified by OBS
    * Websocket and any other startup activities have completed.
    */
-  void onReady(OBSCommunicator communicator);
+  void onReady();
 
   /**
    * Invoked when OBS Websocket has closed the connection; this will occur either if authentication
    * fails, an error has occurred, or the client was told by the user to close the connection.
    * @see <a href="https://github.com/Palakis/obs-websocket/blob/master/docs/generated/protocol.md">OBS Websocket V5 Protocol</a>
    */
-  void onClose(OBSCommunicator communicator, WebSocketCloseCode webSocketCloseCode);
+  void onClose(WebSocketCloseCode webSocketCloseCode);
 
   /**
    * Invoked when the client has fully disconnected from OBS Websocket, and reconnect can be
    * attempted again.
    */
-  void onDisconnect(OBSCommunicator communicator);
+  void onDisconnect();
 
   /**
    * Invoked when an exceptional condition has occurred during client runtime, generally reserved
    * for unexpected exceptions such as NullPointerException and the like.
-   * @param communicator
    * @param reasonThrowable
    */
-  void onError(OBSCommunicator communicator, ReasonThrowable reasonThrowable);
+  void onError(ReasonThrowable reasonThrowable);
 
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
@@ -16,18 +16,17 @@ public class CommunicatorLifecycleListenerBuilder {
 
   private final Consumer DEFAULT_CONSUMER = obj -> {
   };
-  private final BiConsumer DEFAULT_BICONSUMER = (a, b) -> {
-  };
+  private final Runnable DEFAULT_RUNNABLE = () -> {};
 
   private final ObsCommunicatorBuilder obsCommunicatorBuilder;
 
-  private BiConsumer<OBSCommunicator, Session> onConnectCallback;
-  private BiConsumer<OBSCommunicator, Hello> onHelloCallback;
-  private BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback;
-  private Consumer<OBSCommunicator> onReadyCallback;
-  private BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback;
-  private Consumer<OBSCommunicator> onDisconnectCallback;
-  private BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback;
+  private Consumer<Session> onConnectCallback = DEFAULT_CONSUMER;
+  private Consumer<Hello> onHelloCallback = DEFAULT_CONSUMER;
+  private Consumer<Identified> onIdentifiedCallback = DEFAULT_CONSUMER;
+  private Runnable onReadyCallback = DEFAULT_RUNNABLE;
+  private Consumer<WebSocketCloseCode> onCloseCallback = DEFAULT_CONSUMER;
+  private Runnable onDisconnectCallback = DEFAULT_RUNNABLE;
+  private Consumer<ReasonThrowable> onErrorCallback = DEFAULT_CONSUMER;
   private boolean defaultLogging = true;
 
   public CommunicatorLifecycleListenerBuilder(
@@ -36,42 +35,42 @@ public class CommunicatorLifecycleListenerBuilder {
   }
 
   public CommunicatorLifecycleListenerBuilder onConnect(
-      BiConsumer<OBSCommunicator, Session> onConnectCallback) {
+      Consumer<Session> onConnectCallback) {
     this.onConnectCallback = onConnectCallback;
     return this;
   }
 
   public CommunicatorLifecycleListenerBuilder onHello(
-      BiConsumer<OBSCommunicator, Hello> onHelloCallback) {
+      Consumer<Hello> onHelloCallback) {
     this.onHelloCallback = onHelloCallback;
     return this;
   }
 
   public CommunicatorLifecycleListenerBuilder onIdentified(
-      BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback) {
+      Consumer<Identified> onIdentifiedCallback) {
     this.onIdentifiedCallback = onIdentifiedCallback;
     return this;
   }
 
-  public CommunicatorLifecycleListenerBuilder onReady(Consumer<OBSCommunicator> onReadyCallback) {
+  public CommunicatorLifecycleListenerBuilder onReady(Runnable onReadyCallback) {
     this.onReadyCallback = onReadyCallback;
     return this;
   }
 
   public CommunicatorLifecycleListenerBuilder onClose(
-      BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback) {
+      Consumer<WebSocketCloseCode> onCloseCallback) {
     this.onCloseCallback = onCloseCallback;
     return this;
   }
 
   public CommunicatorLifecycleListenerBuilder onDisconnect(
-      Consumer<OBSCommunicator> onDisconnectCallback) {
+      Runnable onDisconnectCallback) {
     this.onDisconnectCallback = onDisconnectCallback;
     return this;
   }
 
   public CommunicatorLifecycleListenerBuilder onError(
-      BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback) {
+      Consumer<ReasonThrowable> onErrorCallback) {
     this.onErrorCallback = onErrorCallback;
     return this;
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
@@ -24,7 +24,9 @@ public class CommunicatorLifecycleListenerBuilder {
   private BiConsumer<OBSCommunicator, Session> onConnectCallback;
   private BiConsumer<OBSCommunicator, Hello> onHelloCallback;
   private BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback;
+  private Consumer<OBSCommunicator> onReadyCallback;
   private BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback;
+  private Consumer<OBSCommunicator> onDisconnectCallback;
   private BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback;
   private boolean defaultLogging = true;
 
@@ -51,9 +53,20 @@ public class CommunicatorLifecycleListenerBuilder {
     return this;
   }
 
+  public CommunicatorLifecycleListenerBuilder onReady(Consumer<OBSCommunicator> onReadyCallback) {
+    this.onReadyCallback = onReadyCallback;
+    return this;
+  }
+
   public CommunicatorLifecycleListenerBuilder onClose(
       BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback) {
     this.onCloseCallback = onCloseCallback;
+    return this;
+  }
+
+  public CommunicatorLifecycleListenerBuilder onDisconnect(
+      Consumer<OBSCommunicator> onDisconnectCallback) {
+    this.onDisconnectCallback = onDisconnectCallback;
     return this;
   }
 
@@ -78,7 +91,9 @@ public class CommunicatorLifecycleListenerBuilder {
         onConnectCallback,
         onHelloCallback,
         onIdentifiedCallback,
+        onReadyCallback,
         onCloseCallback,
+        onDisconnectCallback,
         onErrorCallback
     ));
     if (defaultLogging) {

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CommunicatorLifecycleListenerBuilder.java
@@ -1,36 +1,30 @@
 package io.obswebsocket.community.client.listener.lifecycle.communicator;
 
-import io.obswebsocket.community.client.OBSCommunicator;
-import io.obswebsocket.community.client.ObsCommunicatorBuilder;
+import io.obswebsocket.community.client.OBSCommunicatorBuilder;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.message.authentication.Hello;
 import io.obswebsocket.community.client.message.authentication.Identified;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.eclipse.jetty.websocket.api.Session;
 
 public class CommunicatorLifecycleListenerBuilder {
 
-  private final Consumer DEFAULT_CONSUMER = obj -> {
-  };
-  private final Runnable DEFAULT_RUNNABLE = () -> {};
+  private final OBSCommunicatorBuilder obsCommunicatorBuilder;
 
-  private final ObsCommunicatorBuilder obsCommunicatorBuilder;
-
-  private Consumer<Session> onConnectCallback = DEFAULT_CONSUMER;
-  private Consumer<Hello> onHelloCallback = DEFAULT_CONSUMER;
-  private Consumer<Identified> onIdentifiedCallback = DEFAULT_CONSUMER;
-  private Runnable onReadyCallback = DEFAULT_RUNNABLE;
-  private Consumer<WebSocketCloseCode> onCloseCallback = DEFAULT_CONSUMER;
-  private Runnable onDisconnectCallback = DEFAULT_RUNNABLE;
-  private Consumer<ReasonThrowable> onErrorCallback = DEFAULT_CONSUMER;
+  private Consumer<Session> onConnectCallback;
+  private Consumer<Hello> onHelloCallback;
+  private Consumer<Identified> onIdentifiedCallback;
+  private Runnable onReadyCallback;
+  private Consumer<WebSocketCloseCode> onCloseCallback;
+  private Runnable onDisconnectCallback;
+  private Consumer<ReasonThrowable> onErrorCallback;
   private boolean defaultLogging = true;
 
   public CommunicatorLifecycleListenerBuilder(
-      ObsCommunicatorBuilder obsCommunicatorBuilder) {
+      OBSCommunicatorBuilder obsCommunicatorBuilder) {
     this.obsCommunicatorBuilder = obsCommunicatorBuilder;
   }
 
@@ -80,7 +74,7 @@ public class CommunicatorLifecycleListenerBuilder {
     return this;
   }
 
-  public ObsCommunicatorBuilder and() {
+  public OBSCommunicatorBuilder and() {
     return obsCommunicatorBuilder;
   }
 

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CompositeCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CompositeCommunicatorLifecycleListener.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.listener.lifecycle.communicator;
 
-import io.obswebsocket.community.client.OBSCommunicator;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.message.authentication.Hello;
@@ -23,42 +22,39 @@ public class CompositeCommunicatorLifecycleListener implements CommunicatorLifec
   }
 
   @Override
-  public void onConnect(OBSCommunicator communicator, Session session) {
+  public void onConnect(Session session) {
     listeners.forEach(
-        it -> it.onConnect(communicator, session)
+        it -> it.onConnect(session)
     );
   }
 
   @Override
-  public void onHello(OBSCommunicator communicator, Hello hello) {
-    listeners.forEach(it -> it.onHello(communicator, hello));
+  public void onHello(Hello hello) {
+    listeners.forEach(it -> it.onHello(hello));
   }
 
   @Override
-  public void onIdentified(OBSCommunicator communicator,
-      Identified identified) {
-    listeners.forEach(it -> it.onIdentified(communicator, identified));
+  public void onIdentified(Identified identified) {
+    listeners.forEach(it -> it.onIdentified(identified));
   }
 
   @Override
-  public void onReady(OBSCommunicator communicator) {
-    listeners.forEach(it -> it.onReady(communicator));
+  public void onReady() {
+    listeners.forEach(it -> it.onReady());
   }
 
   @Override
-  public void onClose(OBSCommunicator communicator,
-      WebSocketCloseCode webSocketCloseCode) {
-    listeners.forEach(it -> it.onClose(communicator, webSocketCloseCode));
+  public void onClose(WebSocketCloseCode webSocketCloseCode) {
+    listeners.forEach(it -> it.onClose(webSocketCloseCode));
   }
 
   @Override
-  public void onDisconnect(OBSCommunicator communicator) {
-    listeners.forEach(it -> it.onDisconnect(communicator));
+  public void onDisconnect() {
+    listeners.forEach(it -> it.onDisconnect());
   }
 
   @Override
-  public void onError(OBSCommunicator communicator,
-      ReasonThrowable reasonThrowable) {
-    listeners.forEach(it -> it.onError(communicator, reasonThrowable));
+  public void onError(ReasonThrowable reasonThrowable) {
+    listeners.forEach(it -> it.onError(reasonThrowable));
   }
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CompositeCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/CompositeCommunicatorLifecycleListener.java
@@ -41,9 +41,19 @@ public class CompositeCommunicatorLifecycleListener implements CommunicatorLifec
   }
 
   @Override
+  public void onReady(OBSCommunicator communicator) {
+    listeners.forEach(it -> it.onReady(communicator));
+  }
+
+  @Override
   public void onClose(OBSCommunicator communicator,
       WebSocketCloseCode webSocketCloseCode) {
     listeners.forEach(it -> it.onClose(communicator, webSocketCloseCode));
+  }
+
+  @Override
+  public void onDisconnect(OBSCommunicator communicator) {
+    listeners.forEach(it -> it.onDisconnect(communicator));
   }
 
   @Override

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
@@ -17,22 +17,20 @@ import org.eclipse.jetty.websocket.api.Session;
 public class DelegatingCommunicatorLifecycleListener implements
     CommunicatorLifecycleListener {
 
-  private final BiConsumer<OBSCommunicator, Session> onConnectCallback;
-  private final BiConsumer<OBSCommunicator, Hello> onHelloCallback;
-  private final BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback;
-  private final Consumer<OBSCommunicator> onReadyCallback;
-  private final BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback;
-  private final Consumer<OBSCommunicator> onDisconnectCallback;
-  private final BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback;
+  private final Consumer<Session> onConnectCallback;
+  private final Consumer<Hello> onHelloCallback;
+  private final Consumer<Identified> onIdentifiedCallback;
+  private final Runnable onReadyCallback;
+  private final Consumer<WebSocketCloseCode> onCloseCallback;
+  private final Runnable onDisconnectCallback;
+  private final Consumer<ReasonThrowable> onErrorCallback;
 
   public DelegatingCommunicatorLifecycleListener(
-      BiConsumer<OBSCommunicator, Session> onConnectCallback,
-      BiConsumer<OBSCommunicator, Hello> onHelloCallback,
-      BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback,
-      Consumer<OBSCommunicator> onReadyCallback,
-      BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback,
-      Consumer<OBSCommunicator> onDisconnectCallback,
-      BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback) {
+    Consumer<Session> onConnectCallback,
+    Consumer<Hello> onHelloCallback,
+    Consumer<Identified> onIdentifiedCallback, Runnable onReadyCallback,
+    Consumer<WebSocketCloseCode> onCloseCallback, Runnable onDisconnectCallback,
+    Consumer<ReasonThrowable> onErrorCallback) {
     this.onConnectCallback = onConnectCallback;
     this.onHelloCallback = onHelloCallback;
     this.onIdentifiedCallback = onIdentifiedCallback;
@@ -42,30 +40,30 @@ public class DelegatingCommunicatorLifecycleListener implements
     this.onErrorCallback = onErrorCallback;
   }
 
-  public void onConnect(OBSCommunicator communicator, Session session) {
+  public void onConnect(Session session) {
     if (onConnectCallback != null) {
       try {
-        onConnectCallback.accept(communicator, session);
+        onConnectCallback.accept(session);
       } catch (Exception e) {
         log.warn("onConnect callback threw exception", e);
       }
     }
   }
 
-  public void onHello(OBSCommunicator communicator, Hello hello) {
+  public void onHello(Hello hello) {
     if (onHelloCallback != null) {
       try {
-        onHelloCallback.accept(communicator, hello);
+        onHelloCallback.accept(hello);
       } catch (Exception e) {
         log.warn("onHello callback threw exception", e);
       }
     }
   }
 
-  public void onIdentified(OBSCommunicator communicator, Identified identified) {
+  public void onIdentified(Identified identified) {
     if (onIdentifiedCallback != null) {
       try {
-        onIdentifiedCallback.accept(communicator, identified);
+        onIdentifiedCallback.accept(identified);
       } catch (Exception e) {
         log.warn("onIdentified callback threw exception", e);
       }
@@ -73,20 +71,20 @@ public class DelegatingCommunicatorLifecycleListener implements
   }
 
   @Override
-  public void onReady(OBSCommunicator communicator) {
+  public void onReady() {
     if (onReadyCallback != null) {
       try {
-        onReadyCallback.accept(communicator);
+        onReadyCallback.run();
       } catch (Exception e) {
         log.warn("onReady callback threw exception", e);
       }
     }
   }
 
-  public void onClose(OBSCommunicator communicator, WebSocketCloseCode webSocketCloseCode) {
+  public void onClose(WebSocketCloseCode webSocketCloseCode) {
     if (onCloseCallback != null) {
       try {
-        onCloseCallback.accept(communicator, webSocketCloseCode);
+        onCloseCallback.accept(webSocketCloseCode);
       } catch (Exception e) {
         log.warn("onClose callback threw exception", e);
       }
@@ -94,20 +92,20 @@ public class DelegatingCommunicatorLifecycleListener implements
   }
 
   @Override
-  public void onDisconnect(OBSCommunicator communicator) {
+  public void onDisconnect() {
     if (onDisconnectCallback != null) {
       try {
-        onDisconnectCallback.accept(communicator);
+        onDisconnectCallback.run();
       } catch (Exception e) {
         log.warn("onDisconnect callback threw exception", e);
       }
     }
   }
 
-  public void onError(OBSCommunicator communicator, ReasonThrowable reasonThrowable) {
+  public void onError(ReasonThrowable reasonThrowable) {
     if (onErrorCallback != null) {
       try {
-        onErrorCallback.accept(communicator, reasonThrowable);
+        onErrorCallback.accept(reasonThrowable);
       } catch (Exception e) {
         log.warn("onError callback (ironically) threw an exception", e);
       }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
@@ -40,6 +40,7 @@ public class DelegatingCommunicatorLifecycleListener implements
     this.onErrorCallback = onErrorCallback;
   }
 
+  @Override
   public void onConnect(Session session) {
     if (onConnectCallback != null) {
       try {
@@ -50,6 +51,7 @@ public class DelegatingCommunicatorLifecycleListener implements
     }
   }
 
+  @Override
   public void onHello(Hello hello) {
     if (onHelloCallback != null) {
       try {
@@ -60,6 +62,7 @@ public class DelegatingCommunicatorLifecycleListener implements
     }
   }
 
+  @Override
   public void onIdentified(Identified identified) {
     if (onIdentifiedCallback != null) {
       try {
@@ -81,6 +84,7 @@ public class DelegatingCommunicatorLifecycleListener implements
     }
   }
 
+  @Override
   public void onClose(WebSocketCloseCode webSocketCloseCode) {
     if (onCloseCallback != null) {
       try {
@@ -102,6 +106,7 @@ public class DelegatingCommunicatorLifecycleListener implements
     }
   }
 
+  @Override
   public void onError(ReasonThrowable reasonThrowable) {
     if (onErrorCallback != null) {
       try {

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/DelegatingCommunicatorLifecycleListener.java
@@ -6,6 +6,7 @@ import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.message.authentication.Hello;
 import io.obswebsocket.community.client.message.authentication.Identified;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.websocket.api.Session;
 
@@ -19,19 +20,25 @@ public class DelegatingCommunicatorLifecycleListener implements
   private final BiConsumer<OBSCommunicator, Session> onConnectCallback;
   private final BiConsumer<OBSCommunicator, Hello> onHelloCallback;
   private final BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback;
+  private final Consumer<OBSCommunicator> onReadyCallback;
   private final BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback;
+  private final Consumer<OBSCommunicator> onDisconnectCallback;
   private final BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback;
 
   public DelegatingCommunicatorLifecycleListener(
       BiConsumer<OBSCommunicator, Session> onConnectCallback,
       BiConsumer<OBSCommunicator, Hello> onHelloCallback,
       BiConsumer<OBSCommunicator, Identified> onIdentifiedCallback,
+      Consumer<OBSCommunicator> onReadyCallback,
       BiConsumer<OBSCommunicator, WebSocketCloseCode> onCloseCallback,
+      Consumer<OBSCommunicator> onDisconnectCallback,
       BiConsumer<OBSCommunicator, ReasonThrowable> onErrorCallback) {
     this.onConnectCallback = onConnectCallback;
     this.onHelloCallback = onHelloCallback;
     this.onIdentifiedCallback = onIdentifiedCallback;
+    this.onReadyCallback = onReadyCallback;
     this.onCloseCallback = onCloseCallback;
+    this.onDisconnectCallback = onDisconnectCallback;
     this.onErrorCallback = onErrorCallback;
   }
 
@@ -65,12 +72,34 @@ public class DelegatingCommunicatorLifecycleListener implements
     }
   }
 
+  @Override
+  public void onReady(OBSCommunicator communicator) {
+    if (onReadyCallback != null) {
+      try {
+        onReadyCallback.accept(communicator);
+      } catch (Exception e) {
+        log.warn("onReady callback threw exception", e);
+      }
+    }
+  }
+
   public void onClose(OBSCommunicator communicator, WebSocketCloseCode webSocketCloseCode) {
     if (onCloseCallback != null) {
       try {
         onCloseCallback.accept(communicator, webSocketCloseCode);
       } catch (Exception e) {
         log.warn("onClose callback threw exception", e);
+      }
+    }
+  }
+
+  @Override
+  public void onDisconnect(OBSCommunicator communicator) {
+    if (onDisconnectCallback != null) {
+      try {
+        onDisconnectCallback.accept(communicator);
+      } catch (Exception e) {
+        log.warn("onDisconnect callback threw exception", e);
       }
     }
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/LoggingCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/LoggingCommunicatorLifecycleListener.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.listener.lifecycle.communicator;
 
-import io.obswebsocket.community.client.OBSCommunicator;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.message.authentication.Hello;
@@ -16,41 +15,38 @@ import org.eclipse.jetty.websocket.api.Session;
 public class LoggingCommunicatorLifecycleListener implements CommunicatorLifecycleListener {
 
   @Override
-  public void onConnect(OBSCommunicator communicator, Session session) {
+  public void onConnect(Session session) {
     log.info("Connected to OBS at: " + session.getRemoteAddress());
   }
 
   @Override
-  public void onHello(OBSCommunicator communicator, Hello hello) {
+  public void onHello(Hello hello) {
     log.debug("onHello: " + hello);
   }
 
   @Override
-  public void onIdentified(OBSCommunicator communicator,
-      Identified identified) {
+  public void onIdentified(Identified identified) {
     log.debug("onIdentified: " + identified);
   }
 
   @Override
-  public void onReady(OBSCommunicator communicator) {
+  public void onReady() {
     log.info("Client is ready to accept requests");
   }
 
   @Override
-  public void onClose(OBSCommunicator communicator,
-      WebSocketCloseCode webSocketCloseCode) {
+  public void onClose(WebSocketCloseCode webSocketCloseCode) {
     log.info(String.format("Connection closed: %d - %s%n",
         webSocketCloseCode.getCode(), webSocketCloseCode.name()));
   }
 
   @Override
-  public void onDisconnect(OBSCommunicator communicator) {
+  public void onDisconnect() {
     log.info("Client is now disconnected");
   }
 
   @Override
-  public void onError(OBSCommunicator communicator,
-      ReasonThrowable reasonThrowable) {
+  public void onError(ReasonThrowable reasonThrowable) {
     log.error("onError: " + reasonThrowable.getReason(), reasonThrowable.getThrowable());
   }
 

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/LoggingCommunicatorLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/communicator/LoggingCommunicatorLifecycleListener.java
@@ -32,10 +32,20 @@ public class LoggingCommunicatorLifecycleListener implements CommunicatorLifecyc
   }
 
   @Override
+  public void onReady(OBSCommunicator communicator) {
+    log.info("Client is ready to accept requests");
+  }
+
+  @Override
   public void onClose(OBSCommunicator communicator,
       WebSocketCloseCode webSocketCloseCode) {
     log.info(String.format("Connection closed: %d - %s%n",
         webSocketCloseCode.getCode(), webSocketCloseCode.name()));
+  }
+
+  @Override
+  public void onDisconnect(OBSCommunicator communicator) {
+    log.info("Client is now disconnected");
   }
 
   @Override

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/CompositeControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/CompositeControllerLifecycleListener.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.listener.lifecycle.controller;
 
-import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,7 @@ public class CompositeControllerLifecycleListener implements ControllerLifecycle
   }
 
   @Override
-  public void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable) {
-    listeners.forEach(it -> it.onError(controller, reasonThrowable));
+  public void onError(ReasonThrowable reasonThrowable) {
+    listeners.forEach(it -> it.onError(reasonThrowable));
   }
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/CompositeControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/CompositeControllerLifecycleListener.java
@@ -16,16 +16,6 @@ public class CompositeControllerLifecycleListener implements ControllerLifecycle
   }
 
   @Override
-  public void onReady(OBSRemoteController controller) {
-    listeners.forEach(it -> it.onReady(controller));
-  }
-
-  @Override
-  public void onDisconnect(OBSRemoteController controller) {
-    listeners.forEach(it -> it.onDisconnect(controller));
-  }
-
-  @Override
   public void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable) {
     listeners.forEach(it -> it.onError(controller, reasonThrowable));
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListener.java
@@ -3,11 +3,10 @@ package io.obswebsocket.community.client.listener.lifecycle.controller;
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 
+/**
+ * A listener that is invoked by the ${@link io.obswebsocket.community.client.OBSRemoteController} on
+ * each respective event.
+ */
 public interface ControllerLifecycleListener {
-
-  void onReady(OBSRemoteController controller);
-
-  void onDisconnect(OBSRemoteController controller);
-
   void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable);
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListener.java
@@ -8,5 +8,5 @@ import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
  * each respective event.
  */
 public interface ControllerLifecycleListener {
-  void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable);
+  void onError(ReasonThrowable reasonThrowable);
 }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
@@ -17,8 +17,6 @@ public class ControllerLifecycleListenerBuilder {
 
   private final ObsRemoteControllerBuilder obsRemoteControllerBuilder;
 
-  private Consumer<OBSRemoteController> onReadyCallback = DEFAULT_CONSUMER;
-  private Consumer<OBSRemoteController> onDisconnectCallback = DEFAULT_CONSUMER;
   private BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback = DEFAULT_BICONSUMER;
 
   private boolean defaultLogging = true;
@@ -26,17 +24,6 @@ public class ControllerLifecycleListenerBuilder {
   public ControllerLifecycleListenerBuilder(
       ObsRemoteControllerBuilder obsRemoteControllerBuilder) {
     this.obsRemoteControllerBuilder = obsRemoteControllerBuilder;
-  }
-
-  public ControllerLifecycleListenerBuilder onReady(Consumer<OBSRemoteController> onReadyCallback) {
-    this.onReadyCallback = onReadyCallback;
-    return this;
-  }
-
-  public ControllerLifecycleListenerBuilder onDisconnect(
-      Consumer<OBSRemoteController> onDisconnectCallback) {
-    this.onDisconnectCallback = onDisconnectCallback;
-    return this;
   }
 
   public ControllerLifecycleListenerBuilder onError(
@@ -57,8 +44,6 @@ public class ControllerLifecycleListenerBuilder {
   public CompositeControllerLifecycleListener build() {
     List<ControllerLifecycleListener> listeners = new ArrayList<>();
     listeners.add(new DelegatingControllerLifecycleListener(
-        onReadyCallback,
-        onDisconnectCallback,
         onErrorCallback
     ));
     if (defaultLogging) {

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
@@ -12,12 +12,10 @@ public class ControllerLifecycleListenerBuilder {
 
   private final Consumer DEFAULT_CONSUMER = (a) -> {
   };
-  private final BiConsumer DEFAULT_BICONSUMER = (a, b) -> {
-  };
 
   private final ObsRemoteControllerBuilder obsRemoteControllerBuilder;
 
-  private BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback = DEFAULT_BICONSUMER;
+  private Consumer<ReasonThrowable> onErrorCallback = DEFAULT_CONSUMER;
 
   private boolean defaultLogging = true;
 
@@ -27,7 +25,7 @@ public class ControllerLifecycleListenerBuilder {
   }
 
   public ControllerLifecycleListenerBuilder onError(
-      BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback) {
+    Consumer<ReasonThrowable> onErrorCallback) {
     this.onErrorCallback = onErrorCallback;
     return this;
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/ControllerLifecycleListenerBuilder.java
@@ -1,26 +1,21 @@
 package io.obswebsocket.community.client.listener.lifecycle.controller;
 
-import io.obswebsocket.community.client.OBSRemoteController;
-import io.obswebsocket.community.client.ObsRemoteControllerBuilder;
+import io.obswebsocket.community.client.OBSRemoteControllerBuilder;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class ControllerLifecycleListenerBuilder {
 
-  private final Consumer DEFAULT_CONSUMER = (a) -> {
-  };
+  private final OBSRemoteControllerBuilder obsRemoteControllerBuilder;
 
-  private final ObsRemoteControllerBuilder obsRemoteControllerBuilder;
-
-  private Consumer<ReasonThrowable> onErrorCallback = DEFAULT_CONSUMER;
+  private Consumer<ReasonThrowable> onErrorCallback;
 
   private boolean defaultLogging = true;
 
   public ControllerLifecycleListenerBuilder(
-      ObsRemoteControllerBuilder obsRemoteControllerBuilder) {
+      OBSRemoteControllerBuilder obsRemoteControllerBuilder) {
     this.obsRemoteControllerBuilder = obsRemoteControllerBuilder;
   }
 
@@ -35,7 +30,7 @@ public class ControllerLifecycleListenerBuilder {
     return this;
   }
 
-  public ObsRemoteControllerBuilder and() {
+  public OBSRemoteControllerBuilder and() {
     return obsRemoteControllerBuilder;
   }
 

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/DelegatingControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/DelegatingControllerLifecycleListener.java
@@ -13,39 +13,11 @@ import lombok.extern.slf4j.Slf4j;
 public class DelegatingControllerLifecycleListener implements
     ControllerLifecycleListener {
 
-  private final Consumer<OBSRemoteController> onReadyCallback;
-  private final Consumer<OBSRemoteController> onDisconnectCallback;
   private final BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback;
 
   public DelegatingControllerLifecycleListener(
-      Consumer<OBSRemoteController> onReadyCallback,
-      Consumer<OBSRemoteController> onDisconnectCallback,
       BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback) {
-    this.onReadyCallback = onReadyCallback;
-    this.onDisconnectCallback = onDisconnectCallback;
     this.onErrorCallback = onErrorCallback;
-  }
-
-  @Override
-  public void onReady(OBSRemoteController controller) {
-    if (onReadyCallback != null) {
-      try {
-        onReadyCallback.accept(controller);
-      } catch (Exception e) {
-        log.warn("onReady callback threw exception", e);
-      }
-    }
-  }
-
-  @Override
-  public void onDisconnect(OBSRemoteController controller) {
-    if (onDisconnectCallback != null) {
-      try {
-        onDisconnectCallback.accept(controller);
-      } catch (Exception e) {
-        log.warn("onDisconnect callback threw exception");
-      }
-    }
   }
 
   @Override

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/DelegatingControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/DelegatingControllerLifecycleListener.java
@@ -13,18 +13,18 @@ import lombok.extern.slf4j.Slf4j;
 public class DelegatingControllerLifecycleListener implements
     ControllerLifecycleListener {
 
-  private final BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback;
+  private final Consumer<ReasonThrowable> onErrorCallback;
 
   public DelegatingControllerLifecycleListener(
-      BiConsumer<OBSRemoteController, ReasonThrowable> onErrorCallback) {
+    Consumer<ReasonThrowable> onErrorCallback) {
     this.onErrorCallback = onErrorCallback;
   }
 
   @Override
-  public void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable) {
+  public void onError(ReasonThrowable reasonThrowable) {
     if (onErrorCallback != null) {
       try {
-        onErrorCallback.accept(controller, reasonThrowable);
+        onErrorCallback.accept(reasonThrowable);
       } catch (Exception e) {
         log.warn("onError callback (ironically) threw exception", e);
       }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/LoggingControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/LoggingControllerLifecycleListener.java
@@ -8,16 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 public class LoggingControllerLifecycleListener implements ControllerLifecycleListener {
 
   @Override
-  public void onReady(OBSRemoteController controller) {
-    log.info("OBS RemoteController is ready");
-  }
-
-  @Override
-  public void onDisconnect(OBSRemoteController controller) {
-    log.info("OBS RemoteController has disconnected");
-  }
-
-  @Override
   public void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable) {
     log.error(reasonThrowable.getReason(), reasonThrowable.getThrowable());
   }

--- a/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/LoggingControllerLifecycleListener.java
+++ b/src/main/java/io/obswebsocket/community/client/listener/lifecycle/controller/LoggingControllerLifecycleListener.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.listener.lifecycle.controller;
 
-import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import lombok.extern.slf4j.Slf4j;
 
@@ -8,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 public class LoggingControllerLifecycleListener implements ControllerLifecycleListener {
 
   @Override
-  public void onError(OBSRemoteController controller, ReasonThrowable reasonThrowable) {
+  public void onError(ReasonThrowable reasonThrowable) {
     log.error(reasonThrowable.getReason(), reasonThrowable.getThrowable());
   }
 }

--- a/src/test/java/io/obswebsocket/community/client/test/OBSCommunicatorTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/OBSCommunicatorTest.java
@@ -24,6 +24,7 @@ import io.obswebsocket.community.client.listener.lifecycle.communicator.Communic
 import io.obswebsocket.community.client.listener.request.ObsRequestListener;
 import io.obswebsocket.community.client.message.Message.Type;
 import io.obswebsocket.community.client.message.authentication.Hello;
+import io.obswebsocket.community.client.message.authentication.Identified;
 import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.request.RequestBatch;
@@ -493,6 +494,54 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // And onClose is invoked with Unknown
     verify(lifecycleListener).onClose(any(), eq(WebSocketCloseCode.UnknownCode));
+
+  }
+
+  @Test
+  void clientIsReadyWhenIdentified() {
+
+    // Given a communicator
+    CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
+    OBSCommunicator connector = new OBSCommunicator(
+      mock(MessageTranslator.class),
+      mock(Authenticator.class),
+      lifecycleListener,
+      mock(ObsRequestListener.class),
+      mock(ObsEventListener.class)
+    );
+
+    // And a session is established
+    connector.onConnect(mock(Session.class, RETURNS_DEEP_STUBS));
+
+    // When identified
+    connector.onIdentified(mock(Identified.class));
+
+    // Then it is ready
+    verify(lifecycleListener).onReady(connector);
+
+  }
+
+  @Test
+  void clientDisconnectedAfterClose() {
+
+    // Given a communicator
+    CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
+    OBSCommunicator connector = new OBSCommunicator(
+      mock(MessageTranslator.class),
+      mock(Authenticator.class),
+      lifecycleListener,
+      mock(ObsRequestListener.class),
+      mock(ObsEventListener.class)
+    );
+
+    // And a session is established
+    connector.onConnect(mock(Session.class, RETURNS_DEEP_STUBS));
+
+    // When closed
+    connector.onClose(WebSocketCloseCode.UnknownReason.getCode(), "foo");
+
+    // Then it is disconnected
+    verify(lifecycleListener).onDisconnect(connector);
 
   }
 }

--- a/src/test/java/io/obswebsocket/community/client/test/OBSCommunicatorTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/OBSCommunicatorTest.java
@@ -75,7 +75,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // then onError is called
     ArgumentCaptor<ReasonThrowable> captor = ArgumentCaptor.forClass(ReasonThrowable.class);
-    verify(lifecycleListener).onError(any(), captor.capture());
+    verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getThrowable()).isInstanceOf(IllegalStateException.class);
     assertThat(captor.getValue().getThrowable())
         .hasMessage("Server doesn't support this client's RPC version");
@@ -87,7 +87,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
         .lifecycle()
-        .onError((comm, reasonThrowable) -> {
+        .onError((reasonThrowable) -> {
           System.out.println(reasonThrowable);
           actualTestResult.set(reasonThrowable.getReason());
         })
@@ -109,7 +109,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
         .lifecycle()
-        .onError((comm, reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
         .and()
         .build();
 
@@ -128,7 +128,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
         .lifecycle()
-        .onError((comm, reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
         .and()
         .build();
 
@@ -148,7 +148,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
         .lifecycle()
-        .onError((comm, reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
         .and()
         .build();
 
@@ -170,7 +170,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
         .lifecycle()
-        .onError((comm, reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
         .and()
         .build();
 
@@ -263,7 +263,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Then an error was invoked
     ArgumentCaptor<ReasonThrowable> captor = ArgumentCaptor.forClass(ReasonThrowable.class);
-    verify(lifecycleListener).onError(any(), captor.capture());
+    verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getReason())
         .isEqualTo("Could not send message; no session established");
 
@@ -292,7 +292,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Then an error was invoked
     ArgumentCaptor<ReasonThrowable> captor = ArgumentCaptor.forClass(ReasonThrowable.class);
-    verify(lifecycleListener).onError(any(), captor.capture());
+    verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getReason())
         .isEqualTo("Could not send message; no session established");
 
@@ -490,10 +490,10 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     connector.onClose(invalidCode, "some reason");
 
     // Then onError is not invoked
-    verify(lifecycleListener, times(0)).onError(any(), any());
+    verify(lifecycleListener, times(0)).onError(any());
 
     // And onClose is invoked with Unknown
-    verify(lifecycleListener).onClose(any(), eq(WebSocketCloseCode.UnknownCode));
+    verify(lifecycleListener).onClose(eq(WebSocketCloseCode.UnknownCode));
 
   }
 
@@ -517,7 +517,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     connector.onIdentified(mock(Identified.class));
 
     // Then it is ready
-    verify(lifecycleListener).onReady(connector);
+    verify(lifecycleListener).onReady();
 
   }
 
@@ -541,7 +541,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     connector.onClose(WebSocketCloseCode.UnknownReason.getCode(), "foo");
 
     // Then it is disconnected
-    verify(lifecycleListener).onDisconnect(connector);
+    verify(lifecycleListener).onDisconnect();
 
   }
 }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
@@ -40,7 +40,9 @@ public class CompositeCommunicatorLifecycleListenerTest {
     compositeListener.onConnect(mock(OBSCommunicator.class), mock(Session.class));
     compositeListener.onHello(mock(OBSCommunicator.class), mock(Hello.class));
     compositeListener.onIdentified(mock(OBSCommunicator.class), mock(Identified.class));
+    compositeListener.onReady(mock(OBSCommunicator.class));
     compositeListener.onClose(mock(OBSCommunicator.class), WebSocketCloseCode.AlreadyIdentified);
+    compositeListener.onDisconnect(mock(OBSCommunicator.class));
     compositeListener.onError(mock(OBSCommunicator.class), mock(ReasonThrowable.class));
 
     // Then each is called
@@ -48,7 +50,9 @@ public class CompositeCommunicatorLifecycleListenerTest {
       verify(listener).onConnect(any(), any());
       verify(listener).onHello(any(), any());
       verify(listener).onIdentified(any(), any());
+      verify(listener).onReady(any());
       verify(listener).onClose(any(), eq(WebSocketCloseCode.AlreadyIdentified));
+      verify(listener).onDisconnect(any());
       verify(listener).onError(any(), any());
     });
 

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.ObsCommunicatorBuilder;
+import io.obswebsocket.community.client.OBSCommunicatorBuilder;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.communicator.CommunicatorLifecycleListener;
@@ -59,7 +59,7 @@ public class CompositeCommunicatorLifecycleListenerTest {
 
   @Test
   void lifecycleListenerBuilderProvidesCompositeListener() {
-    assertThat(new CommunicatorLifecycleListenerBuilder(new ObsCommunicatorBuilder()).build())
+    assertThat(new CommunicatorLifecycleListenerBuilder(new OBSCommunicatorBuilder()).build())
         .isInstanceOf(CompositeCommunicatorLifecycleListener.class);
   }
 }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeCommunicatorLifecycleListenerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.OBSCommunicator;
 import io.obswebsocket.community.client.ObsCommunicatorBuilder;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
@@ -37,23 +36,23 @@ public class CompositeCommunicatorLifecycleListenerTest {
         listeners);
 
     // When called
-    compositeListener.onConnect(mock(OBSCommunicator.class), mock(Session.class));
-    compositeListener.onHello(mock(OBSCommunicator.class), mock(Hello.class));
-    compositeListener.onIdentified(mock(OBSCommunicator.class), mock(Identified.class));
-    compositeListener.onReady(mock(OBSCommunicator.class));
-    compositeListener.onClose(mock(OBSCommunicator.class), WebSocketCloseCode.AlreadyIdentified);
-    compositeListener.onDisconnect(mock(OBSCommunicator.class));
-    compositeListener.onError(mock(OBSCommunicator.class), mock(ReasonThrowable.class));
+    compositeListener.onConnect(mock(Session.class));
+    compositeListener.onHello(mock(Hello.class));
+    compositeListener.onIdentified(mock(Identified.class));
+    compositeListener.onReady();
+    compositeListener.onClose(WebSocketCloseCode.AlreadyIdentified);
+    compositeListener.onDisconnect();
+    compositeListener.onError(mock(ReasonThrowable.class));
 
     // Then each is called
     listeners.forEach(listener -> {
-      verify(listener).onConnect(any(), any());
-      verify(listener).onHello(any(), any());
-      verify(listener).onIdentified(any(), any());
-      verify(listener).onReady(any());
-      verify(listener).onClose(any(), eq(WebSocketCloseCode.AlreadyIdentified));
-      verify(listener).onDisconnect(any());
-      verify(listener).onError(any(), any());
+      verify(listener).onConnect(any());
+      verify(listener).onHello(any());
+      verify(listener).onIdentified(any());
+      verify(listener).onReady();
+      verify(listener).onClose(eq(WebSocketCloseCode.AlreadyIdentified));
+      verify(listener).onDisconnect();
+      verify(listener).onError(any());
     });
 
   }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.ObsRemoteControllerBuilder;
+import io.obswebsocket.community.client.OBSRemoteControllerBuilder;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.controller.CompositeControllerLifecycleListener;
 import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListener;
@@ -42,7 +42,7 @@ public class CompositeControllerLifecycleListenerTest {
 
   @Test
   void lifecycleListenerBuilderProvidesCompositeListener() {
-    assertThat(new ControllerLifecycleListenerBuilder(new ObsRemoteControllerBuilder()).build())
+    assertThat(new ControllerLifecycleListenerBuilder(new OBSRemoteControllerBuilder()).build())
         .isInstanceOf(CompositeControllerLifecycleListener.class);
   }
 }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
@@ -32,14 +32,10 @@ public class CompositeControllerLifecycleListenerTest {
         listeners);
 
     // When called
-    compositeListener.onReady(mock(OBSRemoteController.class));
-    compositeListener.onDisconnect(mock(OBSRemoteController.class));
     compositeListener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
 
     // Then each is called
     listeners.forEach(listener -> {
-      verify(listener).onReady(any());
-      verify(listener).onDisconnect(any());
       verify(listener).onError(any(), any());
     });
 

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/CompositeControllerLifecycleListenerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.ObsRemoteControllerBuilder;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.controller.CompositeControllerLifecycleListener;
@@ -32,11 +31,11 @@ public class CompositeControllerLifecycleListenerTest {
         listeners);
 
     // When called
-    compositeListener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
+    compositeListener.onError(mock(ReasonThrowable.class));
 
     // Then each is called
     listeners.forEach(listener -> {
-      verify(listener).onError(any(), any());
+      verify(listener).onError(any());
     });
 
   }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingCommunicatorLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingCommunicatorLifecycleListenerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.OBSCommunicator;
 import io.obswebsocket.community.client.WebSocketCloseCode;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.communicator.DelegatingCommunicatorLifecycleListener;
@@ -22,13 +21,13 @@ public class DelegatingCommunicatorLifecycleListenerTest {
   void callbacksAreCalled() {
 
     // Given callbacks registered to the listener
-    BiConsumer onConnect = mock(BiConsumer.class);
-    BiConsumer onHello = mock(BiConsumer.class);
-    BiConsumer onIdentified = mock(BiConsumer.class);
-    Consumer onReadyCallback = mock(Consumer.class);
-    BiConsumer onClose = mock(BiConsumer.class);
-    Consumer onDisconnectCallback = mock(Consumer.class);
-    BiConsumer onError = mock(BiConsumer.class);
+    Consumer onConnect = mock(Consumer.class);
+    Consumer onHello = mock(Consumer.class);
+    Consumer onIdentified = mock(Consumer.class);
+    Runnable onReadyCallback = mock(Runnable.class);
+    Consumer onClose = mock(Consumer.class);
+    Runnable onDisconnectCallback = mock(Runnable.class);
+    Consumer onError = mock(Consumer.class);
     DelegatingCommunicatorLifecycleListener listener = new DelegatingCommunicatorLifecycleListener(
         onConnect,
         onHello,
@@ -40,22 +39,22 @@ public class DelegatingCommunicatorLifecycleListenerTest {
     );
 
     // When invoked on the listener
-    listener.onConnect(mock(OBSCommunicator.class), mock(Session.class));
-    listener.onHello(mock(OBSCommunicator.class), mock(Hello.class));
-    listener.onIdentified(mock(OBSCommunicator.class), mock(Identified.class));
-    listener.onReady(mock(OBSCommunicator.class));
-    listener.onClose(mock(OBSCommunicator.class), WebSocketCloseCode.AlreadyIdentified);
-    listener.onDisconnect(mock(OBSCommunicator.class));
-    listener.onError(mock(OBSCommunicator.class), mock(ReasonThrowable.class));
+    listener.onConnect(mock(Session.class));
+    listener.onHello(mock(Hello.class));
+    listener.onIdentified(mock(Identified.class));
+    listener.onReady();
+    listener.onClose(WebSocketCloseCode.AlreadyIdentified);
+    listener.onDisconnect();
+    listener.onError(mock(ReasonThrowable.class));
 
     // Then the callbacks are invoked
-    verify(onConnect).accept(any(), any());
-    verify(onHello).accept(any(), any());
-    verify(onIdentified).accept(any(), any());
-    verify(onReadyCallback).accept(any());
-    verify(onClose).accept(any(), eq(WebSocketCloseCode.AlreadyIdentified));
-    verify(onDisconnectCallback).accept(any());
-    verify(onError).accept(any(), any());
+    verify(onConnect).accept(any());
+    verify(onHello).accept(any());
+    verify(onIdentified).accept(any());
+    verify(onReadyCallback).run();
+    verify(onClose).accept(eq(WebSocketCloseCode.AlreadyIdentified));
+    verify(onDisconnectCallback).run();
+    verify(onError).accept(any());
 
   }
 
@@ -74,44 +73,44 @@ public class DelegatingCommunicatorLifecycleListenerTest {
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onConnect(mock(OBSCommunicator.class), mock(Session.class));
-    listener.onHello(mock(OBSCommunicator.class), mock(Hello.class));
-    listener.onIdentified(mock(OBSCommunicator.class), mock(Identified.class));
-    listener.onReady(mock(OBSCommunicator.class));
-    listener.onClose(mock(OBSCommunicator.class), WebSocketCloseCode.AlreadyIdentified);
-    listener.onDisconnect(mock(OBSCommunicator.class));
-    listener.onError(mock(OBSCommunicator.class), mock(ReasonThrowable.class));
+    listener.onConnect(mock(Session.class));
+    listener.onHello(mock(Hello.class));
+    listener.onIdentified(mock(Identified.class));
+    listener.onReady();
+    listener.onClose(WebSocketCloseCode.AlreadyIdentified);
+    listener.onDisconnect();
+    listener.onError(mock(ReasonThrowable.class));
 
   }
 
   @Test
   void exceptionsAreIgnored() {
     // Given a listener with null callbacks
-    BiConsumer exceptionThrowingBiConsumer = (a, b) -> {
+    Consumer exceptionThrowingConsumer = (a) -> {
       throw new RuntimeException("whoops");
     };
-    Consumer exceptionThrowingConsumer = (a) -> {
+    Runnable exceptionThrowingRunnable = () -> {
       throw new RuntimeException("whoops");
     };
 
     DelegatingCommunicatorLifecycleListener listener = new DelegatingCommunicatorLifecycleListener(
-        exceptionThrowingBiConsumer,
-        exceptionThrowingBiConsumer,
-        exceptionThrowingBiConsumer,
         exceptionThrowingConsumer,
-        exceptionThrowingBiConsumer,
         exceptionThrowingConsumer,
-        exceptionThrowingBiConsumer
+        exceptionThrowingConsumer,
+        exceptionThrowingRunnable,
+        exceptionThrowingConsumer,
+        exceptionThrowingRunnable,
+        exceptionThrowingConsumer
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onConnect(mock(OBSCommunicator.class), mock(Session.class));
-    listener.onHello(mock(OBSCommunicator.class), mock(Hello.class));
-    listener.onIdentified(mock(OBSCommunicator.class), mock(Identified.class));
-    listener.onReady(mock(OBSCommunicator.class));
-    listener.onClose(mock(OBSCommunicator.class), WebSocketCloseCode.AlreadyIdentified);
-    listener.onDisconnect(mock(OBSCommunicator.class));
-    listener.onError(mock(OBSCommunicator.class), mock(ReasonThrowable.class));
+    listener.onConnect(mock(Session.class));
+    listener.onHello(mock(Hello.class));
+    listener.onIdentified(mock(Identified.class));
+    listener.onReady();
+    listener.onClose(WebSocketCloseCode.AlreadyIdentified);
+    listener.onDisconnect();
+    listener.onError(mock(ReasonThrowable.class));
 
   }
 

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingControllerLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingControllerLifecycleListenerTest.java
@@ -17,24 +17,16 @@ public class DelegatingControllerLifecycleListenerTest {
   void callbacksAreCalled() {
 
     // Given callbacks registered to the listener
-    Consumer onReady = mock(Consumer.class);
-    Consumer onDisconnect = mock(Consumer.class);
     BiConsumer onError = mock(BiConsumer.class);
 
     DelegatingControllerLifecycleListener listener = new DelegatingControllerLifecycleListener(
-        onReady,
-        onDisconnect,
         onError
     );
 
     // When invoked on the listener
-    listener.onReady(mock(OBSRemoteController.class));
-    listener.onDisconnect(mock(OBSRemoteController.class));
     listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
 
     // Then the callbacks are invoked
-    verify(onReady).accept(any());
-    verify(onDisconnect).accept(any());
     verify(onError).accept(any(), any());
 
   }
@@ -44,14 +36,10 @@ public class DelegatingControllerLifecycleListenerTest {
 
     // Given a listener with null callbacks
     DelegatingControllerLifecycleListener listener = new DelegatingControllerLifecycleListener(
-        null,
-        null,
         null
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onReady(mock(OBSRemoteController.class));
-    listener.onDisconnect(mock(OBSRemoteController.class));
     listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
 
   }
@@ -66,14 +54,10 @@ public class DelegatingControllerLifecycleListenerTest {
       throw new RuntimeException("whoops");
     };
     DelegatingControllerLifecycleListener listener = new DelegatingControllerLifecycleListener(
-        exceptionThrowingConsumer,
-        exceptionThrowingConsumer,
         exceptionThrowingBiConsumer
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onReady(mock(OBSRemoteController.class));
-    listener.onDisconnect(mock(OBSRemoteController.class));
     listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
 
   }

--- a/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingControllerLifecycleListenerTest.java
+++ b/src/test/java/io/obswebsocket/community/client/test/listeners/DelegatingControllerLifecycleListenerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.controller.DelegatingControllerLifecycleListener;
 import java.util.function.BiConsumer;
@@ -17,17 +16,17 @@ public class DelegatingControllerLifecycleListenerTest {
   void callbacksAreCalled() {
 
     // Given callbacks registered to the listener
-    BiConsumer onError = mock(BiConsumer.class);
+    Consumer onError = mock(Consumer.class);
 
     DelegatingControllerLifecycleListener listener = new DelegatingControllerLifecycleListener(
         onError
     );
 
     // When invoked on the listener
-    listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
+    listener.onError(mock(ReasonThrowable.class));
 
     // Then the callbacks are invoked
-    verify(onError).accept(any(), any());
+    verify(onError).accept(any());
 
   }
 
@@ -40,7 +39,7 @@ public class DelegatingControllerLifecycleListenerTest {
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
+    listener.onError(mock(ReasonThrowable.class));
 
   }
 
@@ -50,15 +49,12 @@ public class DelegatingControllerLifecycleListenerTest {
     Consumer exceptionThrowingConsumer = (a) -> {
       throw new RuntimeException("whoops");
     };
-    BiConsumer exceptionThrowingBiConsumer = (a, b) -> {
-      throw new RuntimeException("whoops");
-    };
     DelegatingControllerLifecycleListener listener = new DelegatingControllerLifecycleListener(
-        exceptionThrowingBiConsumer
+        exceptionThrowingConsumer
     );
 
     // When each are called, then no exceptions are thrown
-    listener.onError(mock(OBSRemoteController.class), mock(ReasonThrowable.class));
+    listener.onError(mock(ReasonThrowable.class));
 
   }
 


### PR DESCRIPTION
- Moved onReady and onDisconnect from RemoteController to Communicator
- Removed RemoteControllerBuilder references to the Communicator builder directly; added listenerBuilder facade providing access to setting lifecycle callbacks for both without exposing the Communicator builder
- Removed references to commuicator and controller in lifecycle callbacks; was a legacy feature and is no longer needed (nor desired)