### PR TITLE
Fix change in messages (#134) + more

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Pull and Run OBS Websocket
-        run: docker run -p 4444:4444 -d tinatiel/obswebsocket:latest
+        run: docker run -p 4455:4455 -d tinatiel/obswebsocket:latest
       - name: Run End2End Secured tests
         run: ./gradlew client:endToEndSecuredTest
       - name: Upload Failing Unit Test Results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Pull and Run OBS Websocket
-        run: docker run -p 4455:4455 -d tinatiel/obswebsocket:latest
+        run: docker run -p 4455:4444 -d tinatiel/obswebsocket:latest
       - name: Run End2End Secured tests
         run: ./gradlew client:endToEndSecuredTest
       - name: Upload Failing Unit Test Results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,24 @@
 # Contributing
 
 ## 📘 Notice to Developers: Repository Transfer 📘
-On June 21st, 2021, this repository was transferred from the `Twasi` Organization to the 
-`obs-websocket-community-projects` Organization. This was done to better align this library with the 
+
+On June 21st, 2021, this repository was transferred from the `Twasi` Organization to the
+`obs-websocket-community-projects` Organization. This was done to better align this library with the
 greater Palakis' OBS Websocket plugin community, and provide better administrative tools.
 
-Remotes will continue to operate as normal, due to GitHub automatic redirects. However, to avoid 
-confusion GitHub strongly recommends you update those remotes. 
+Remotes will continue to operate as normal, due to GitHub automatic redirects. However, to avoid
+confusion GitHub strongly recommends you update those remotes.
 
 If you haven't updated your remote, you can check like so; the below example shows an old remote:
+
 ```
 C:\Users\...\websocket-obs-java>git remote -v
 origin  https://github.com/Twasi/websocket-obs-java.git (fetch)
 origin  https://github.com/Twasi/websocket-obs-java.git (push)
 ```
+
 You can update and verify your remote is correct like this:
+
 ```
 C:\Users\...\websocket-obs-java>git remote set-url origin https://github.com/obs-websocket-community-projects/obs-websocket-java.git
 (no output)
@@ -22,12 +26,14 @@ C:\Users\...\websocket-obs-java>git remote -v
 origin  https://github.com/obs-websocket-community-projects/obs-websocket-java.git (fetch)
 origin  https://github.com/obs-websocket-community-projects/obs-websocket-java.git (push)
 ```
+
 See [Transferring a repository](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/transferring-a-repository)
 for more information.
 
 ## Testing
 
 ### Unit and Integration Tests
+
 These tests can be run completely standalone and do not require an instance of OBS (though, they
 may try to simulate bad network connections). These should always run automatically in CI/CD flows.
 
@@ -37,15 +43,21 @@ gradlew client:integrationTest
 ```
 
 ### End-To-End Automated Tests
-These tests only exercise the authentication process with OBS Websockets (and not OS/env specific OBS features, such as Browser or VLC media sources). They are divided into the 'secure' and 'unsecure' portions. 
 
-The 'secure' portions require OBS Websockets to have authentication enabled with the password set to `password`, and are automated via CI/CD with the help of the [obs-websocket-docker](https://github.com/TinaTiel/obs-websocket-docker) docker library. 
+These tests only exercise the authentication process with OBS Websockets (and not OS/env specific
+OBS features, such as Browser or VLC media sources). They are divided into the 'secure' and '
+unsecure' portions.
+
+The 'secure' portions require OBS Websockets to have authentication enabled with the password set
+to `password`, and are automated via CI/CD with the help of
+the [obs-websocket-docker](https://github.com/TinaTiel/obs-websocket-docker) docker library.
 
 ```
 gradlew client:endToEndUnsecuredTest
 ```
 
-The 'unsecure' portions require OBS Websockets authentication be disabled, and at this time must be run manually.
+The 'unsecure' portions require OBS Websockets authentication be disabled, and at this time must be
+run manually.
 
 ```
 gradlew client:endToEndSecuredTest
@@ -53,29 +65,32 @@ gradlew client:endToEndSecuredTest
 
 ### End-To-End Manual Tests
 
-Unfortunately, there is incomplete feature parity between Windows and Linux distributions of OBS 
+Unfortunately, there is incomplete feature parity between Windows and Linux distributions of OBS
 (Windows having the lion's share of features). This means that it isn't possible to exercise all
 features offered by OBS (and OBS Websockets) unless run on a Windows environment and under specific
-conditions. 
+conditions.
 
-Therefore, the tests in the `endToEndManualTest` module require running manually in a local 
+Therefore, the tests in the `endToEndManualTest` module require running manually in a local
 environment meeting these requirements:
 
-  - Windows 10 OS
-  - OBS 27+
-  - OBS Websockets 5+
-  - VLC Media Player
-  - Scene Collection from this project installed (See [OBS Resources](obs-resources/README.md) 
-    for more information)
+- Windows 10 OS
+- OBS 27+
+- OBS Websockets 5+
+- VLC Media Player
+- Scene Collection from this project installed (See [OBS Resources](obs-resources/README.md)
+  for more information)
 
-These tests are run manually, and require you to follow the prompts during the test and watch for the results in OBS; you cannot run these test using a Docker image.
+These tests are run manually, and require you to follow the prompts during the test and watch for
+the results in OBS; you cannot run these test using a Docker image.
 
 ```
 gradlew client:endToEndManualTest
 ```
 
 ### Example Project
-We provide an example project to help people understand how to use this library. At this time, we verify only during CI/CD that it compiles.
+
+We provide an example project to help people understand how to use this library. At this time, we
+verify only during CI/CD that it compiles.
 
 ```
 gradlew example:build
@@ -84,9 +99,11 @@ gradlew example:build
 ## Pull Request / Code Guidelines
 
 ### Branching
-All Pull requests must be directed against the `develop` branch. Unless you are a contributor, you 
-will need to fork this repository and make a pull request for your fork. If you review a PR, we 
-recommend you use the GitHub CLI to pull the PR so that you can pull the code (e.g. if the fork branch
+
+All Pull requests must be directed against the `develop` branch. Unless you are a contributor, you
+will need to fork this repository and make a pull request for your fork. If you review a PR, we
+recommend you use the GitHub CLI to pull the PR so that you can pull the code (e.g. if the fork
+branch
 is in a private repository).
 
 You can follow whichever convention you would like for the names of your branches, but we recommend
@@ -94,53 +111,60 @@ that if working against a specific issue you reference the issue number (e.g. `t
 the purpose of your branch more clear.
 
 ### Code Conventions & Best Practices
-  - Only push code that compiles.
-  - Try to follow Google style conventions.
-  - Include small unit tests when possible.
-  - Manual tests need to pass before filing PRs.
-  - Update the manual observation integration test where applicable; allow other developers to 
-    easily verify your code works as expected without requiring them to write their own.
-  - If you are adding a new feature (for example, setting the current scene), then include any 
-    tangential features (in this example, getting the current scene, and registering for
-    "scene changed" events) to provide feature-completeness for users of this library.
-  - Use Lombok to generate getters, setters, builders, toString, etc. to keep DTO
-    boilerplate more manageable. Exceptions to this should be considered carefully where customization
-    makes sense (for example, in the ObsCommunicator and ObsRemoteController builders).
-  - Avoid switch-case statements to handle serialization/deserialization. Instead, register Gson 
-    TypeAdapters and include unit tests to verify serialization/deserialization works as expected.
-    
+
+- Only push code that compiles.
+- Try to follow [Google style conventions](https://github.com/google/google-java-format).
+- Include small unit tests when possible.
+- Manual tests need to pass before filing PRs.
+- Update the manual observation integration test where applicable; allow other developers to
+  easily verify your code works as expected without requiring them to write their own.
+- If you are adding a new feature (for example, setting the current scene), then include any
+  tangential features (in this example, getting the current scene, and registering for
+  "scene changed" events) to provide feature-completeness for users of this library.
+- Use Lombok to generate getters, setters, builders, toString, etc. to keep DTO
+  boilerplate more manageable. Exceptions to this should be considered carefully where customization
+  makes sense (for example, in the ObsCommunicator and ObsRemoteController builders).
+- Avoid switch-case statements to handle serialization/deserialization. Instead, register Gson
+  TypeAdapters and include unit tests to verify serialization/deserialization works as expected.
+
 ## CI/CD
 
-All CI/CD is governed by push-to-branch naming semantics, and the [VERSION](VERSION) file. All are 
+All CI/CD is governed by push-to-branch naming semantics, and the [VERSION](VERSION) file. All are
 executed by GitHub Actions (see [.github/workflows](.github/workflows)).
-  - [build.gradle](build.gradle) manages pushing releases or snapshots with other metadata to maven central.
-  - Version is configured by the [VERSION](VERSION) file.
-  - Release/Snapshot is governed by the `IS_RELEASE` env var set to 'YES' or not.
-  - Pushes to `develop` trigger snapshot releases to maven central. Creds are in GH secrets.
-  - Pushes to `release/*` trigger releases to maven central. Creds are in GH secrets.
-  - Pushes to `master` creates a git tag using the VERSION file.
+
+- [build.gradle](build.gradle) manages pushing releases or snapshots with other metadata to maven
+  central.
+- Version is configured by the [VERSION](VERSION) file.
+- Release/Snapshot is governed by the `IS_RELEASE` env var set to 'YES' or not.
+- Pushes to `develop` trigger snapshot releases to maven central. Creds are in GH secrets.
+- Pushes to `release/*` trigger releases to maven central. Creds are in GH secrets.
+- Pushes to `master` creates a git tag using the VERSION file.
 
 ### Publishing Snapshots
+
 Snapshots are available to developers wanting to use the latest version of this library.
 While not perfect, any pushes to develop should (1) Compile, (2) pass unit tests, and (3) have been
-checked manually as described above. 
+checked manually as described above.
 
 Provided these are satisfied, this is how you can publish a snapshot:
+
 1. Create a branch from `develop` and work on it.
 1. Create a PR for merge into the `develop` branch.
 1. Merge into `develop`; this triggers a SNAPSHOT release
 
 ### Publishing Releases
-Releases are available to the general-public as official releases on Maven Central. In addition 
+
+Releases are available to the general-public as official releases on Maven Central. In addition
 to meeting code standards, they also include release notes and a tag in git.
 
 To make an official release, follow this process:
-1. When you want to release what is on the `develop` branch, create a new branch with the 
+
+1. When you want to release what is on the `develop` branch, create a new branch with the
    name `release/A.B.C`.
 1. Push the new release branch; this will create a new release in Maven Central.
-1. Create a PR to merge that branch into `master`. Include in that PR any release notes for that 
-   release; see [Release 1.3.0](https://github.com/Twasi/websocket-obs-java/pull/44) for an 
+1. Create a PR to merge that branch into `master`. Include in that PR any release notes for that
+   release; see [Release 1.3.0](https://github.com/Twasi/websocket-obs-java/pull/44) for an
    example, if you're not sure what to write.
 1. Merge the PR into master; this will create a tag on master using the current VERSION
-1. Checkout the `develop` branch and increment the patch version; this way, future pushes to 
+1. Checkout the `develop` branch and increment the patch version; this way, future pushes to
    develop will be against the snapshot of that version. 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, the builder connects to `localhost` on port `4444` without a passwor
 ```java
 OBSRemoteController controller = OBSRemoteController.builder()
   .host("localhost")                  // Default host
-  .port(4444)                         // Default port
+  .port(4455)                         // Default port
   .password("your secure password")   // Provide your password here
   .connectionTimeout(3)               // Seconds the client will wait for OBS to respond
   .build();

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
@@ -65,7 +65,7 @@ public abstract class AbstractObsE2ETest {
         }))
         .and()
         .build();
-//    remote = new OBSRemoteController("ws://localhost:4444", false);
+//    remote = new OBSRemoteController("ws://localhost:4455", false);
 //    remote.registerConnectionFailedCallback(message -> {
 //      fail("Failed to connect to OBS: " + message);
 //    });

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eIT.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eIT.java
@@ -3,15 +3,17 @@ package io.obswebsocket.community.client.test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
-import io.obswebsocket.community.client.message.response.scenes.GetSceneListResponse;
-import io.obswebsocket.community.client.model.Scene;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.response.scenes.GetSceneListResponse;
+import io.obswebsocket.community.client.model.Scene;
 
 /**
  * This test relies on your OBS instance having the expected scene collection installed; See the
@@ -41,15 +43,11 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
 
     // Given expected scenes and sources
     List<Scene> expectedScenes = Arrays.asList(
-        new Scene(SCENE1, 2, false),
-        new Scene(SCENE2, 1, false),
-        new Scene(SCENE3, 0, false)
+            new Scene(SCENE1, 2, false),
+            new Scene(SCENE2, 1, false),
+            new Scene(SCENE3, 0, false)
     );
-    GetSceneListResponse.Data.SpecificData expectedResponseData = new GetSceneListResponse.Data.SpecificData(
-        SCENE1,
-        null,
-        expectedScenes
-    );
+    GetSceneListResponse.Data expectedResponseData = GetSceneListResponse.Data.builder().currentProgramSceneName(SCENE1).scenes(expectedScenes).build();
 
     // When retrieved
     remote.getSceneList(capturingCallback);
@@ -58,7 +56,7 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
     // Then scenes match as expected
     GetSceneListResponse res = getPreviousResponseAs(GetSceneListResponse.class);
     assertThat(res.getMessageData().getResponseData())
-        .usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedResponseData);
+            .usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedResponseData);
 
   }
 
@@ -68,16 +66,16 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
 
     // Given expected sources (all custom sources + mic and desktop audio default obs sources)
     List<String> expectedNames = Arrays.asList(
-        SOURCE_TEXT_SCENE1,
-        SOURCE_TEXT_SCENE2,
-        SOURCE_RED_SQUARE,
-        SOURCE_MEDIA,
-        SOURCE_VLC_MEDIA,
-        SOURCE_BROWSER,
-        SOURCE_GROUP,
-        SOURCE_GROUP_TEXT,
-        "Mic/Aux",
-        "Desktop Audio"
+            SOURCE_TEXT_SCENE1,
+            SOURCE_TEXT_SCENE2,
+            SOURCE_RED_SQUARE,
+            SOURCE_MEDIA,
+            SOURCE_VLC_MEDIA,
+            SOURCE_BROWSER,
+            SOURCE_GROUP,
+            SOURCE_GROUP_TEXT,
+            "Mic/Aux",
+            "Desktop Audio"
     );
 
     // When retrieved

--- a/client/src/integrationTest/java/io/obswebsocket/community/client/test/ObsCommunicatorEventIT.java
+++ b/client/src/integrationTest/java/io/obswebsocket/community/client/test/ObsCommunicatorEventIT.java
@@ -2,6 +2,7 @@ package io.obswebsocket.community.client.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.obswebsocket.community.client.OBSCommunicator;
 import io.obswebsocket.community.client.message.event.Event;
@@ -1185,7 +1186,7 @@ public class ObsCommunicatorEventIT {
         Type.SceneListChanged);
     assertEquals(actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getSceneName(), "sceneName");
     assertEquals(actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getSceneIndex(), 5);
-    assertEquals(actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getIsGroup(), true);
+    assertTrue(actualTestResult.get().getMessageData().getEventData().getScenes().get(0).isGroup());
   }
 
   @Test

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -1,6 +1,21 @@
 package io.obswebsocket.community.client;
 
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
 import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListener;
 import io.obswebsocket.community.client.message.request.Request;
@@ -248,19 +263,7 @@ import io.obswebsocket.community.client.message.response.transitions.SetTransiti
 import io.obswebsocket.community.client.message.response.transitions.TriggerStudioModeTransitionResponse;
 import io.obswebsocket.community.client.model.Input;
 import io.obswebsocket.community.client.model.Projector;
-import java.net.ConnectException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 /**
  * This is the main entrypoint for the client. It provides methods for making requests against OBS
@@ -272,7 +275,7 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 @Slf4j
 public class OBSRemoteController {
 
-  private URI uri;
+  private final URI uri;
   private final OBSCommunicator communicator;
   private final WebSocketClient webSocketClient;
   private final int connectionTimeoutSeconds;
@@ -293,13 +296,13 @@ public class OBSRemoteController {
    * @param autoConnect                 If true, will connect after this class is instantiated.
    */
   public OBSRemoteController(
-      WebSocketClient webSocketClient,
-      OBSCommunicator communicator,
-      ControllerLifecycleListener controllerLifecycleListener,
-      String host,
-      int port,
-      int connectionTimeoutSeconds,
-      boolean autoConnect) {
+          WebSocketClient webSocketClient,
+          OBSCommunicator communicator,
+          ControllerLifecycleListener controllerLifecycleListener,
+          String host,
+          int port,
+          int connectionTimeoutSeconds,
+          boolean autoConnect) {
     if (connectionTimeoutSeconds < 0) {
       throw new IllegalArgumentException("Connection timeout must be greater than zero");
     }
@@ -328,9 +331,11 @@ public class OBSRemoteController {
       // Note that start() must have been called, otherwise an exception
       // is thrown when connect is called.
       ClientUpgradeRequest request = new ClientUpgradeRequest();
-      this.webSocketClient.start();
+      if (!webSocketClient.isStarted() || !webSocketClient.isStarting()) {
+        this.webSocketClient.start();
+      }
       Future<Session> connection = this.webSocketClient.connect(
-          this.communicator, uri, request
+              this.communicator, uri, request
       );
       log.debug(String.format("Connecting to: %s", uri));
 
@@ -340,25 +345,25 @@ public class OBSRemoteController {
       // If the exception is caused by OBS being unavailable over the network
       // (or not installed or started), then call onError with helpful message
       if (
-          t instanceof TimeoutException
-              || (t instanceof ExecutionException && t.getCause() != null && t
-              .getCause() instanceof ConnectException)
-              || (t instanceof ExecutionException && t.getCause() != null && t
-              .getCause() instanceof UnknownHostException)
+              t instanceof TimeoutException
+                      || (t instanceof ExecutionException && t.getCause() != null && t
+                      .getCause() instanceof ConnectException)
+                      || (t instanceof ExecutionException && t.getCause() != null && t
+                      .getCause() instanceof UnknownHostException)
       ) {
         this.controllerLifecycleListener.onError(
-          new ReasonThrowable("Could not contact OBS on: " + this.uri
-                + ", verify OBS is running, the plugin is installed, and it can be reached over the network",
-                t.getCause() == null
-                    ? t
-                    : t.getCause()
-            )
+                new ReasonThrowable("Could not contact OBS on: " + this.uri
+                        + ", verify OBS is running, the plugin is installed, and it can be reached over the network",
+                        t.getCause() == null
+                                ? t
+                                : t.getCause()
+                )
         );
       }
       // Otherwise, something unexpected has happened during connect
       else {
         this.controllerLifecycleListener.onError(
-          new ReasonThrowable("An unexpected exception occurred during connect", t)
+                new ReasonThrowable("An unexpected exception occurred during connect", t)
         );
       }
     }
@@ -371,10 +376,12 @@ public class OBSRemoteController {
       this.communicator.awaitClose(connectionTimeoutSeconds, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       this.controllerLifecycleListener.onError(
-        new ReasonThrowable("Error during closing websocket connection", e)
+              new ReasonThrowable("Error during closing websocket connection", e)
       );
     }
+  }
 
+  public void stop() {
     // stop the client if it isn't already stopped or stopping
     if (!this.webSocketClient.isStopped() || !this.webSocketClient.isStopping()) {
       try {
@@ -382,7 +389,7 @@ public class OBSRemoteController {
         this.webSocketClient.stop();
       } catch (Exception e) {
         this.controllerLifecycleListener.onError(
-          new ReasonThrowable("Error during stopping websocket client", e)
+                new ReasonThrowable("Error during stopping websocket client", e)
         );
       }
     }
@@ -401,7 +408,7 @@ public class OBSRemoteController {
    * @param <RR>     extends {@link RequestResponse}
    */
   public <R extends Request, RR extends RequestResponse> void sendRequest(R request,
-      Consumer<RR> callback) {
+          Consumer<RR> callback) {
     this.communicator.sendRequest(request, callback);
   }
 
@@ -424,16 +431,16 @@ public class OBSRemoteController {
   }
 
   public void setStudioModeEnabled(boolean studioModeEnabled,
-      Consumer<SetStudioModeEnabledResponse> callback) {
+          Consumer<SetStudioModeEnabledResponse> callback) {
     this.sendRequest(
-        SetStudioModeEnabledRequest.builder().studioModeEnabled(studioModeEnabled).build(),
-        callback);
+            SetStudioModeEnabledRequest.builder().studioModeEnabled(studioModeEnabled).build(),
+            callback);
   }
 
   public void broadcastCustomEvent(JsonObject customEventData,
-      Consumer<BroadcastCustomEventResponse> callback) {
+          Consumer<BroadcastCustomEventResponse> callback) {
     this.sendRequest(BroadcastCustomEventRequest.builder().requestData(customEventData).build(),
-        callback);
+            callback);
   }
 
   public void sleep(Long sleepMillis, Consumer<BroadcastCustomEventResponse> callback) {
@@ -449,16 +456,16 @@ public class OBSRemoteController {
   }
 
   public void triggerHotkeyByName(String hotkeyName,
-      Consumer<TriggerHotkeyByNameResponse> callback) {
+          Consumer<TriggerHotkeyByNameResponse> callback) {
     this.sendRequest(TriggerHotkeyByNameRequest.builder().hotkeyName(hotkeyName).build(), callback);
   }
 
   public void triggerHotkeyByKeySequence(String keyId,
-      TriggerHotkeyByKeySequenceRequest.KeyModifiers keyModifiers,
-      Consumer<TriggerHotkeyByKeySequenceResponse> callback) {
+          TriggerHotkeyByKeySequenceRequest.KeyModifiers keyModifiers,
+          Consumer<TriggerHotkeyByKeySequenceResponse> callback) {
     this.sendRequest(
-        TriggerHotkeyByKeySequenceRequest.builder().keyId(keyId).keyModifiers(keyModifiers).build(),
-        callback);
+            TriggerHotkeyByKeySequenceRequest.builder().keyId(keyId).keyModifiers(keyModifiers).build(),
+            callback);
   }
 
   public void getSceneCollectionList(Consumer<GetSceneCollectionListResponse> callback) {
@@ -466,24 +473,24 @@ public class OBSRemoteController {
   }
 
   public void setCurrentSceneCollection(String sceneCollectionName,
-      Consumer<SetCurrentSceneCollectionResponse> callback) {
+          Consumer<SetCurrentSceneCollectionResponse> callback) {
     this.sendRequest(
-        SetCurrentSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
-        callback);
+            SetCurrentSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
+            callback);
   }
 
   public void createSceneCollectionRequest(String sceneCollectionName,
-      Consumer<CreateSceneCollectionResponse> callback) {
+          Consumer<CreateSceneCollectionResponse> callback) {
     this.sendRequest(
-        CreateSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
-        callback);
+            CreateSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
+            callback);
   }
 
   public void removeSceneCollectionRequest(String sceneCollectionName,
-      Consumer<RemoveSceneCollectionResponse> callback) {
+          Consumer<RemoveSceneCollectionResponse> callback) {
     this.sendRequest(
-        RemoveSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
-        callback);
+            RemoveSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(),
+            callback);
   }
 
   public void getCurrentProgramSceneRequest(Consumer<GetCurrentProgramSceneResponse> callback) {
@@ -491,9 +498,9 @@ public class OBSRemoteController {
   }
 
   public void setCurrentProgramSceneRequest(String sceneName,
-      Consumer<SetCurrentProgramSceneResponse> callback) {
+          Consumer<SetCurrentProgramSceneResponse> callback) {
     this.sendRequest(SetCurrentProgramSceneRequest.builder().sceneName(sceneName).build(),
-        callback);
+            callback);
   }
 
   public void getCurrentPreviewSceneRequest(Consumer<GetCurrentPreviewSceneResponse> callback) {
@@ -501,9 +508,9 @@ public class OBSRemoteController {
   }
 
   public void setCurrentPreviewSceneRequest(String sceneName,
-      Consumer<SetCurrentPreviewSceneResponse> callback) {
+          Consumer<SetCurrentPreviewSceneResponse> callback) {
     this.sendRequest(SetCurrentPreviewSceneRequest.builder().sceneName(sceneName).build(),
-        callback);
+            callback);
   }
 
   public void createSceneRequest(String sceneName, Consumer<CreateSceneResponse> callback) {
@@ -515,15 +522,15 @@ public class OBSRemoteController {
   }
 
   public void getProfileParameterRequest(String parameterCategory, String parameterName,
-      Consumer<GetProfileParameterResponse> callback) {
+          Consumer<GetProfileParameterResponse> callback) {
     this.sendRequest(GetProfileParameterRequest.builder().parameterCategory(parameterCategory)
-        .parameterName(parameterName).build(), callback);
+                                               .parameterName(parameterName).build(), callback);
   }
 
   public void setProfileParameterRequest(String parameterCategory, String parameterName,
-      String parameterValue, Consumer<SetProfileParameterResponse> callback) {
+          String parameterValue, Consumer<SetProfileParameterResponse> callback) {
     this.sendRequest(SetProfileParameterRequest.builder().parameterCategory(parameterCategory)
-        .parameterName(parameterName).parameterValue(parameterValue).build(), callback);
+                                               .parameterName(parameterName).parameterValue(parameterValue).build(), callback);
   }
 
   public void removeSceneRequest(String sceneName, Consumer<RemoveSceneResponse> callback) {
@@ -531,14 +538,14 @@ public class OBSRemoteController {
   }
 
   public void setSceneName(String sceneName, String newSceneName,
-      Consumer<SetSceneNameResponse> callback) {
+          Consumer<SetSceneNameResponse> callback) {
     this.sendRequest(
-        SetSceneNameRequest.builder().sceneName(sceneName).newSceneName(newSceneName).build(),
-        callback);
+            SetSceneNameRequest.builder().sceneName(sceneName).newSceneName(newSceneName).build(),
+            callback);
   }
 
   public void getSourceActiveRequest(String sourceName,
-      Consumer<GetSourceActiveResponse> callback) {
+          Consumer<GetSourceActiveResponse> callback) {
     this.sendRequest(GetSourceActiveRequest.builder().sourceName(sourceName).build(), callback);
   }
 
@@ -547,26 +554,26 @@ public class OBSRemoteController {
   }
 
   public void getInputDefaultSettingsRequest(String inputKind,
-      Consumer<GetInputDefaultSettingsResponse> callback) {
+          Consumer<GetInputDefaultSettingsResponse> callback) {
     this.sendRequest(GetInputDefaultSettingsRequest.builder().inputKind(inputKind).build(),
-        callback);
+            callback);
   }
 
   public void getInputKindListRequest(Boolean unversioned,
-      Consumer<GetInputListResponse> callback) {
+          Consumer<GetInputListResponse> callback) {
     this.sendRequest(GetInputKindListRequest.builder().unversioned(unversioned).build(), callback);
   }
 
   public void getInputSettingsRequest(String inputName,
-      Consumer<GetInputSettingsResponse> callback) {
+          Consumer<GetInputSettingsResponse> callback) {
     this.sendRequest(GetInputSettingsRequest.builder().inputName(inputName).build(), callback);
   }
 
   public void setInputSettingsRequest(String inputName, JsonObject inputSettings, Boolean overlay,
-      Consumer<SetInputSettingsResponse> callback) {
+          Consumer<SetInputSettingsResponse> callback) {
     this.sendRequest(
-        SetInputSettingsRequest.builder().inputName(inputName).inputSettings(inputSettings)
-            .overlay(overlay).build(), callback);
+            SetInputSettingsRequest.builder().inputName(inputName).inputSettings(inputSettings)
+                                   .overlay(overlay).build(), callback);
   }
 
   public void getInputMuteRequest(String inputName, Consumer<GetInputMuteResponse> callback) {
@@ -574,10 +581,10 @@ public class OBSRemoteController {
   }
 
   public void setInputMuteRequest(String inputName, boolean inputMuted,
-      Consumer<SetInputMuteResponse> callback) {
+          Consumer<SetInputMuteResponse> callback) {
     this.sendRequest(
-        SetInputMuteRequest.builder().inputName(inputName).inputMuted(inputMuted).build(),
-        callback);
+            SetInputMuteRequest.builder().inputName(inputName).inputMuted(inputMuted).build(),
+            callback);
   }
 
   public void toggleInputMuteRequest(String inputName, Consumer<ToggleInputMuteResponse> callback) {
@@ -589,28 +596,28 @@ public class OBSRemoteController {
   }
 
   public void getSourceScreenshotRequest(String sourceName, String imageFormat, Integer imageWidth,
-      Integer imageHeight, Integer imageCompressionQuality,
-      Consumer<GetSourceScreenshotResponse> callback) {
+          Integer imageHeight, Integer imageCompressionQuality,
+          Consumer<GetSourceScreenshotResponse> callback) {
     this.sendRequest(
-        GetSourceScreenshotRequest.builder().sourceName(sourceName).imageFormat(imageFormat)
-            .imageWidth(imageWidth).imageHeight(imageHeight)
-            .imageCompressionQuality(imageCompressionQuality).build(), callback);
+            GetSourceScreenshotRequest.builder().sourceName(sourceName).imageFormat(imageFormat)
+                                      .imageWidth(imageWidth).imageHeight(imageHeight)
+                                      .imageCompressionQuality(imageCompressionQuality).build(), callback);
   }
 
   public void saveSourceScreenshotRequest(String sourceName, String imageFilePath,
-      String imageFormat, Integer imageWidth, Integer imageHeight, Integer imageCompressionQuality,
-      Consumer<SaveSourceScreenshotResponse> callback) {
+          String imageFormat, Integer imageWidth, Integer imageHeight, Integer imageCompressionQuality,
+          Consumer<SaveSourceScreenshotResponse> callback) {
     this.sendRequest(
-        SaveSourceScreenshotRequest.builder().sourceName(sourceName).imageFilePath(imageFilePath)
-            .imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight)
-            .imageCompressionQuality(imageCompressionQuality).build(), callback);
+            SaveSourceScreenshotRequest.builder().sourceName(sourceName).imageFilePath(imageFilePath)
+                                       .imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight)
+                                       .imageCompressionQuality(imageCompressionQuality).build(), callback);
   }
 
   public void openProjectorRequest(Projector.Type projectorType, Integer projectorMonitor,
-      String projectorGeometry, String sourceName, Consumer<OpenProjectorResponse> callback) {
+          String projectorGeometry, String sourceName, Consumer<OpenProjectorResponse> callback) {
     this.sendRequest(OpenProjectorRequest.builder().projectorType(projectorType)
-        .projectorMonitor(projectorMonitor).projectorGeometry(projectorGeometry)
-        .sourceName(sourceName).build(), callback);
+                                         .projectorMonitor(projectorMonitor).projectorGeometry(projectorGeometry)
+                                         .sourceName(sourceName).build(), callback);
   }
 
   public void getVideoSettingsRequest(Consumer<GetVideoSettingsResponse> callback) {
@@ -618,21 +625,21 @@ public class OBSRemoteController {
   }
 
   public void deleteSceneTransitionOverrideRequest(String sceneName,
-      Consumer<DeleteSceneTransitionOverrideResponse> callback) {
+          Consumer<DeleteSceneTransitionOverrideResponse> callback) {
     this.sendRequest(DeleteSceneTransitionOverrideRequest.builder().sceneName(sceneName).build(),
-        callback);
+            callback);
   }
 
   public void getSceneTransitionOverrideRequest(String sceneName,
-      Consumer<GetSceneTransitionOverrideResponse> callback) {
+          Consumer<GetSceneTransitionOverrideResponse> callback) {
     this.sendRequest(DeleteSceneTransitionOverrideRequest.builder().sceneName(sceneName).build(),
-        callback);
+            callback);
   }
 
   public void setSceneTransitionOverrideRequest(String sceneName, String transitionName,
-      Integer transitionDuration, Consumer<SetSceneTransitionOverrideResponse> callback) {
+          Integer transitionDuration, Consumer<SetSceneTransitionOverrideResponse> callback) {
     this.sendRequest(SetSceneTransitionOverrideRequest.builder().sceneName(sceneName)
-        .transitionName(transitionName).transitionDuration(transitionDuration).build(), callback);
+                                                      .transitionName(transitionName).transitionDuration(transitionDuration).build(), callback);
   }
 
   public void getSpecialInputNamesRequest(Consumer<GetSpecialInputNamesResponse> callback) {
@@ -640,24 +647,24 @@ public class OBSRemoteController {
   }
 
   public void setInputNameRequest(String inputName, String newInputName,
-      Consumer<SetInputNameResponse> callback) {
+          Consumer<SetInputNameResponse> callback) {
     this.sendRequest(
-        SetInputNameRequest.builder().inputName(inputName).newInputName(newInputName).build(),
-        callback);
+            SetInputNameRequest.builder().inputName(inputName).newInputName(newInputName).build(),
+            callback);
   }
 
   public void setInputVolumeRequest(String inputName, Float inputVolumeDb, Float inputVolumeMul,
-      Consumer<SetInputVolumeResponse> callback) {
+          Consumer<SetInputVolumeResponse> callback) {
     this.sendRequest(
-        SetInputVolumeRequest.builder().inputName(inputName).inputVolumeDb(inputVolumeDb)
-            .inputVolumeMul(inputVolumeMul).build(), callback);
+            SetInputVolumeRequest.builder().inputName(inputName).inputVolumeDb(inputVolumeDb)
+                                 .inputVolumeMul(inputVolumeMul).build(), callback);
   }
 
   public void createInputRequest(String inputName, String inputKind, String sceneName,
-      JsonObject inputSettings, Boolean sceneItemEnabled, Consumer<CreateInputResponse> callback) {
+          JsonObject inputSettings, Boolean sceneItemEnabled, Consumer<CreateInputResponse> callback) {
     this.sendRequest(
-        CreateInputRequest.builder().inputName(inputName).inputKind(inputKind).sceneName(sceneName)
-            .inputSettings(inputSettings).sceneItemEnabled(sceneItemEnabled).build(), callback);
+            CreateInputRequest.builder().inputName(inputName).inputKind(inputKind).sceneName(sceneName)
+                              .inputSettings(inputSettings).sceneItemEnabled(sceneItemEnabled).build(), callback);
   }
 
   public void getInputAudioTracksRequest(String inputName, Consumer<GetInputAudioTracksResponse> callback) {
@@ -665,15 +672,15 @@ public class OBSRemoteController {
   }
 
   public void getInputMonitorTypeRequest(String inputName,
-      Consumer<GetInputAudioMonitorTypeResponse> callback) {
+          Consumer<GetInputAudioMonitorTypeResponse> callback) {
     this.sendRequest(GetInputAudioMonitorTypeRequest.builder().inputName(inputName).build(), callback);
   }
 
   public void setInputMonitorTypeRequest(String inputName, Input.MonitorType monitorType,
-      Consumer<SetInputAudioMonitorTypeResponse> callback) {
+          Consumer<SetInputAudioMonitorTypeResponse> callback) {
     this.sendRequest(
-        SetInputAudioMonitorTypeRequest.builder().inputName(inputName).monitorType(monitorType).build(),
-        callback);
+            SetInputAudioMonitorTypeRequest.builder().inputName(inputName).monitorType(monitorType).build(),
+            callback);
   }
 
   public void getCurrentTransitionRequest(Consumer<GetCurrentTransitionResponse> callback) {
@@ -685,28 +692,28 @@ public class OBSRemoteController {
   }
 
   public void getTransitionSettingsRequest(String transitionName,
-      Consumer<GetTransitionSettingsResponse> callback) {
+          Consumer<GetTransitionSettingsResponse> callback) {
     this.sendRequest(GetTransitionSettingsRequest.builder().transitionName(transitionName).build(),
-        callback);
+            callback);
   }
 
   public void setCurrentTransitionDurationRequest(Integer transitionDuration,
-      Consumer<SetCurrentTransitionDurationResponse> callback) {
+          Consumer<SetCurrentTransitionDurationResponse> callback) {
     this.sendRequest(
-        SetCurrentTransitionDurationRequest.builder().transitionDuration(transitionDuration)
-            .build(), callback);
+            SetCurrentTransitionDurationRequest.builder().transitionDuration(transitionDuration)
+                                               .build(), callback);
   }
 
   public void setCurrentTransitionRequest(String transitionName,
-      Consumer<SetCurrentTransitionResponse> callback) {
+          Consumer<SetCurrentTransitionResponse> callback) {
     this.sendRequest(SetCurrentTransitionRequest.builder().transitionName(transitionName).build(),
-        callback);
+            callback);
   }
 
   public void setTransitionSettingsRequest(String transitionName, JsonObject transitionSettings,
-      Consumer<SetTransitionSettingsResponse> callback) {
+          Consumer<SetTransitionSettingsResponse> callback) {
     this.sendRequest(SetTransitionSettingsRequest.builder().transitionName(transitionName)
-        .transitionSettings(transitionSettings).build(), callback);
+                                                 .transitionSettings(transitionSettings).build(), callback);
   }
 
   public void releaseTbarRequest(Consumer<ReleaseTbarResponse> callback) {
@@ -714,134 +721,134 @@ public class OBSRemoteController {
   }
 
   public void setTbarPositionRequest(Double position, Boolean release,
-      Consumer<SetTbarPositionResponse> callback) {
+          Consumer<SetTbarPositionResponse> callback) {
     this.sendRequest(SetTbarPositionRequest.builder().position(position).release(release).build(),
-        callback);
+            callback);
   }
 
   public void triggerStudioModeTransitionRequest(
-      Consumer<TriggerStudioModeTransitionResponse> callback) {
+          Consumer<TriggerStudioModeTransitionResponse> callback) {
     this.sendRequest(TriggerStudioModeTransitionRequest.builder().build(), callback);
   }
 
   public void getSourceFilterListRequest(String sourceName,
-      Consumer<GetSourceFilterListResponse> callback) {
+          Consumer<GetSourceFilterListResponse> callback) {
     this.sendRequest(GetSourceFilterListRequest.builder().sourceName(sourceName).build(), callback);
   }
 
   public void getSourceFilterRequest(String sourceName, String filterName,
-      Consumer<GetSourceFilterResponse> callback) {
+          Consumer<GetSourceFilterResponse> callback) {
     this.sendRequest(
-        GetSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(),
-        callback);
+            GetSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(),
+            callback);
   }
 
   public void setSourceFilterIndexRequest(String sourceName, String filterName, Integer filterIndex,
-      Consumer<SetSourceFilterIndexResponse> callback) {
+          Consumer<SetSourceFilterIndexResponse> callback) {
     this.sendRequest(
-        SetSourceFilterIndexRequest.builder().sourceName(sourceName).filterName(filterName)
-            .filterIndex(filterIndex).build(), callback);
+            SetSourceFilterIndexRequest.builder().sourceName(sourceName).filterName(filterName)
+                                       .filterIndex(filterIndex).build(), callback);
   }
 
   public void createSourceFilterRequest(String sourceName, String filterName, Integer filterIndex,
-      String filterKind, JsonObject filterSettings, Consumer<CreateSourceFilterResponse> callback) {
+          String filterKind, JsonObject filterSettings, Consumer<CreateSourceFilterResponse> callback) {
     this.sendRequest(
-        CreateSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName)
-            .filterKind(filterKind).filterSettings(filterSettings).filterIndex(filterIndex).build(),
-        callback);
+            CreateSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName)
+                                     .filterKind(filterKind).filterSettings(filterSettings).filterIndex(filterIndex).build(),
+            callback);
   }
 
   public void removeSourceFilterRequest(String sourceName, String filterName,
-      Consumer<RemoveSourceFilterResponse> callback) {
+          Consumer<RemoveSourceFilterResponse> callback) {
     this.sendRequest(
-        RemoveSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(),
-        callback);
+            RemoveSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(),
+            callback);
   }
 
   public void setSourceFilterEnabledRequest(String sourceName, String filterName,
-      Boolean filterEnabled, Consumer<SetSourceFilterEnabledResponse> callback) {
+          Boolean filterEnabled, Consumer<SetSourceFilterEnabledResponse> callback) {
     this.sendRequest(
-        SetSourceFilterEnabledRequest.builder().sourceName(sourceName).filterName(filterName)
-            .filterEnabled(filterEnabled).build(), callback);
+            SetSourceFilterEnabledRequest.builder().sourceName(sourceName).filterName(filterName)
+                                         .filterEnabled(filterEnabled).build(), callback);
   }
 
   public void setSourceFilterSettingsRequest(String sourceName, String filterName,
-      JsonObject filterSettings, Consumer<SetSourceFilterEnabledResponse> callback) {
+          JsonObject filterSettings, Consumer<SetSourceFilterEnabledResponse> callback) {
     this.sendRequest(
-        SetSourceFilterSettingsRequest.builder().sourceName(sourceName).filterName(filterName)
-            .filterSettings(filterSettings).build(), callback);
+            SetSourceFilterSettingsRequest.builder().sourceName(sourceName).filterName(filterName)
+                                          .filterSettings(filterSettings).build(), callback);
   }
 
   public void getSceneItemListRequest(String sceneName,
-      Consumer<GetSceneItemListResponse> callback) {
+          Consumer<GetSceneItemListResponse> callback) {
     this.sendRequest(GetSceneItemListRequest.builder().sceneName(sceneName).build(), callback);
   }
 
   public void getSceneItemEnabledRequest(String sceneName, Integer sceneItemId,
-      Consumer<GetSceneItemEnabledResponse> callback) {
+          Consumer<GetSceneItemEnabledResponse> callback) {
     this.sendRequest(
-        GetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
-        callback);
+            GetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
+            callback);
   }
 
   public void setSceneItemEnabledRequest(String sceneName, Integer sceneItemId,
-      Boolean sceneItemEnabled, Consumer<SetSceneItemEnabledResponse> callback) {
+          Boolean sceneItemEnabled, Consumer<SetSceneItemEnabledResponse> callback) {
     this.sendRequest(
-        SetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-            .sceneItemEnabled(sceneItemEnabled).build(), callback);
+            SetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                      .sceneItemEnabled(sceneItemEnabled).build(), callback);
   }
 
   public void getSceneItemLockedRequest(String sceneName, Integer sceneItemId,
-      Consumer<GetSceneItemLockedResponse> callback) {
+          Consumer<GetSceneItemLockedResponse> callback) {
     this.sendRequest(
-        GetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
-        callback);
+            GetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
+            callback);
   }
 
   public void setSceneItemLockedRequest(String sceneName, Integer sceneItemId,
-      Boolean sceneItemLocked, Consumer<SetSceneItemLockedResponse> callback) {
+          Boolean sceneItemLocked, Consumer<SetSceneItemLockedResponse> callback) {
     this.sendRequest(
-        SetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-            .sceneItemLocked(sceneItemLocked).build(), callback);
+            SetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                     .sceneItemLocked(sceneItemLocked).build(), callback);
   }
 
   public void getSceneItemColor(String sceneName, Integer sceneItemId,
-      Consumer<GetSceneItemColorResponse> callback) {
+          Consumer<GetSceneItemColorResponse> callback) {
     this.sendRequest(
-        GetSceneItemColorRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
-        callback);
+            GetSceneItemColorRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
+            callback);
   }
 
   public void setSceneItemIndexRequest(String sceneName, Integer sceneItemId,
-      Integer sceneItemIndex, Consumer<SetSceneItemIndexResponse> callback) {
+          Integer sceneItemIndex, Consumer<SetSceneItemIndexResponse> callback) {
     this.sendRequest(
-        SetSceneItemIndexRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-            .sceneItemIndex(sceneItemIndex).build(), callback);
+            SetSceneItemIndexRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                    .sceneItemIndex(sceneItemIndex).build(), callback);
   }
 
   public void createSceneItem(String sceneName, String sourceName, Boolean sceneItemEnabled,
-      Consumer<CreateSceneItemResponse> callback) {
+          Consumer<CreateSceneItemResponse> callback) {
     this.sendRequest(
-        CreateSceneItemRequest.builder().sceneName(sceneName).sourceName(sourceName).sceneItemEnabled(sceneItemEnabled).build(),
-        callback);
+            CreateSceneItemRequest.builder().sceneName(sceneName).sourceName(sourceName).sceneItemEnabled(sceneItemEnabled).build(),
+            callback);
   }
 
   public void removeSceneItem(String sceneName, Integer sceneItemId,
-      Consumer<RemoveSceneItemResponse> callback) {
+          Consumer<RemoveSceneItemResponse> callback) {
     this.sendRequest(
-        RemoveSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
-        callback);
+            RemoveSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(),
+            callback);
   }
 
   public void duplicateSceneItem(String sceneName, Integer sceneItemId, String destinationSceneName,
-      Consumer<DuplicateSceneItemResponse> callback) {
+          Consumer<DuplicateSceneItemResponse> callback) {
     this.sendRequest(
-        DuplicateSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-            .destinationSceneName(destinationSceneName).build(), callback);
+            DuplicateSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                     .destinationSceneName(destinationSceneName).build(), callback);
   }
 
   public void getLastReplayBufferReplayRequest(
-      Consumer<GetLastReplayBufferReplayResponse> callback) {
+          Consumer<GetLastReplayBufferReplayResponse> callback) {
     this.sendRequest(GetLastReplayBufferReplayRequest.builder().build(), callback);
   }
 
@@ -882,7 +889,7 @@ public class OBSRemoteController {
   }
 
   public void getRecordFilenameFormattingRequest(
-      Consumer<GetRecordFilenameFormattingResponse> callback) {
+          Consumer<GetRecordFilenameFormattingResponse> callback) {
     this.sendRequest(GetRecordFilenameFormattingRequest.builder().build(), callback);
   }
 
@@ -899,16 +906,16 @@ public class OBSRemoteController {
   }
 
   public void setRecordDirectoryRequest(String recordDirectory, Boolean createIfNotExist,
-      Consumer<SetRecordDirectoryResponse> callback) {
+          Consumer<SetRecordDirectoryResponse> callback) {
     this.sendRequest(SetRecordDirectoryRequest.builder().recordDirectory(recordDirectory)
-        .createIfNotExist(createIfNotExist).build(), callback);
+                                              .createIfNotExist(createIfNotExist).build(), callback);
   }
 
   public void setRecordFilenameFormattingRequest(String filenameFormatting,
-      Consumer<SetRecordFilenameFormattingResponse> callback) {
+          Consumer<SetRecordFilenameFormattingResponse> callback) {
     this.sendRequest(
-        SetRecordFilenameFormattingRequest.builder().filenameFormatting(filenameFormatting).build(),
-        callback);
+            SetRecordFilenameFormattingRequest.builder().filenameFormatting(filenameFormatting).build(),
+            callback);
   }
 
   public void startRecordRequest(Boolean waitForResult, Consumer<StartRecordResponse> callback) {
@@ -936,9 +943,9 @@ public class OBSRemoteController {
   }
 
   public void closeProjectorRequest(String projectorName,
-      Consumer<CloseProjectorResponse> callback) {
+          Consumer<CloseProjectorResponse> callback) {
     this.sendRequest(CloseProjectorRequest.builder().projectorName(projectorName).build(),
-        callback);
+            callback);
   }
 
   public void removeInputRequest(String inputName, Consumer<RemoveInputResponse> callback) {
@@ -954,15 +961,15 @@ public class OBSRemoteController {
   }
 
   public void sendStreamCaptionRequest(String captionText,
-      Consumer<SendStreamCaptionResponse> callback) {
+          Consumer<SendStreamCaptionResponse> callback) {
     this.sendRequest(SendStreamCaptionRequest.builder().captionText(captionText).build(), callback);
   }
 
   public void setStreamServiceSettingsRequest(String streamServiceType, JsonObject serviceSettings,
-      Consumer<SetStreamServiceSettingsResponse> callback) {
+          Consumer<SetStreamServiceSettingsResponse> callback) {
     this.sendRequest(
-        SetStreamServiceSettingsRequest.builder().streamServiceType(streamServiceType).serviceSettings(serviceSettings).build(),
-        callback);
+            SetStreamServiceSettingsRequest.builder().streamServiceType(streamServiceType).serviceSettings(serviceSettings).build(),
+            callback);
   }
 
   public void startStreamRequest(Consumer<StartStreamResponse> callback) {
@@ -978,45 +985,45 @@ public class OBSRemoteController {
   }
 
   public void getMediaInputStatusRequest(String inputName,
-      Consumer<GetMediaInputStatusResponse> callback) {
+          Consumer<GetMediaInputStatusResponse> callback) {
     this.sendRequest(GetMediaInputStatusRequest.builder().inputName(inputName).build(), callback);
   }
 
   public void nextMediaInputPlaylistItemRequest(String inputName,
-      Consumer<NextMediaInputPlaylistItemResponse> callback) {
+          Consumer<NextMediaInputPlaylistItemResponse> callback) {
     this.sendRequest(NextMediaInputPlaylistItemRequest.builder().inputName(inputName).build(),
-        callback);
+            callback);
   }
 
   public void offsetMediaInputTimecodeRequest(String inputName, Long timestampOffset,
-      Consumer<OffsetMediaInputTimecodeResponse> callback) {
+          Consumer<OffsetMediaInputTimecodeResponse> callback) {
     this.sendRequest(OffsetMediaInputTimecodeRequest.builder().inputName(inputName)
-        .timestampOffset(timestampOffset).build(), callback);
+                                                    .timestampOffset(timestampOffset).build(), callback);
   }
 
   public void previousMediaInputPlaylistItemRequest(String inputName,
-      Consumer<PreviousMediaInputPlaylistItemResponse> callback) {
+          Consumer<PreviousMediaInputPlaylistItemResponse> callback) {
     this.sendRequest(PreviousMediaInputPlaylistItemRequest.builder().inputName(inputName).build(),
-        callback);
+            callback);
   }
 
   public void restartMediaInputRequest(String inputName,
-      Consumer<RestartMediaInputResponse> callback) {
+          Consumer<RestartMediaInputResponse> callback) {
     this.sendRequest(RestartMediaInputRequest.builder().inputName(inputName).build(), callback);
   }
 
   public void setMediaInputPauseStateRequest(String inputName, Boolean pause,
-      Consumer<SetMediaInputPauseStateResponse> callback) {
+          Consumer<SetMediaInputPauseStateResponse> callback) {
     this.sendRequest(
-        SetMediaInputPauseStateRequest.builder().inputName(inputName).pause(pause).build(),
-        callback);
+            SetMediaInputPauseStateRequest.builder().inputName(inputName).pause(pause).build(),
+            callback);
   }
 
   public void setMediaInputTimecodeRequest(String inputName, Long mediaTimestamp,
-      Consumer<SetMediaInputTimecodeResponse> callback) {
+          Consumer<SetMediaInputTimecodeResponse> callback) {
     this.sendRequest(
-        SetMediaInputTimecodeRequest.builder().inputName(inputName).mediaTimestamp(mediaTimestamp)
-            .build(), callback);
+            SetMediaInputTimecodeRequest.builder().inputName(inputName).mediaTimestamp(mediaTimestamp)
+                                        .build(), callback);
   }
 
   public void stopMediaInputRequest(String inputName, Consumer<StopMediaInputResponse> callback) {
@@ -1040,20 +1047,20 @@ public class OBSRemoteController {
   }
 
   public void setVideoSettingsRequest(Integer baseWidth,
-      Integer baseHeight,
-      Integer outputWidth,
-      Integer outputHeight,
-      Integer fpsNumerator,
-      Integer fpsDenominator,
-      Consumer<RemoveProfileResponse> callback) {
+          Integer baseHeight,
+          Integer outputWidth,
+          Integer outputHeight,
+          Integer fpsNumerator,
+          Integer fpsDenominator,
+          Consumer<RemoveProfileResponse> callback) {
     this.sendRequest(SetVideoSettingsRequest.builder()
-            .baseWidth(baseWidth)
-            .baseHeight(baseHeight)
-            .outputWidth(outputWidth)
-            .outputHeight(outputHeight)
-            .fpsNumerator(fpsNumerator)
-            .fpsDenominator(fpsDenominator)
-            .build(), callback);
+                                            .baseWidth(baseWidth)
+                                            .baseHeight(baseHeight)
+                                            .outputWidth(outputWidth)
+                                            .outputHeight(outputHeight)
+                                            .fpsNumerator(fpsNumerator)
+                                            .fpsDenominator(fpsDenominator)
+                                            .build(), callback);
   }
 
   public void getInputAudioSyncOffsetRequest(String inputName, Consumer<GetInputAudioSyncOffsetResponse> callback) {
@@ -1070,11 +1077,11 @@ public class OBSRemoteController {
 
   public void pressInputPropertiesButtonRequest(String inputName, String propertyName, Consumer<PressInputPropertiesButtonResponse> callback) {
     this.sendRequest(
-        PressInputPropertiesButtonRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
+            PressInputPropertiesButtonRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
   }
 
   public void StartReplayBufferRequest(Consumer<StartReplayBufferResponse> callback) {
     this.sendRequest(
-        StartReplayBufferRequest.builder().build(), callback);
+            StartReplayBufferRequest.builder().build(), callback);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -332,7 +332,7 @@ public class OBSRemoteController {
       Future<Session> connection = this.webSocketClient.connect(
           this.communicator, uri, request
       );
-      log.info(String.format("Connecting to: %s", uri));
+      log.debug(String.format("Connecting to: %s", uri));
 
       // Block on the connection succeeding
       connection.get(connectionTimeoutSeconds, TimeUnit.SECONDS);

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteController.java
@@ -373,7 +373,7 @@ public class OBSRemoteController {
     // trigger the latch
     try {
       log.debug("Closing connection.");
-      this.communicator.awaitClose(connectionTimeoutSeconds, TimeUnit.SECONDS);
+      this.communicator.closeAndAwait(connectionTimeoutSeconds, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       this.controllerLifecycleListener.onError(
               new ReasonThrowable("Error during closing websocket connection", e)

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
@@ -25,7 +25,7 @@ public class OBSRemoteControllerBuilder {
 
   @Getter private final WebSocketClient webSocketClient = new WebSocketClient();
   private String host = "localhost";
-  private int port = 4444;
+  private int port = 4455;
   private int connectionTimeoutSeconds = 3;
   private boolean autoConnect = false;
 

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBuilder.java
@@ -1,34 +1,33 @@
 package io.obswebsocket.community.client;
 
+import java.util.function.Consumer;
+
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
 import io.obswebsocket.community.client.listener.lifecycle.LifecycleListenerBuilderFacade;
 import io.obswebsocket.community.client.listener.lifecycle.controller.ControllerLifecycleListenerBuilder;
 import io.obswebsocket.community.client.message.event.Event;
-import java.util.function.Consumer;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
+import lombok.Getter;
 
 /**
  * The internal builder for creating ${@link OBSRemoteController} instances.
  */
 public class OBSRemoteControllerBuilder {
 
-  private ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder = new ControllerLifecycleListenerBuilder(this);
-  private OBSCommunicatorBuilder obsCommunicatorBuilder = new OBSCommunicatorBuilder();
-  private LifecycleListenerBuilderFacade lifecycleListenerBuilderFacade = new LifecycleListenerBuilderFacade(
-    this,
-    obsCommunicatorBuilder.lifecycle(),
-    controllerLifecycleListenerBuilder
+  private final ControllerLifecycleListenerBuilder controllerLifecycleListenerBuilder = new ControllerLifecycleListenerBuilder(this);
+  private final OBSCommunicatorBuilder obsCommunicatorBuilder = new OBSCommunicatorBuilder();
+  private final LifecycleListenerBuilderFacade lifecycleListenerBuilderFacade = new LifecycleListenerBuilderFacade(
+          this,
+          obsCommunicatorBuilder.lifecycle(),
+          controllerLifecycleListenerBuilder
   );
   private OBSCommunicator communicator;
 
-  private WebSocketClient webSocketClient = WEBSOCKET_CLIENT();
+  @Getter private final WebSocketClient webSocketClient = new WebSocketClient();
   private String host = "localhost";
   private int port = 4444;
   private int connectionTimeoutSeconds = 3;
   private boolean autoConnect = false;
-
-  public static WebSocketClient WEBSOCKET_CLIENT() {
-    return new WebSocketClient();
-  }
 
   public OBSRemoteControllerBuilder host(String host) {
     this.host = host;
@@ -46,7 +45,7 @@ public class OBSRemoteControllerBuilder {
   }
 
   public <T extends Event> OBSRemoteControllerBuilder registerEventListener(Class<T> eventClass,
-      Consumer<T> listener) {
+          Consumer<T> listener) {
     this.obsCommunicatorBuilder.registerEventListener(eventClass, listener);
     return this;
   }
@@ -73,15 +72,15 @@ public class OBSRemoteControllerBuilder {
   public OBSRemoteController build() {
 
     return new OBSRemoteController(
-        webSocketClient,
-        communicator == null
-            ? obsCommunicatorBuilder.build()
-            : communicator,
-        controllerLifecycleListenerBuilder.build(),
-        host,
-        port,
-        connectionTimeoutSeconds,
-        autoConnect
+            webSocketClient,
+            communicator == null
+                    ? obsCommunicatorBuilder.build()
+                    : communicator,
+            controllerLifecycleListenerBuilder.build(),
+            host,
+            port,
+            connectionTimeoutSeconds,
+            autoConnect
     );
 
   }

--- a/client/src/main/java/io/obswebsocket/community/client/WebSocketCloseCode.java
+++ b/client/src/main/java/io/obswebsocket/community/client/WebSocketCloseCode.java
@@ -22,35 +22,43 @@ public enum WebSocketCloseCode {
   /**
    * A data key is missing but required
    */
-  MissingDataKey(4003),
+  MissingDataField(4003),
   /**
    * A data key has an invalid type
    */
-  InvalidDataKeyType(4004),
+  InvalidDataFieldType(4004),
   /**
    * The specified `op` was invalid or missing
    */
-  UnknownOpCode(4005),
+  InvalidDataFieldValue(4005),
   /**
    * The client sent a websocket message without first sending `Identify` message
    */
-  NotIdentified(4006),
+  UnknownOpCode(4006),
+  /**
+   * The client sent a websocket message without first sending Identify message.
+   */
+  NotIdentified(4007),
   /**
    * The client sent an `Identify` message while already identified
    */
-  AlreadyIdentified(4007),
+  AlreadyIdentified(4008),
   /**
    * The authentication attempt (via `Identify`), failed
    */
-  AuthenticationFailed(4008),
+  AuthenticationFailed(4009),
   /**
    * The server detected the usage of an old version of the obs-websocket protocol.,
    */
-  UnsupportedRpcVersion(4009),
+  UnsupportedRpcVersion(4010),
   /**
    * The websocket session has been invalidated by the obs-websocket server.
    */
-  SessionInvalidated(4010),
+  SessionInvalidated(4011),
+  /**
+   * A requested feature is not supported due to hardware/software limitations.
+   */
+  UnsupportedFeature(4012),
   ;
 
   private final int code;
@@ -65,9 +73,9 @@ public enum WebSocketCloseCode {
 
   public static WebSocketCloseCode fromCode(int code) {
     return Arrays.stream(WebSocketCloseCode.values())
-        .filter(it -> it.getCode() == code)
-        .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("Code is invalid"));
+                 .filter(it -> it.getCode() == code)
+                 .findFirst()
+                 .orElseThrow(() -> new IllegalArgumentException("Code is invalid"));
   }
 
 }

--- a/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
+++ b/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
@@ -1,11 +1,10 @@
 package io.obswebsocket.community.client.listener.event;
 
+import io.obswebsocket.community.client.message.event.Event;
+import io.obswebsocket.community.client.message.event.Event.Intent;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-
-import io.obswebsocket.community.client.message.event.Event;
-import io.obswebsocket.community.client.message.event.Event.Intent;
 
 public class OBSEventListenerImpl implements OBSEventListener {
 
@@ -37,8 +36,8 @@ public class OBSEventListenerImpl implements OBSEventListener {
       try {
         Constructor<? extends Event> constructor = aClass.getDeclaredConstructor();
         constructor.setAccessible(true);
-        Event instance = constructor.newInstance();
-        intent = instance.getEventIntent();
+        Event<?> instance = constructor.newInstance();
+        intent = instance.getMessageData().getEventIntent();
       } catch (Throwable t) {
         t.printStackTrace();
       }

--- a/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
+++ b/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
@@ -37,7 +37,9 @@ public class OBSEventListenerImpl implements OBSEventListener {
         Constructor<? extends Event> constructor = aClass.getDeclaredConstructor();
         constructor.setAccessible(true);
         Event instance = constructor.newInstance();
-        intent = instance.getMessageData().getEventIntent();
+        if (instance.getMessageData() != null) {
+          intent = instance.getMessageData().getEventIntent();
+        }
       } catch (Throwable t) {
         t.printStackTrace();
       }

--- a/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
+++ b/client/src/main/java/io/obswebsocket/community/client/listener/event/OBSEventListenerImpl.java
@@ -1,17 +1,18 @@
 package io.obswebsocket.community.client.listener.event;
 
-import io.obswebsocket.community.client.message.event.Event;
-import io.obswebsocket.community.client.message.event.Event.Intent;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+
+import io.obswebsocket.community.client.message.event.Event;
+import io.obswebsocket.community.client.message.event.Event.Intent;
 
 public class OBSEventListenerImpl implements OBSEventListener {
 
   private final ConcurrentHashMap<Class<? extends Event>, Consumer> eventListeners = new ConcurrentHashMap<>();
 
   public OBSEventListenerImpl(
-      ConcurrentHashMap<Class<? extends Event>, Consumer> eventListeners) {
+          ConcurrentHashMap<Class<? extends Event>, Consumer> eventListeners) {
     if (eventListeners != null) {
       this.eventListeners.putAll(eventListeners);
     }
@@ -37,9 +38,7 @@ public class OBSEventListenerImpl implements OBSEventListener {
         Constructor<? extends Event> constructor = aClass.getDeclaredConstructor();
         constructor.setAccessible(true);
         Event instance = constructor.newInstance();
-        if (instance.getMessageData() != null) {
-          intent = instance.getMessageData().getEventIntent();
-        }
+        intent = instance.getEventIntent();
       } catch (Throwable t) {
         t.printStackTrace();
       }

--- a/client/src/main/java/io/obswebsocket/community/client/listener/request/ObsRequestListenerImpl.java
+++ b/client/src/main/java/io/obswebsocket/community/client/listener/request/ObsRequestListenerImpl.java
@@ -1,11 +1,12 @@
 package io.obswebsocket.community.client.listener.request;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.request.RequestBatch;
 import io.obswebsocket.community.client.message.response.RequestBatchResponse;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
 public class ObsRequestListenerImpl implements ObsRequestListener {
 

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
@@ -1,7 +1,6 @@
 package io.obswebsocket.community.client.message.event;
 
 import com.google.gson.annotations.SerializedName;
-
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.event.config.CurrentProfileChangedEvent;
 import io.obswebsocket.community.client.message.event.config.CurrentSceneCollectionChangedEvent;
@@ -57,19 +56,15 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @ToString(callSuper = true)
 public abstract class Event<T> extends Message {
-  @ToString.Exclude private final transient Intent eventIntent;
-
   @SerializedName("d")
   private Data<T> messageData;
 
   protected Event(Intent eventIntent) {
-    super(OperationCode.Event);
-    this.eventIntent = eventIntent;
+    this(eventIntent, null);
   }
 
   protected Event(Intent eventIntent, T messageData) {
     super(OperationCode.Event);
-    this.eventIntent = eventIntent;
     this.messageData = Data.<T>builder().eventType(Type.from(getClass())).eventIntent(eventIntent).eventData(messageData).build();
   }
 

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
@@ -67,6 +67,12 @@ public abstract class Event<T> extends Message {
     this.eventIntent = eventIntent;
   }
 
+  protected Event(Intent eventIntent, T messageData) {
+    super(OperationCode.Event);
+    this.eventIntent = eventIntent;
+    this.messageData = Data.<T>builder().eventType(Type.from(getClass())).eventIntent(eventIntent).eventData(messageData).build();
+  }
+
   @Getter
   public enum Type {
     // General
@@ -142,6 +148,15 @@ public abstract class Event<T> extends Message {
 
     Type(Class<? extends Event> eventClass) {
       this.eventClass = eventClass;
+    }
+
+    private static Type from(Class<? extends Event> eventClass) {
+      for (Type type : values()) {
+        if (type.eventClass.equals(eventClass)) {
+          return type;
+        }
+      }
+      return null;
     }
   }
 

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/Event.java
@@ -1,5 +1,7 @@
 package io.obswebsocket.community.client.message.event;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.event.config.CurrentProfileChangedEvent;
 import io.obswebsocket.community.client.message.event.config.CurrentSceneCollectionChangedEvent;
@@ -54,15 +56,15 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public abstract class Event extends Message {
+public abstract class Event<T> extends Message {
+  @ToString.Exclude private final transient Intent eventIntent;
 
-  private transient Data messageData;
+  @SerializedName("d")
+  private Data<T> messageData;
 
-  protected Event(
-      Type eventType,
-      Intent eventIntent
-  ) {
+  protected Event(Intent eventIntent) {
     super(OperationCode.Event);
+    this.eventIntent = eventIntent;
   }
 
   @Getter
@@ -189,7 +191,7 @@ public abstract class Event extends Message {
      * Receive all event categories (default subscription setting)
      */
     All(General.value | Config.value | Scenes.value | Inputs.value | Transitions.value
-        | Filters.value | Outputs.value | SceneItems.value | MediaInputs.value),
+            | Filters.value | Outputs.value | SceneItems.value | MediaInputs.value),
     /**
      * InputVolumeMeters event (high-volume)
      */
@@ -214,9 +216,9 @@ public abstract class Event extends Message {
   @Getter
   @ToString
   @SuperBuilder
-  public static class Data {
-
-    protected Type eventType;
-    protected Intent eventIntent;
+  public static class Data<T> {
+    private Type eventType;
+    private Intent eventIntent;
+    private T eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangedEvent.java
@@ -1,35 +1,19 @@
 package io.obswebsocket.community.client.message.event.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CurrentProfileChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
-
+public class CurrentProfileChangedEvent extends Event<CurrentProfileChangedEvent.SpecificData> {
   protected CurrentProfileChangedEvent() {
-    super(Type.CurrentProfileChanged, Intent.Config);
+    super(Intent.Config);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String currentProfileName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CurrentSceneCollectionChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class CurrentSceneCollectionChangedEvent extends Event<CurrentSceneCollectionChangedEvent.SpecificData> {
   protected CurrentSceneCollectionChangedEvent() {
-    super(Type.CurrentSceneCollectionChanged, Intent.Config);
+    super(Intent.Config);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String currentSceneCollectionName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/ProfileListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/ProfileListChangedEvent.java
@@ -1,36 +1,22 @@
 package io.obswebsocket.community.client.message.event.config;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
 import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.Profile;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ProfileListChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class ProfileListChangedEvent extends Event<ProfileListChangedEvent.SpecificData> {
   protected ProfileListChangedEvent() {
-    super(Type.ProfileListChanged, Intent.Config);
+    super(Intent.Config);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private List<Profile> profiles;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/SceneCollectionListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/SceneCollectionListChangedEvent.java
@@ -1,36 +1,22 @@
 package io.obswebsocket.community.client.message.event.config;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
 import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.SceneCollection;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneCollectionListChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneCollectionListChangedEvent extends Event<SceneCollectionListChangedEvent.SpecificData> {
   protected SceneCollectionListChangedEvent() {
-    super(Type.SceneCollectionListChanged, Intent.Config);
+    super(Intent.Config);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private List<SceneCollection> sceneCollections;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterCreatedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class FilterCreatedEvent extends FilterEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class FilterCreatedEvent extends FilterEvent<FilterEvent.SpecificData> {
   protected FilterCreatedEvent() {
-    super(Type.FilterCreated, Intent.Filters);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends FilterEvent.Data {
-
-    protected FilterEvent.SpecificData eventData;
+    super(Intent.Filters);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.filters;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class FilterEvent extends Event {
-
-  private transient Data messageData;
-
-  protected FilterEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class FilterEvent<T extends FilterEvent.SpecificData> extends Event<T> {
+  protected FilterEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String filterName; // TODO FilterEvent.Data
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterNameChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class FilterNameChangedEvent extends FilterEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class FilterNameChangedEvent extends FilterEvent<FilterNameChangedEvent.SpecificData> {
   protected FilterNameChangedEvent() {
-    super(Type.FilterNameChanged, Intent.Filters);
+    super(Intent.Filters);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends FilterEvent.SpecificData {
-
     private String oldFilterName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends FilterEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/FilterRemovedEvent.java
@@ -1,17 +1,12 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class FilterRemovedEvent extends FilterEvent {
-
-  @SerializedName("d")
-  private FilterEvent.Data messageData;
-
+public class FilterRemovedEvent extends FilterEvent<FilterEvent.SpecificData> {
   protected FilterRemovedEvent() {
-    super(Type.FilterRemoved, Intent.Filters);
+    super(Intent.Filters);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterAddedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterAddedEvent.java
@@ -1,17 +1,12 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
 public class SourceFilterAddedEvent extends SourceFilterEvent {
-
-  @SerializedName("d")
-  private SourceFilterEvent.Data messageData;
-
   protected SourceFilterAddedEvent() {
-    super(Type.SourceFilterAdded, Intent.Filters);
+    super(Intent.Filters);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterEvent.java
@@ -3,31 +3,18 @@ package io.obswebsocket.community.client.message.event.filters;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SourceFilterEvent extends Event {
-
-  private transient Data messageData;
-
-  protected SourceFilterEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class SourceFilterEvent extends Event<SourceFilterEvent.SpecificData> {
+  protected SourceFilterEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String sourceName; // TODO SourceFilterEvent.Data
     private String filterName; // TODO SourceFilterEvent.Data
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterListReindexedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterListReindexedEvent.java
@@ -1,33 +1,19 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SourceFilterListReindexedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SourceFilterListReindexedEvent extends Event<SourceFilterListReindexedEvent.SpecificData> {
   protected SourceFilterListReindexedEvent() {
-    super(Type.SourceFilterListReindexed, Intent.Filters);
+    super(Intent.Filters);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
     // TODO SourceFilterListReindexedEvent.Data
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterRemovedEvent.java
@@ -1,17 +1,12 @@
 package io.obswebsocket.community.client.message.event.filters;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
 public class SourceFilterRemovedEvent extends SourceFilterEvent {
-
-  @SerializedName("d")
-  private SourceFilterEvent.Data messageData;
-
   protected SourceFilterRemovedEvent() {
-    super(Type.SourceFilterRemoved, Intent.Filters);
+    super(Intent.Filters);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/general/CustomEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/general/CustomEvent.java
@@ -1,28 +1,15 @@
 package io.obswebsocket.community.client.message.event.general;
 
 import com.google.gson.JsonObject;
-import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CustomEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class CustomEvent extends Event<JsonObject> {
   protected CustomEvent() {
-    super(Type.CustomEvent, Intent.General);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected JsonObject eventData;
+    super(Intent.General);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/general/ExitStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/general/ExitStartedEvent.java
@@ -1,18 +1,13 @@
 package io.obswebsocket.community.client.message.event.general;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ExitStartedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class ExitStartedEvent extends Event<Void> {
   protected ExitStartedEvent() {
-    super(Type.ExitStarted, Intent.General);
+    super(Intent.General);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/general/StudioModeStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/general/StudioModeStateChangedEvent.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.event.general;
 
 import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
@@ -20,7 +21,6 @@ public class StudioModeStateChangedEvent extends Event {
   @Getter
   @ToString
   public static class SpecificData {
-
     private Boolean studioModeEnabled;
   }
 
@@ -28,7 +28,6 @@ public class StudioModeStateChangedEvent extends Event {
   @ToString(callSuper = true)
   @SuperBuilder
   public static class Data extends Event.Data {
-
     protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/general/StudioModeStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/general/StudioModeStateChangedEvent.java
@@ -1,33 +1,19 @@
 package io.obswebsocket.community.client.message.event.general;
 
-import com.google.gson.annotations.SerializedName;
-
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class StudioModeStateChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class StudioModeStateChangedEvent extends Event<StudioModeStateChangedEvent.SpecificData> {
   protected StudioModeStateChangedEvent() {
-    super(Type.StudioModeStateChanged, Intent.General);
+    super(Intent.General);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
     private Boolean studioModeEnabled;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputActiveStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputActiveStateChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.highvolume;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputActiveStateChangedEvent extends InputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputActiveStateChangedEvent extends InputStateChangedEvent<InputActiveStateChangedEvent.SpecificData> {
   protected InputActiveStateChangedEvent() {
-    super(Type.InputActiveStateChanged, Intent.InputActiveStateChanged);
+    super(Intent.InputActiveStateChanged);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputStateChangedEvent.SpecificData {
-
     private Boolean videoActive;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputStateChangedEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputShowStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputShowStateChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.highvolume;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputShowStateChangedEvent extends InputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputShowStateChangedEvent extends InputStateChangedEvent<InputShowStateChangedEvent.SpecificData> {
   protected InputShowStateChangedEvent() {
-    super(Type.InputShowStateChanged, Intent.InputShowStateChanged);
+    super(Intent.InputShowStateChanged);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputStateChangedEvent.SpecificData {
-
     private Boolean videoShowing;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputStateChangedEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputStateChangedEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.highvolume;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class InputStateChangedEvent extends Event {
-
-  private transient Data messageData;
-
-  protected InputStateChangedEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class InputStateChangedEvent<T extends InputStateChangedEvent.SpecificData> extends Event<T> {
+  protected InputStateChangedEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String inputName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputVolumeMetersEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/highvolume/InputVolumeMetersEvent.java
@@ -1,32 +1,28 @@
 package io.obswebsocket.community.client.message.event.highvolume;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.Input;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class InputVolumeMetersEvent extends Event {
-
-  private Data eventData;
-
+public class InputVolumeMetersEvent extends Event<InputVolumeMetersEvent.SpecificData> {
   protected InputVolumeMetersEvent() {
-    super(Type.InputVolumeMeters, Intent.InputVolumeMeters);
+    super(Intent.InputVolumeMeters);
   }
 
   @Getter
   @ToString
-  public static class Data {
-
+  public static class SpecificData {
     private List<InputLevels> inputs;
   }
 
   @Getter
   @ToString(callSuper = true)
   static class InputLevels extends Input {
-
     private Double inputVolumeDb;
     private Double inputVolumeMul;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioSyncOffsetChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioSyncOffsetChangedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputAudioSyncOffsetChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputAudioSyncOffsetChangedEvent extends Event<InputAudioSyncOffsetChangedEvent.SpecificData> {
   protected InputAudioSyncOffsetChangedEvent() {
-    super(Type.InputAudioSyncOffsetChanged, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private Long inputAudioSyncOffset;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioTracksChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioTracksChangedEvent.java
@@ -1,34 +1,20 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.List;
+
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputAudioTracksChangedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputAudioTracksChangedEvent extends InputEvent<InputAudioTracksChangedEvent.SpecificData> {
   protected InputAudioTracksChangedEvent() {
-    super(Type.InputAudioTracksChanged, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputEvent.SpecificData {
-
     private List<Integer> inputAudioTracks;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputCreatedEvent.java
@@ -1,36 +1,22 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
 import com.google.gson.JsonObject;
-import com.google.gson.annotations.SerializedName;
+
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputCreatedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputCreatedEvent extends InputEvent<InputCreatedEvent.SpecificData> {
   protected InputCreatedEvent() {
-    super(Type.InputCreated, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputEvent.SpecificData {
-
     private String inputKind;
     private JsonObject inputSettings;
     private JsonObject defaultInputSettings;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@ToString
-abstract class InputEvent extends Event {
-
-  private transient Data messageData;
-
-  protected InputEvent(Event.Type eventType, Intent intent) {
-    super(eventType, intent);
+@ToString(callSuper = true)
+abstract class InputEvent<T extends InputEvent.SpecificData> extends Event<T> {
+  protected InputEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     protected String inputName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputMuteStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputMuteStateChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputMuteStateChangedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputMuteStateChangedEvent extends InputEvent<InputMuteStateChangedEvent.SpecificData> {
   protected InputMuteStateChangedEvent() {
-    super(Type.InputMuteStateChanged, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputEvent.SpecificData {
-
     private Boolean inputMuted;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputNameChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputNameChangedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputNameChangedEvent extends InputEvent<InputNameChangedEvent.SpecificData> {
   protected InputNameChangedEvent() {
-    super(Type.InputNameChanged, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputEvent.SpecificData {
-
     private String oldInputName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputRemovedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputRemovedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputRemovedEvent extends InputEvent<InputEvent.SpecificData> {
   protected InputRemovedEvent() {
-    super(Type.InputRemoved, Intent.Inputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected InputEvent.SpecificData eventData;
+    super(Intent.Inputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeChangedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.inputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class InputVolumeChangedEvent extends InputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class InputVolumeChangedEvent extends InputEvent<InputVolumeChangedEvent.SpecificData> {
   protected InputVolumeChangedEvent() {
-    super(Type.InputVolumeChanged, Intent.Inputs);
+    super(Intent.Inputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends InputEvent.SpecificData {
-
     private float inputVolumeMul;
     private float inputVolumeDb;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends InputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputActionTriggeredEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputActionTriggeredEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.mediainputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class MediaInputActionTriggeredEvent extends MediaInputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class MediaInputActionTriggeredEvent extends MediaInputEvent<MediaInputActionTriggeredEvent.SpecificData> {
   protected MediaInputActionTriggeredEvent() {
-    super(Type.MediaInputActionTriggered, Intent.MediaInputs);
+    super(Intent.MediaInputs);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends MediaInputEvent.SpecificData {
-
     private String mediaAction;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends MediaInputEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.mediainputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class MediaInputEvent extends Event {
-
-  private transient Data messageData;
-
-  protected MediaInputEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class MediaInputEvent<T extends MediaInputEvent.SpecificData> extends Event<T> {
+  protected MediaInputEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String inputName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackEndedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackEndedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.mediainputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class MediaInputPlaybackEndedEvent extends MediaInputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class MediaInputPlaybackEndedEvent extends MediaInputEvent<MediaInputEvent.SpecificData> {
   protected MediaInputPlaybackEndedEvent() {
-    super(Type.MediaInputPlaybackEnded, Intent.MediaInputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends MediaInputEvent.Data {
-
-    protected MediaInputEvent.SpecificData eventData;
+    super(Intent.MediaInputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackStartedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.mediainputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class MediaInputPlaybackStartedEvent extends MediaInputEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class MediaInputPlaybackStartedEvent extends MediaInputEvent<MediaInputEvent.SpecificData> {
   protected MediaInputPlaybackStartedEvent() {
-    super(Type.MediaInputPlaybackStarted, Intent.MediaInputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends MediaInputEvent.Data {
-
-    protected MediaInputEvent.SpecificData eventData;
+    super(Intent.MediaInputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/OutputStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/OutputStateChangedEvent.java
@@ -3,31 +3,18 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@ToString
-abstract class OutputStateChangedEvent extends Event {
-
-  private transient Data messageData;
-
-  protected OutputStateChangedEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+@ToString(callSuper = true)
+abstract class OutputStateChangedEvent extends Event<OutputStateChangedEvent.SpecificData> {
+  protected OutputStateChangedEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private Boolean outputActive;
     private String outputState;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/RecordStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/RecordStateChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.outputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class RecordStateChangedEvent extends OutputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected RecordStateChangedEvent() {
-    super(Type.RecordStateChanged, Intent.Outputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends OutputStateChangedEvent.Data {
-
-    protected OutputStateChangedEvent.SpecificData eventData;
+    super(Intent.Outputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferSavedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferSavedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.outputs;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@ToString
-public class ReplayBufferSavedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+@ToString(callSuper = true)
+public class ReplayBufferSavedEvent extends Event<ReplayBufferSavedEvent.SpecificData> {
   protected ReplayBufferSavedEvent() {
-    super(Type.ReplayBufferSaved, Intent.Outputs);
+    super(Intent.Outputs);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String savedReplayPath;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferStateChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.outputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class ReplayBufferStateChangedEvent extends OutputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected ReplayBufferStateChangedEvent() {
-    super(Type.ReplayBufferStateChanged, Intent.Outputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends OutputStateChangedEvent.Data {
-
-    protected OutputStateChangedEvent.SpecificData eventData;
+    super(Intent.Outputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/StreamStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/StreamStateChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.outputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class StreamStateChangedEvent extends OutputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected StreamStateChangedEvent() {
-    super(Type.StreamStateChanged, Intent.Outputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends OutputStateChangedEvent.Data {
-
-    protected OutputStateChangedEvent.SpecificData eventData;
+    super(Intent.Outputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/VirtualcamStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/VirtualcamStateChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.outputs;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class VirtualcamStateChangedEvent extends OutputStateChangedEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected VirtualcamStateChangedEvent() {
-    super(Type.VirtualcamStateChanged, Intent.Outputs);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends OutputStateChangedEvent.Data {
-
-    protected OutputStateChangedEvent.SpecificData eventData;
+    super(Intent.Outputs);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemCreatedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.sceneitems;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class SceneItemCreatedEvent extends SceneItemSourceEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected SceneItemCreatedEvent() {
-    super(Type.SceneItemCreated, Intent.SceneItems);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemEvent.Data {
-
-    protected SceneItemEvent.SpecificData eventData;
+    super(Intent.SceneItems);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEnableStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEnableStateChangedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.sceneitems;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneItemEnableStateChangedEvent extends SceneItemEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneItemEnableStateChangedEvent extends SceneItemEvent<SceneItemEnableStateChangedEvent.SpecificData> {
   protected SceneItemEnableStateChangedEvent() {
-    super(Type.SceneItemEnableStateChanged, Intent.SceneItems);
+    super(Intent.SceneItems);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneItemEvent.SpecificData {
-
     private Integer sceneItemId;
     private Boolean sceneItemEnabled;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneItemEvent extends Event {
-
-  private transient Data messageData;
-
-  protected SceneItemEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class SceneItemEvent<T extends SceneItemEvent.SpecificData> extends Event<T> {
+  protected SceneItemEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String sceneName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemListReindexedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemListReindexedEvent.java
@@ -1,42 +1,27 @@
 package io.obswebsocket.community.client.message.event.sceneitems;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.List;
+
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneItemListReindexedEvent extends SceneItemEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneItemListReindexedEvent extends SceneItemEvent<SceneItemListReindexedEvent.SpecificData> {
   protected SceneItemListReindexedEvent() {
-    super(Type.SceneItemListReindexed, Intent.SceneItems);
+    super(Intent.SceneItems);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneItemEvent.SpecificData {
-
     private List<SceneItem> sceneItems;
 
     @Getter
     @ToString
     public static class SceneItem {
-
       private Integer sceneItemId;
       private Integer sceneItemIndex;
     }
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemLockStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemLockStateChangedEvent.java
@@ -1,34 +1,19 @@
 package io.obswebsocket.community.client.message.event.sceneitems;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneItemLockStateChangedEvent extends SceneItemEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneItemLockStateChangedEvent extends SceneItemEvent<SceneItemLockStateChangedEvent.SpecificData> {
   protected SceneItemLockStateChangedEvent() {
-    super(Type.SceneItemLockStateChanged, Intent.SceneItems);
+    super(Intent.SceneItems);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneItemEvent.SpecificData {
-
     private Integer sceneItemId;
     private Boolean sceneItemLocked;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemRemovedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.sceneitems;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 public class SceneItemRemovedEvent extends SceneItemSourceEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
   protected SceneItemRemovedEvent() {
-    super(Type.SceneItemRemoved, Intent.SceneItems);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemSourceEvent.Data {
-
-    protected SceneItemSourceEvent.SpecificData eventData;
+    super(Intent.SceneItems);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemSourceEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemSourceEvent.java
@@ -2,31 +2,18 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneItemSourceEvent extends SceneItemEvent {
-
-  private transient SceneItemEvent.Data messageData;
-
-  protected SceneItemSourceEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class SceneItemSourceEvent extends SceneItemEvent<SceneItemSourceEvent.SpecificData> {
+  protected SceneItemSourceEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneItemEvent.SpecificData {
-
     private String sourceName;
     private Integer sourceItemId;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneItemEvent.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentPreviewSceneChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentPreviewSceneChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CurrentPreviewSceneChangedEvent extends SceneEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class CurrentPreviewSceneChangedEvent extends SceneEvent<SceneEvent.SpecificData> {
   protected CurrentPreviewSceneChangedEvent() {
-    super(Type.CurrentPreviewSceneChanged, Intent.Scenes);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneEvent.Data {
-
-    protected SceneEvent.SpecificData eventData;
+    super(Intent.Scenes);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentProgramSceneChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentProgramSceneChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CurrentProgramSceneChangedEvent extends SceneEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class CurrentProgramSceneChangedEvent extends SceneEvent<SceneEvent.SpecificData> {
   protected CurrentProgramSceneChangedEvent() {
-    super(Type.CurrentProgramSceneChanged, Intent.Scenes);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneEvent.Data {
-
-    protected SceneEvent.SpecificData eventData;
+    super(Intent.Scenes);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneCreatedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneCreatedEvent extends SceneEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneCreatedEvent extends SceneEvent<SceneCreatedEvent.SpecificData> {
   protected SceneCreatedEvent() {
-    super(Type.SceneCreated, Intent.Scenes);
+    super(Intent.Scenes);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneEvent.SpecificData {
-
     private Boolean isGroup;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneEvent.java
@@ -3,30 +3,17 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneEvent extends Event {
-
-  private transient Data messageData;
-
-  protected SceneEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class SceneEvent<T extends SceneEvent.SpecificData> extends Event<T> {
+  protected SceneEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private String sceneName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneListChangedEvent.java
@@ -1,37 +1,22 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
 import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.Scene;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneListChangedEvent extends Event {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneListChangedEvent extends Event<SceneListChangedEvent.SpecificData> {
   protected SceneListChangedEvent() {
-    super(Type.SceneListChanged, Intent.Scenes);
+    super(Intent.Scenes);
   }
 
   @Getter
   @ToString
   public static class SpecificData {
-
     private List<Scene> scenes;
   }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected SpecificData eventData;
-  }
-
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneNameChangedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneNameChangedEvent extends SceneEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneNameChangedEvent extends SceneEvent<SceneNameChangedEvent.SpecificData> {
   protected SceneNameChangedEvent() {
-    super(Type.SceneNameChanged, Intent.Scenes);
+    super(Intent.Scenes);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneEvent.SpecificData {
-
     private String oldSceneName;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneRemovedEvent.java
@@ -1,33 +1,18 @@
 package io.obswebsocket.community.client.message.event.scenes;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SceneRemovedEvent extends SceneEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class SceneRemovedEvent extends SceneEvent<SceneRemovedEvent.SpecificData> {
   protected SceneRemovedEvent() {
-    super(Type.SceneRemoved, Intent.Scenes);
+    super(Intent.Scenes);
   }
 
   @Getter
   @ToString(callSuper = true)
   public static class SpecificData extends SceneEvent.SpecificData {
-
     private Boolean isGroup;
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends SceneEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentTransitionChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentTransitionChangedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CurrentTransitionChangedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class CurrentTransitionChangedEvent extends TransitionEvent<TransitionEvent.SpecificData> {
   protected CurrentTransitionChangedEvent() {
-    super(Type.CurrentTransitionChanged, Intent.Transitions);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected TransitionEvent.SpecificData eventData;
+    super(Intent.Transitions);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionCreatedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class TransitionCreatedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class TransitionCreatedEvent extends TransitionEvent<TransitionEvent.SpecificData> {
   protected TransitionCreatedEvent() {
-    super(Type.TransitionCreated, Intent.Transitions);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected TransitionEvent.SpecificData eventData;
+    super(Intent.Transitions);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEndedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEndedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class TransitionEndedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class TransitionEndedEvent extends TransitionEvent<TransitionEvent.SpecificData> {
   protected TransitionEndedEvent() {
-    super(Type.TransitionEnded, Intent.Transitions);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected TransitionEvent.SpecificData eventData;
+    super(Intent.Transitions);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEvent.java
@@ -7,27 +7,15 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class TransitionEvent extends Event {
-
-  protected transient Data messageData;
-
-  protected TransitionEvent(Type eventType, Intent intent) {
-    super(eventType, intent);
+abstract class TransitionEvent<T extends TransitionEvent.SpecificData> extends Event<T> {
+  protected TransitionEvent(Intent intent) {
+    super(intent);
   }
 
   @Getter
   @ToString
   @SuperBuilder
   public static class SpecificData {
-
     protected String transitionName; // TODO TransitionEvent.Data
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends Event.Data {
-
-    protected transient SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionEvent.java
@@ -12,6 +12,10 @@ abstract class TransitionEvent<T extends TransitionEvent.SpecificData> extends E
     super(intent);
   }
 
+  protected TransitionEvent(Intent intent, T data) {
+    super(intent, data);
+  }
+
   @Getter
   @ToString
   @SuperBuilder

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionNameChangedEvent.java
@@ -1,34 +1,20 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class TransitionNameChangedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class TransitionNameChangedEvent extends TransitionEvent<TransitionNameChangedEvent.SpecificData> {
   protected TransitionNameChangedEvent() {
-    super(Type.TransitionNameChanged, Intent.Transitions);
+    super(Intent.Transitions);
   }
 
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
   public static class SpecificData extends TransitionEvent.SpecificData {
-
     private String oldTransitionName; // TODO TransitionNameChangedEvent.Data
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected SpecificData eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionRemovedEvent.java
@@ -1,26 +1,12 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class TransitionRemovedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class TransitionRemovedEvent extends TransitionEvent<TransitionEvent.SpecificData> {
   protected TransitionRemovedEvent() {
-    super(Type.TransitionRemoved, Intent.Transitions);
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected TransitionEvent.SpecificData eventData;
+    super(Intent.Transitions);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionStartedEvent.java
@@ -1,35 +1,12 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class TransitionStartedEvent extends TransitionEvent {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class TransitionStartedEvent extends TransitionEvent<TransitionEvent.SpecificData> {
   protected TransitionStartedEvent() {
-    super(Type.TransitionStarted, Intent.Transitions);
-  }
-
-  protected TransitionStartedEvent(String transitionName) {
-    this();
-    this.messageData = Data.builder()
-        .eventType(Type.TransitionStarted)
-        .eventIntent(Intent.Transitions)
-        .eventData(SpecificData.builder().transitionName(transitionName).build())
-        .build();
-  }
-
-  @Getter
-  @ToString(callSuper = true)
-  @SuperBuilder
-  public static class Data extends TransitionEvent.Data {
-
-    protected TransitionEvent.SpecificData eventData;
+    super(Intent.Transitions);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/TransitionStartedEvent.java
@@ -9,4 +9,8 @@ public class TransitionStartedEvent extends TransitionEvent<TransitionEvent.Spec
   protected TransitionStartedEvent() {
     super(Intent.Transitions);
   }
+
+  protected TransitionStartedEvent(TransitionEvent.SpecificData data) {
+    super(Intent.Transitions, data);
+  }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
@@ -1,5 +1,9 @@
 package io.obswebsocket.community.client.message.request;
 
+import java.util.UUID;
+
+import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.request.config.CreateProfileRequest;
 import io.obswebsocket.community.client.message.request.config.CreateSceneCollectionRequest;
@@ -251,7 +255,6 @@ import io.obswebsocket.community.client.message.response.transitions.SetCurrentT
 import io.obswebsocket.community.client.message.response.transitions.SetTbarPositionResponse;
 import io.obswebsocket.community.client.message.response.transitions.SetTransitionSettingsResponse;
 import io.obswebsocket.community.client.message.response.transitions.TriggerStudioModeTransitionResponse;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -259,7 +262,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @ToString(callSuper = true)
 public abstract class Request extends Message {
-
+  @SerializedName("d")
   protected Data data;
 
   protected Request(Data.Type type) {
@@ -471,7 +474,7 @@ public abstract class Request extends Message {
       private final Class<? extends RequestResponse> requestResponseClass;
 
       Type(Class<? extends Request> requestClass,
-           Class<? extends RequestResponse> requestResponseClass) {
+              Class<? extends RequestResponse> requestResponseClass) {
         this.requestClass = requestClass;
         this.requestResponseClass = requestResponseClass;
       }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
@@ -1,9 +1,6 @@
 package io.obswebsocket.community.client.message.request;
 
-import java.util.UUID;
-
 import com.google.gson.annotations.SerializedName;
-
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.request.config.CreateProfileRequest;
 import io.obswebsocket.community.client.message.request.config.CreateSceneCollectionRequest;
@@ -255,6 +252,7 @@ import io.obswebsocket.community.client.message.response.transitions.SetCurrentT
 import io.obswebsocket.community.client.message.response.transitions.SetTbarPositionResponse;
 import io.obswebsocket.community.client.message.response.transitions.SetTransitionSettingsResponse;
 import io.obswebsocket.community.client.message.response.transitions.TriggerStudioModeTransitionResponse;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -263,14 +261,12 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @ToString(callSuper = true)
 public abstract class Request<T> extends Message {
-  private final transient Data.Type type;
 
   @SerializedName("d")
   private RequestData<T> data;
 
   protected Request(Data.Type type, T requestData) {
     super(OperationCode.Request);
-    this.type = type;
     this.data = RequestData.<T>builder().requestType(type).requestId(UUID.randomUUID().toString()).requestData(requestData).build();
   }
 
@@ -280,10 +276,6 @@ public abstract class Request<T> extends Message {
 
   public Data.Type getRequestType() {
     return this.data.requestType;
-  }
-
-  public Data.Type getType() {
-    return data != null && data.requestType != null ? data.requestType : type;
   }
 
   @SuperBuilder

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
@@ -282,6 +282,10 @@ public abstract class Request<T> extends Message {
     return this.data.requestType;
   }
 
+  public Data.Type getType() {
+    return data != null && data.requestType != null ? data.requestType : type;
+  }
+
   @SuperBuilder
   @Getter
   @ToString

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
@@ -254,7 +254,6 @@ import io.obswebsocket.community.client.message.response.transitions.SetTransiti
 import io.obswebsocket.community.client.message.response.transitions.TriggerStudioModeTransitionResponse;
 import java.util.UUID;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
@@ -281,13 +280,12 @@ public abstract class Request<T> extends Message {
   @SuperBuilder
   @Getter
   @ToString
-  public static class RequestData<T> { // Would be `extends Data` but the @SuperBuilder does not like that
-    @Setter protected String requestId;
-    @Setter protected Data.Type requestType;
+  public static class RequestData<T> extends Data {
+
     protected T requestData;
   }
 
-  @SuperBuilder
+  @SuperBuilder(builderMethodName = "baseBuilder")
   @Getter
   @ToString
   public static class Data {

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/Request.java
@@ -256,19 +256,22 @@ import io.obswebsocket.community.client.message.response.transitions.SetTbarPosi
 import io.obswebsocket.community.client.message.response.transitions.SetTransitionSettingsResponse;
 import io.obswebsocket.community.client.message.response.transitions.TriggerStudioModeTransitionResponse;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public abstract class Request extends Message {
+public abstract class Request<T> extends Message {
+  private final transient Data.Type type;
+
   @SerializedName("d")
-  protected Data data;
+  private RequestData<T> data;
 
-  protected Request(Data.Type type) {
+  protected Request(Data.Type type, T requestData) {
     super(OperationCode.Request);
-
-    this.data = Data.builder().requestType(type).requestId(UUID.randomUUID().toString()).build();
+    this.type = type;
+    this.data = RequestData.<T>builder().requestType(type).requestId(UUID.randomUUID().toString()).requestData(requestData).build();
   }
 
   public String getRequestId() {
@@ -277,6 +280,15 @@ public abstract class Request extends Message {
 
   public Data.Type getRequestType() {
     return this.data.requestType;
+  }
+
+  @SuperBuilder
+  @Getter
+  @ToString
+  public static class RequestData<T> { // Would be `extends Data` but the @SuperBuilder does not like that
+    @Setter protected String requestId;
+    @Setter protected Data.Type requestType;
+    protected T requestData;
   }
 
   @SuperBuilder

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/CreateProfileRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/CreateProfileRequest.java
@@ -8,13 +8,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class CreateProfileRequest extends ProfileRequest {
-
-  private final Data requestData;
-
   @Builder
   private CreateProfileRequest(String profileName) {
-    super(Request.Data.Type.CreateProfile);
-
-    this.requestData = Data.builder().profileName(profileName).build();
+    super(Request.Data.Type.CreateProfile, Data.builder().profileName(profileName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/CreateSceneCollectionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/CreateSceneCollectionRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,17 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneCollectionRequest extends SceneCollectionRequest {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class CreateSceneCollectionRequest extends SceneCollectionRequest<SceneCollectionRequest.SpecificData> {
   @Builder
   private CreateSceneCollectionRequest(String sceneCollectionName) {
-    super(Request.Data.Type.SetCurrentSceneCollection);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .requestData(SpecificData.builder().sceneCollectionName(sceneCollectionName).build())
-        .build();
+    super(Request.Data.Type.SetCurrentSceneCollection, SpecificData.builder().sceneCollectionName(sceneCollectionName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetPersistentDataRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetPersistentDataRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,15 +8,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class GetPersistentDataRequest extends PersistentDataRequest {
-
-  @SerializedName("d")
-  private final PersistentDataRequest.Data data;
-
   @Builder
   private GetPersistentDataRequest(String realm, String slotName) {
-    super(Request.Data.Type.GetPersistentData);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType()).requestData(SpecificData.builder().realm(realm).slotName(slotName).build()).build();
+    super(Request.Data.Type.GetPersistentData, SpecificData.builder().realm(realm).slotName(slotName).build());
   }
-
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetProfileListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetProfileListRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,16 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProfileListRequest extends Request {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class GetProfileListRequest extends Request<Void> {
   @Builder
   private GetProfileListRequest() {
-    super(Data.Type.GetProfileList);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .build();
+    super(Data.Type.GetProfileList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetProfileParameterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetProfileParameterRequest.java
@@ -1,36 +1,18 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProfileParameterRequest extends Request {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class GetProfileParameterRequest extends Request<GetProfileParameterRequest.SpecificData> {
   @Builder
   private GetProfileParameterRequest(String parameterCategory, String parameterName) {
-    super(Request.Data.Type.GetProfileParameter);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .requestData(
-            SpecificData.builder().parameterCategory(parameterCategory).parameterName(parameterName)
-                .build()).build();
-  }
-
-  @SuperBuilder
-  @Getter
-  @ToString
-  static class Data extends Request.Data {
-
-    private SpecificData requestData;
+    super(Request.Data.Type.GetProfileParameter, SpecificData.builder().parameterCategory(parameterCategory).parameterName(parameterName)
+                                                             .build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetSceneCollectionListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetSceneCollectionListRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,16 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneCollectionListRequest extends Request {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class GetSceneCollectionListRequest extends Request<Void> {
   @Builder
   private GetSceneCollectionListRequest() {
-    super(Data.Type.GetSceneCollectionList);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .build();
+    super(Data.Type.GetSceneCollectionList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetVideoSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/GetVideoSettingsRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,16 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetVideoSettingsRequest extends Request {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class GetVideoSettingsRequest extends Request<Void> {
   @Builder
   private GetVideoSettingsRequest() {
-    super(Data.Type.GetVideoSettings);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .build();
+    super(Data.Type.GetVideoSettings, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/PersistentDataRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/PersistentDataRequest.java
@@ -8,17 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class PersistentDataRequest extends Request {
+abstract class PersistentDataRequest extends Request<PersistentDataRequest.SpecificData> {
 
-  PersistentDataRequest(Request.Data.Type type) {
-    super(type);
-  }
-
-  @SuperBuilder
-  @Getter
-  @ToString
-  static class Data extends Request.Data {
-    private SpecificData requestData;
+  PersistentDataRequest(Request.Data.Type type, SpecificData data) {
+    super(type, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/ProfileRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/ProfileRequest.java
@@ -8,17 +8,15 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-abstract class ProfileRequest extends Request {
-
-  ProfileRequest(Request.Data.Type type) {
-    super(type);
+abstract class ProfileRequest extends Request<ProfileRequest.Data> {
+  ProfileRequest(Request.Data.Type type, ProfileRequest.Data data) {
+    super(type, data);
   }
 
   @Getter
   @ToString
   @Builder
   static class Data {
-
     @NonNull
     private final String profileName;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/RemoveProfileRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/RemoveProfileRequest.java
@@ -8,13 +8,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class RemoveProfileRequest extends ProfileRequest {
-
-  private final Data requestData;
-
   @Builder
   private RemoveProfileRequest(String profileName) {
-    super(Request.Data.Type.RemoveProfile);
-
-    this.requestData = Data.builder().profileName(profileName).build();
+    super(Request.Data.Type.RemoveProfile, Data.builder().profileName(profileName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/RemoveSceneCollectionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/RemoveSceneCollectionRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,17 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneCollectionRequest extends SceneCollectionRequest {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class RemoveSceneCollectionRequest extends SceneCollectionRequest<SceneCollectionRequest.SpecificData> {
   @Builder
   private RemoveSceneCollectionRequest(String sceneCollectionName) {
-    super(Request.Data.Type.RemoveSceneCollection);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .requestData(SpecificData.builder().sceneCollectionName(sceneCollectionName).build())
-        .build();
+    super(Request.Data.Type.RemoveSceneCollection, SpecificData.builder().sceneCollectionName(sceneCollectionName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SceneCollectionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SceneCollectionRequest.java
@@ -8,18 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneCollectionRequest extends Request {
+abstract class SceneCollectionRequest<T extends SceneCollectionRequest.SpecificData> extends Request<T> {
 
-  SceneCollectionRequest(Request.Data.Type requestType) {
-    super(requestType);
-  }
-
-  @SuperBuilder
-  @Getter
-  @ToString
-  static class Data extends Request.Data {
-
-    private SpecificData requestData;
+  SceneCollectionRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SceneCollectionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SceneCollectionRequest.java
@@ -14,7 +14,6 @@ abstract class SceneCollectionRequest extends Request {
     super(requestType);
   }
 
-
   @SuperBuilder
   @Getter
   @ToString

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetCurrentProfileRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetCurrentProfileRequest.java
@@ -8,13 +8,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class SetCurrentProfileRequest extends ProfileRequest {
-
-  private final Data requestData;
-
   @Builder
   private SetCurrentProfileRequest(String profileName) {
-    super(Request.Data.Type.SetCurrentProfile);
-
-    this.requestData = Data.builder().profileName(profileName).build();
+    super(Request.Data.Type.SetCurrentProfile, Data.builder().profileName(profileName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetCurrentSceneCollectionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetCurrentSceneCollectionRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,17 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentSceneCollectionRequest extends SceneCollectionRequest {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class SetCurrentSceneCollectionRequest extends SceneCollectionRequest<SceneCollectionRequest.SpecificData> {
   @Builder
   private SetCurrentSceneCollectionRequest(String sceneCollectionName) {
-    super(Request.Data.Type.SetCurrentSceneCollection);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .requestData(SpecificData.builder().sceneCollectionName(sceneCollectionName).build())
-        .build();
+    super(Request.Data.Type.SetCurrentSceneCollection, SpecificData.builder().sceneCollectionName(sceneCollectionName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetPersistentDataRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetPersistentDataRequest.java
@@ -1,6 +1,5 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,15 +10,9 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @ToString(callSuper = true)
 public class SetPersistentDataRequest extends PersistentDataRequest {
-
-  @SerializedName("d")
-  private final Data data;
-
   @Builder
   private SetPersistentDataRequest(String realm, String slotName, Object slotValue) {
-    super(Request.Data.Type.SetPersistentData);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType()).requestData(SpecificData.builder().realm(realm).slotName(slotName).slotValue(slotValue).build()).build();
+    super(Request.Data.Type.SetPersistentData, SpecificData.builder().realm(realm).slotName(slotName).slotValue(slotValue).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetProfileParameterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetProfileParameterRequest.java
@@ -1,37 +1,19 @@
 package io.obswebsocket.community.client.message.request.config;
 
-import com.google.gson.annotations.SerializedName;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetProfileParameterRequest extends Request {
-
-  @SerializedName("d")
-  private final Data data;
-
+public class SetProfileParameterRequest extends Request<SetProfileParameterRequest.SpecificData> {
   @Builder
   private SetProfileParameterRequest(String parameterCategory, String parameterName,
-      String parameterValue) {
-    super(Request.Data.Type.SetProfileParameter);
-
-    this.data = Data.builder().requestId(this.getRequestId()).requestType(this.getRequestType())
-        .requestData(
-            SpecificData.builder().parameterCategory(parameterCategory).parameterName(parameterName)
-                .parameterValue(parameterValue).build()).build();
-  }
-
-  @SuperBuilder
-  @Getter
-  @ToString
-  static class Data extends Request.Data {
-
-    private SpecificData requestData;
+          String parameterValue) {
+    super(Request.Data.Type.SetProfileParameter, SpecificData.builder().parameterCategory(parameterCategory).parameterName(parameterName)
+                                                             .parameterValue(parameterValue).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetVideoSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/config/SetVideoSettingsRequest.java
@@ -7,27 +7,22 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetVideoSettingsRequest extends Request {
-
-  private final Data requestData;
-
+public class SetVideoSettingsRequest extends Request<SetVideoSettingsRequest.Data> {
   @Builder
   private SetVideoSettingsRequest(Integer baseWidth,
-      Integer baseHeight,
-      Integer outputWidth,
-      Integer outputHeight,
-      Integer fpsNumerator,
-      Integer fpsDenominator) {
-    super(Request.Data.Type.SetVideoSettings);
-
-    this.requestData = Data.builder()
-        .baseWidth(baseWidth)
-        .baseHeight(baseHeight)
-        .outputWidth(outputWidth)
-        .outputHeight(outputHeight)
-        .fpsNumerator(fpsNumerator)
-        .fpsDenominator(fpsDenominator)
-        .build();
+          Integer baseHeight,
+          Integer outputWidth,
+          Integer outputHeight,
+          Integer fpsNumerator,
+          Integer fpsDenominator) {
+    super(Request.Data.Type.SetVideoSettings, Data.builder()
+                                                  .baseWidth(baseWidth)
+                                                  .baseHeight(baseHeight)
+                                                  .outputWidth(outputWidth)
+                                                  .outputHeight(outputHeight)
+                                                  .fpsNumerator(fpsNumerator)
+                                                  .fpsDenominator(fpsDenominator)
+                                                  .build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/CreateSourceFilterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/CreateSourceFilterRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.filters;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,17 +11,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSourceFilterRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class CreateSourceFilterRequest extends FilterRequest<CreateSourceFilterRequest.Data> {
   @Builder
   private CreateSourceFilterRequest(String sourceName, String filterName, Integer filterIndex,
-      String filterKind, JsonObject filterSettings) {
-    super(Request.Data.Type.CreateSourceFilter);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName)
-        .filterIndex(filterIndex).filterKind(filterKind).filterSettings(filterSettings).build();
+          String filterKind, JsonObject filterSettings) {
+    super(Request.Data.Type.CreateSourceFilter, Data.builder().sourceName(sourceName).filterName(filterName)
+                                                    .filterIndex(filterIndex).filterKind(filterKind).filterSettings(filterSettings).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/FilterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/FilterRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class FilterRequest extends Request {
+abstract class FilterRequest<T extends FilterRequest.Data> extends Request<T> {
 
-  FilterRequest(Request.Data.Type requestType) {
-    super(requestType);
+  FilterRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/GetSourceFilterListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/GetSourceFilterListRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceFilterListRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class GetSourceFilterListRequest extends FilterRequest<FilterRequest.Data> {
   @Builder
   private GetSourceFilterListRequest(String sourceName) {
-    super(Request.Data.Type.GetSourceFilterList);
-
-    this.requestData = Data.builder().sourceName(sourceName).build();
+    super(Request.Data.Type.GetSourceFilterList, Data.builder().sourceName(sourceName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/GetSourceFilterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/GetSourceFilterRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceFilterRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class GetSourceFilterRequest extends FilterRequest<GetSourceFilterRequest.Data> {
   @Builder
   private GetSourceFilterRequest(String sourceName, String filterName) {
-    super(Request.Data.Type.GetSourceFilter);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName).build();
+    super(Request.Data.Type.GetSourceFilter, Data.builder().sourceName(sourceName).filterName(filterName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/RemoveSourceFilterRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/RemoveSourceFilterRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSourceFilterRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class RemoveSourceFilterRequest extends FilterRequest<RemoveSourceFilterRequest.Data> {
   @Builder
   private RemoveSourceFilterRequest(String sourceName, String filterName) {
-    super(Request.Data.Type.RemoveSourceFilter);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName).build();
+    super(Request.Data.Type.RemoveSourceFilter, Data.builder().sourceName(sourceName).filterName(filterName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterEnabledRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterEnabledRequest.java
@@ -9,17 +9,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterEnabledRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class SetSourceFilterEnabledRequest extends FilterRequest<SetSourceFilterEnabledRequest.Data> {
   @Builder
   private SetSourceFilterEnabledRequest(String sourceName, String filterName,
-      Boolean filterEnabled) {
-    super(Request.Data.Type.SetSourceFilterEnabled);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName)
-        .filterEnabled(filterEnabled).build();
+          Boolean filterEnabled) {
+    super(Request.Data.Type.SetSourceFilterEnabled, Data.builder().sourceName(sourceName).filterName(filterName)
+                                                        .filterEnabled(filterEnabled).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterIndexRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterIndexRequest.java
@@ -9,16 +9,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterIndexRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class SetSourceFilterIndexRequest extends FilterRequest<SetSourceFilterIndexRequest.Data> {
   @Builder
   private SetSourceFilterIndexRequest(String sourceName, String filterName, Integer filterIndex) {
-    super(Request.Data.Type.SetSourceFilterIndex);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName)
-        .filterIndex(filterIndex).build();
+    super(Request.Data.Type.SetSourceFilterIndex, Data.builder().sourceName(sourceName).filterName(filterName)
+                                                      .filterIndex(filterIndex).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/filters/SetSourceFilterSettingsRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.filters;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,17 +11,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterSettingsRequest extends FilterRequest {
-
-  private final Data requestData;
-
+public class SetSourceFilterSettingsRequest extends FilterRequest<SetSourceFilterSettingsRequest.Data> {
   @Builder
   private SetSourceFilterSettingsRequest(String sourceName, String filterName,
-      JsonObject filterSettings) {
-    super(Request.Data.Type.SetSourceFilterSettings);
-
-    this.requestData = Data.builder().sourceName(sourceName).filterName(filterName)
-        .filterSettings(filterSettings).build();
+          JsonObject filterSettings) {
+    super(Request.Data.Type.SetSourceFilterSettings, Data.builder().sourceName(sourceName).filterName(filterName)
+                                                         .filterSettings(filterSettings).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/BroadcastCustomEventRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/BroadcastCustomEventRequest.java
@@ -1,23 +1,18 @@
 package io.obswebsocket.community.client.message.request.general;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class BroadcastCustomEventRequest extends Request {
-
-  @NonNull
-  private final JsonObject requestData;
+public class BroadcastCustomEventRequest extends Request<JsonObject> {
 
   @Builder
   private BroadcastCustomEventRequest(JsonObject requestData) {
-    super(Data.Type.BroadcastCustomEvent);
-
-    this.requestData = requestData;
+    super(Data.Type.BroadcastCustomEvent, requestData);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/CloseProjectorRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/CloseProjectorRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CloseProjectorRequest extends Request {
-
-  private final Data requestData;
-
+public class CloseProjectorRequest extends Request<CloseProjectorRequest.Data> {
   @Builder
   private CloseProjectorRequest(String projectorName) {
-    super(Request.Data.Type.CloseProjector);
-
-    this.requestData = Data.builder().projectorName(projectorName).build();
+    super(Request.Data.Type.CloseProjector, Data.builder().projectorName(projectorName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetHotkeyListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetHotkeyListRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetHotkeyListRequest extends Request {
+public class GetHotkeyListRequest extends Request<Void> {
 
   @Builder
   private GetHotkeyListRequest() {
-    super(Data.Type.GetHotkeyList);
+    super(Data.Type.GetHotkeyList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetProjectorListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetProjectorListRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProjectorListRequest extends Request {
+public class GetProjectorListRequest extends Request<Void> {
 
   @Builder
   private GetProjectorListRequest() {
-    super(Data.Type.GetProjectorList);
+    super(Data.Type.GetProjectorList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetStatsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetStatsRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStatsRequest extends Request {
+public class GetStatsRequest extends Request<Void> {
 
   @Builder
   private GetStatsRequest() {
-    super(Data.Type.GetStats);
+    super(Data.Type.GetStats, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetStudioModeEnabledRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetStudioModeEnabledRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStudioModeEnabledRequest extends Request {
+public class GetStudioModeEnabledRequest extends Request<Void> {
 
   @Builder
   private GetStudioModeEnabledRequest() {
-    super(Data.Type.GetStudioModeEnabled);
+    super(Data.Type.GetStudioModeEnabled, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetSystemStatsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetSystemStatsRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSystemStatsRequest extends Request {
+public class GetSystemStatsRequest extends Request<Void> {
 
   @Builder
   private GetSystemStatsRequest() {
-    super(Data.Type.GetSystemStats);
+    super(Data.Type.GetSystemStats, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetVersionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/GetVersionRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetVersionRequest extends Request {
-
+public class GetVersionRequest extends Request<Void> {
   @Builder
   private GetVersionRequest() {
-    super(Data.Type.GetVersion);
+    super(Data.Type.GetVersion, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/OpenProjectorRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/OpenProjectorRequest.java
@@ -9,18 +9,13 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class OpenProjectorRequest extends Request {
-
-  private final Data requestData;
-
+public class OpenProjectorRequest extends Request<OpenProjectorRequest.Data> {
   @Builder
   private OpenProjectorRequest(Projector.Type projectorType, Integer projectorMonitor,
-      String projectorGeometry, String sourceName) {
-    super(Request.Data.Type.OpenProjector);
-
-    this.requestData = Data.builder().projectorType(projectorType)
-        .projectorMonitor(projectorMonitor).projectorGeometry(projectorGeometry)
-        .sourceName(sourceName).build();
+          String projectorGeometry, String sourceName) {
+    super(Request.Data.Type.OpenProjector, Data.builder().projectorType(projectorType)
+                                               .projectorMonitor(projectorMonitor).projectorGeometry(projectorGeometry)
+                                               .sourceName(sourceName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/SetStudioModeEnabledRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/SetStudioModeEnabledRequest.java
@@ -8,22 +8,16 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetStudioModeEnabledRequest extends Request {
-
-  private final Data requestData;
-
+public class SetStudioModeEnabledRequest extends Request<SetStudioModeEnabledRequest.Data> {
   @Builder
   private SetStudioModeEnabledRequest(Boolean studioModeEnabled) {
-    super(Request.Data.Type.SetStudioModeEnabled);
-
-    this.requestData = Data.builder().studioModeEnabled(studioModeEnabled).build();
+    super(Request.Data.Type.SetStudioModeEnabled, Data.builder().studioModeEnabled(studioModeEnabled).build());
   }
 
   @Getter
   @ToString
   @Builder
   static class Data {
-
     @NonNull
     private final Boolean studioModeEnabled;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/SleepRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/SleepRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SleepRequest extends Request {
-
-  private final Data requestData;
-
+public class SleepRequest extends Request<SleepRequest.Data> {
   @Builder
   private SleepRequest(Long sleepMillis) {
-    super(Request.Data.Type.Sleep);
-
-    this.requestData = Data.builder().sleepMillis(sleepMillis).build();
+    super(Request.Data.Type.Sleep, Data.builder().sleepMillis(sleepMillis).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/TriggerHotkeyByKeySequenceRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/TriggerHotkeyByKeySequenceRequest.java
@@ -7,15 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerHotkeyByKeySequenceRequest extends Request {
-
-  private final Data requestData;
-
+public class TriggerHotkeyByKeySequenceRequest extends Request<TriggerHotkeyByKeySequenceRequest.Data> {
   @Builder
   private TriggerHotkeyByKeySequenceRequest(String keyId, KeyModifiers keyModifiers) {
-    super(Request.Data.Type.TriggerHotkeyByName);
-
-    this.requestData = Data.builder().keyId(keyId).keyModifiers(keyModifiers).build();
+    super(Request.Data.Type.TriggerHotkeyByName, Data.builder().keyId(keyId).keyModifiers(keyModifiers).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/general/TriggerHotkeyByNameRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/general/TriggerHotkeyByNameRequest.java
@@ -8,22 +8,16 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerHotkeyByNameRequest extends Request {
-
-  private final Data requestData;
-
+public class TriggerHotkeyByNameRequest extends Request<TriggerHotkeyByNameRequest.Data> {
   @Builder
   private TriggerHotkeyByNameRequest(String hotkeyName) {
-    super(Request.Data.Type.TriggerHotkeyByName);
-
-    this.requestData = Data.builder().hotkeyName(hotkeyName).build();
+    super(Request.Data.Type.TriggerHotkeyByName, Data.builder().hotkeyName(hotkeyName).build());
   }
 
   @Getter
   @ToString
   @Builder
   static class Data {
-
     @NonNull
     private final String hotkeyName;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/CreateInputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/CreateInputRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.inputs;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,17 +11,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateInputRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class CreateInputRequest extends InputRequest<CreateInputRequest.Data> {
   @Builder
   private CreateInputRequest(String inputName, String inputKind, String sceneName,
-      JsonObject inputSettings, Boolean sceneItemEnabled) {
-    super(Request.Data.Type.CreateInput);
-
-    this.requestData = Data.builder().inputName(inputName).inputKind(inputKind).sceneName(sceneName)
-        .inputSettings(inputSettings).sceneItemEnabled(sceneItemEnabled).build();
+          JsonObject inputSettings, Boolean sceneItemEnabled) {
+    super(Request.Data.Type.CreateInput, Data.builder().inputName(inputName).inputKind(inputKind).sceneName(sceneName)
+                                             .inputSettings(inputSettings).sceneItemEnabled(sceneItemEnabled).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioMonitorTypeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioMonitorTypeRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioMonitorTypeRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputAudioMonitorTypeRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private GetInputAudioMonitorTypeRequest(String inputName) {
-    super(Request.Data.Type.GetInputAudioMonitorType);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputAudioMonitorType, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioSyncOffsetRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioSyncOffsetRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioSyncOffsetRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputAudioSyncOffsetRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private GetInputAudioSyncOffsetRequest(String inputName) {
-    super(Request.Data.Type.GetInputAudioSyncOffset);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputAudioSyncOffset, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioTracksRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputAudioTracksRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioTracksRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputAudioTracksRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private GetInputAudioTracksRequest(String inputName) {
-    super(Request.Data.Type.GetInputAudioTracks);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputAudioTracks, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputDefaultSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputDefaultSettingsRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputDefaultSettingsRequest extends Request {
-
-  private final Data requestData;
-
+public class GetInputDefaultSettingsRequest extends Request<GetInputDefaultSettingsRequest.Data> {
   @Builder
   private GetInputDefaultSettingsRequest(String inputKind) {
-    super(Request.Data.Type.GetInputDefaultSettings);
-
-    this.requestData = Data.builder().inputKind(inputKind).build();
+    super(Request.Data.Type.GetInputDefaultSettings, Data.builder().inputKind(inputKind).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputKindListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputKindListRequest.java
@@ -7,22 +7,16 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputKindListRequest extends Request {
-
-  private final Data requestData;
-
+public class GetInputKindListRequest extends Request<GetInputKindListRequest.Data> {
   @Builder
   private GetInputKindListRequest(Boolean unversioned) {
-    super(Request.Data.Type.GetInputKindList);
-
-    this.requestData = Data.builder().unversioned(unversioned).build();
+    super(Request.Data.Type.GetInputKindList, Data.builder().unversioned(unversioned).build());
   }
 
   @Getter
   @ToString
   @Builder
   static class Data {
-
     private final Boolean unversioned;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputListRequest.java
@@ -7,15 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputListRequest extends Request {
-
-  private final Data requestData;
-
+public class GetInputListRequest extends Request<GetInputListRequest.Data> {
   @Builder
   private GetInputListRequest(String inputKind) {
-    super(Request.Data.Type.GetInputList);
-
-    this.requestData = Data.builder().inputKind(inputKind).build();
+    super(Request.Data.Type.GetInputList, Data.builder().inputKind(inputKind).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputMuteRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputMuteRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputMuteRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputMuteRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private GetInputMuteRequest(String inputName) {
-    super(Request.Data.Type.GetInputMute);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputMute, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputPropertiesListPropertyItemsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputPropertiesListPropertyItemsRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputPropertiesListPropertyItemsRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputPropertiesListPropertyItemsRequest extends InputRequest<GetInputPropertiesListPropertyItemsRequest.Data> {
   @Builder
   private GetInputPropertiesListPropertyItemsRequest(String inputName, String propertyName) {
-    super(Request.Data.Type.GetInputPropertiesListPropertyItems);
-
-    this.requestData = Data.builder().inputName(inputName).propertyName(propertyName).build();
+    super(Request.Data.Type.GetInputPropertiesListPropertyItems, Data.builder().inputName(inputName).propertyName(propertyName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputSettingsRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputSettingsRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class GetInputSettingsRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private GetInputSettingsRequest(String inputName) {
-    super(Request.Data.Type.GetInputSettings);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputSettings, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputVolumeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetInputVolumeRequest.java
@@ -7,14 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputVolumeRequest extends InputRequest {
-
-  private final Data requestData;
+public class GetInputVolumeRequest extends InputRequest<InputRequest.Data> {
 
   @Builder
   private GetInputVolumeRequest(String inputName) {
-    super(Request.Data.Type.GetInputVolume);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetInputVolume, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetSpecialInputNamesRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/GetSpecialInputNamesRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSpecialInputNamesRequest extends Request {
+public class GetSpecialInputNamesRequest extends Request<Void> {
 
   @Builder
   private GetSpecialInputNamesRequest() {
-    super(Data.Type.GetSpecialInputNames);
+    super(Data.Type.GetSpecialInputNames, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/InputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/InputRequest.java
@@ -8,10 +8,9 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class InputRequest extends Request {
-
-  InputRequest(Request.Data.Type type) {
-    super(type);
+abstract class InputRequest<T extends InputRequest.Data> extends Request<T> {
+  InputRequest(Request.Data.Type type, T data) {
+    super(type, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/PressInputPropertiesButtonRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/PressInputPropertiesButtonRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class PressInputPropertiesButtonRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class PressInputPropertiesButtonRequest extends InputRequest<PressInputPropertiesButtonRequest.Data> {
   @Builder
   private PressInputPropertiesButtonRequest(String inputName, String propertyName) {
-    super(Request.Data.Type.PressInputPropertiesButton);
-
-    this.requestData = Data.builder().inputName(inputName).propertyName(propertyName).build();
+    super(Request.Data.Type.PressInputPropertiesButton, Data.builder().inputName(inputName).propertyName(propertyName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/RemoveInputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/RemoveInputRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveInputRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class RemoveInputRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private RemoveInputRequest(String inputName) {
-    super(Request.Data.Type.RemoveInput);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.RemoveInput, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputAudioMonitorTypeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputAudioMonitorTypeRequest.java
@@ -10,15 +10,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputAudioMonitorTypeRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class SetInputAudioMonitorTypeRequest extends InputRequest<SetInputAudioMonitorTypeRequest.Data> {
   @Builder
   private SetInputAudioMonitorTypeRequest(String inputName, Input.MonitorType monitorType) {
-    super(Request.Data.Type.SetInputAudioMonitorType);
-
-    this.requestData = Data.builder().inputName(inputName).monitorType(monitorType).build();
+    super(Request.Data.Type.SetInputAudioMonitorType, Data.builder().inputName(inputName).monitorType(monitorType).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputAudioSyncOffsetRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputAudioSyncOffsetRequest.java
@@ -9,16 +9,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputAudioSyncOffsetRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class SetInputAudioSyncOffsetRequest extends InputRequest<SetInputAudioSyncOffsetRequest.Data> {
   @Builder
   private SetInputAudioSyncOffsetRequest(String inputName, Long inputAudioSyncOffset) {
-    super(Request.Data.Type.SetInputAudioSyncOffset);
-
-    this.requestData = Data.builder().inputName(inputName)
-        .inputAudioSyncOffset(inputAudioSyncOffset).build();
+    super(Request.Data.Type.SetInputAudioSyncOffset, Data.builder().inputName(inputName)
+                                                         .inputAudioSyncOffset(inputAudioSyncOffset).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputMuteRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputMuteRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputMuteRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class SetInputMuteRequest extends InputRequest<SetInputMuteRequest.Data> {
   @Builder
   private SetInputMuteRequest(String inputName, Boolean inputMuted) {
-    super(Request.Data.Type.SetInputMute);
-
-    this.requestData = Data.builder().inputName(inputName).inputMuted(inputMuted).build();
+    super(Request.Data.Type.SetInputMute, Data.builder().inputName(inputName).inputMuted(inputMuted).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputNameRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputNameRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputNameRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class SetInputNameRequest extends InputRequest<SetInputNameRequest.Data> {
   @Builder
   private SetInputNameRequest(String inputName, String newInputName) {
-    super(Request.Data.Type.SetInputName);
-
-    this.requestData = Data.builder().inputName(inputName).newInputName(newInputName).build();
+    super(Request.Data.Type.SetInputName, Data.builder().inputName(inputName).newInputName(newInputName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputSettingsRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.inputs;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,16 +11,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputSettingsRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class SetInputSettingsRequest extends InputRequest<SetInputSettingsRequest.Data> {
   @Builder
   private SetInputSettingsRequest(String inputName, JsonObject inputSettings, Boolean overlay) {
-    super(Request.Data.Type.SetInputSettings);
-
-    this.requestData = Data.builder().inputName(inputName).inputSettings(inputSettings)
-        .overlay(overlay).build();
+    super(Request.Data.Type.SetInputSettings, Data.builder().inputName(inputName).inputSettings(inputSettings)
+                                                  .overlay(overlay).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputVolumeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/SetInputVolumeRequest.java
@@ -8,16 +8,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputVolumeRequest extends InputRequest {
-
-  private final Data requestData;
+public class SetInputVolumeRequest extends InputRequest<SetInputVolumeRequest.Data> {
 
   @Builder
   private SetInputVolumeRequest(String inputName, Float inputVolumeDb, Float inputVolumeMul) {
-    super(Request.Data.Type.SetInputVolume);
-
-    this.requestData = Data.builder().inputName(inputName).inputVolumeDb(inputVolumeDb)
-        .inputVolumeMul(inputVolumeMul).build();
+    super(Request.Data.Type.SetInputVolume, Data.builder().inputName(inputName).inputVolumeDb(inputVolumeDb)
+                                                .inputVolumeMul(inputVolumeMul).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/ToggleInputMuteRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/inputs/ToggleInputMuteRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleInputMuteRequest extends InputRequest {
-
-  private final Data requestData;
-
+public class ToggleInputMuteRequest extends InputRequest<InputRequest.Data> {
   @Builder
   private ToggleInputMuteRequest(String inputName) {
-    super(Request.Data.Type.ToggleInputMute);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.ToggleInputMute, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/GetMediaInputStatusRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/GetMediaInputStatusRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetMediaInputStatusRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class GetMediaInputStatusRequest extends MediaInputRequest<MediaInputRequest.Data> {
   @Builder
   private GetMediaInputStatusRequest(String inputName) {
-    super(Request.Data.Type.GetMediaInputStatus);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.GetMediaInputStatus, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/MediaInputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/MediaInputRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class MediaInputRequest extends Request {
+abstract class MediaInputRequest<T extends MediaInputRequest.Data> extends Request<T> {
 
-  MediaInputRequest(Request.Data.Type type) {
-    super(type);
+  MediaInputRequest(Request.Data.Type type, T data) {
+    super(type, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/NextMediaInputPlaylistItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/NextMediaInputPlaylistItemRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class NextMediaInputPlaylistItemRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class NextMediaInputPlaylistItemRequest extends MediaInputRequest<MediaInputRequest.Data> {
   @Builder
   private NextMediaInputPlaylistItemRequest(String inputName) {
-    super(Request.Data.Type.NextMediaInputPlaylistItem);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.NextMediaInputPlaylistItem, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/OffsetMediaInputTimecodeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/OffsetMediaInputTimecodeRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class OffsetMediaInputTimecodeRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class OffsetMediaInputTimecodeRequest extends MediaInputRequest<OffsetMediaInputTimecodeRequest.Data> {
   @Builder
   private OffsetMediaInputTimecodeRequest(String inputName, Long timestampOffset) {
-    super(Request.Data.Type.OffsetMediaInputTimecode);
-
-    this.requestData = Data.builder().inputName(inputName).timestampOffset(timestampOffset).build();
+    super(Request.Data.Type.OffsetMediaInputTimecode, Data.builder().inputName(inputName).timestampOffset(timestampOffset).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/PreviousMediaInputPlaylistItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/PreviousMediaInputPlaylistItemRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class PreviousMediaInputPlaylistItemRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class PreviousMediaInputPlaylistItemRequest extends MediaInputRequest<MediaInputRequest.Data> {
   @Builder
   private PreviousMediaInputPlaylistItemRequest(String inputName) {
-    super(Request.Data.Type.PreviousMediaInputPlaylistItem);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.PreviousMediaInputPlaylistItem, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/RestartMediaInputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/RestartMediaInputRequest.java
@@ -7,14 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RestartMediaInputRequest extends MediaInputRequest {
-
-  private final Data requestData;
+public class RestartMediaInputRequest extends MediaInputRequest<MediaInputRequest.Data> {
 
   @Builder
   private RestartMediaInputRequest(String inputName) {
-    super(Request.Data.Type.RestartMediaInput);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.RestartMediaInput, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/SetMediaInputPauseStateRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/SetMediaInputPauseStateRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetMediaInputPauseStateRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class SetMediaInputPauseStateRequest extends MediaInputRequest<SetMediaInputPauseStateRequest.Data> {
   @Builder
   private SetMediaInputPauseStateRequest(String inputName, Boolean pause) {
-    super(Request.Data.Type.SetMediaInputPauseState);
-
-    this.requestData = Data.builder().inputName(inputName).pause(pause).build();
+    super(Request.Data.Type.SetMediaInputPauseState, Data.builder().inputName(inputName).pause(pause).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/SetMediaInputTimecodeRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/SetMediaInputTimecodeRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetMediaInputTimecodeRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class SetMediaInputTimecodeRequest extends MediaInputRequest<SetMediaInputTimecodeRequest.Data> {
   @Builder
   private SetMediaInputTimecodeRequest(String inputName, Long mediaTimestamp) {
-    super(Request.Data.Type.SetMediaInputTimecode);
-
-    this.requestData = Data.builder().inputName(inputName).mediaTimestamp(mediaTimestamp).build();
+    super(Request.Data.Type.SetMediaInputTimecode, Data.builder().inputName(inputName).mediaTimestamp(mediaTimestamp).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/StopMediaInputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/mediainputs/StopMediaInputRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopMediaInputRequest extends MediaInputRequest {
-
-  private final Data requestData;
-
+public class StopMediaInputRequest extends MediaInputRequest<MediaInputRequest.Data> {
   @Builder
   private StopMediaInputRequest(String inputName) {
-    super(Request.Data.Type.StopMediaInput);
-
-    this.requestData = Data.builder().inputName(inputName).build();
+    super(Request.Data.Type.StopMediaInput, Data.builder().inputName(inputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetLastReplayBufferReplayRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetLastReplayBufferReplayRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetLastReplayBufferReplayRequest extends Request {
+public class GetLastReplayBufferReplayRequest extends Request<Void> {
 
   @Builder
   private GetLastReplayBufferReplayRequest() {
-    super(Data.Type.GetLastReplayBufferReplay);
+    super(Data.Type.GetLastReplayBufferReplay, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetOutputListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetOutputListRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetOutputListRequest extends Request {
+public class GetOutputListRequest extends Request<Void> {
 
   @Builder
   private GetOutputListRequest() {
-    super(Data.Type.GetOutputList);
+    super(Data.Type.GetOutputList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetReplayBufferStatusRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/GetReplayBufferStatusRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetReplayBufferStatusRequest extends Request {
-
+public class GetReplayBufferStatusRequest extends Request<Void> {
   @Builder
   private GetReplayBufferStatusRequest() {
-    super(Data.Type.GetReplayBufferStatus);
+    super(Data.Type.GetReplayBufferStatus, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/OutputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/OutputRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class OutputRequest extends Request {
+abstract class OutputRequest<T extends OutputRequest.Data> extends Request<T> {
 
-  OutputRequest(Request.Data.Type type) {
-    super(type);
+  OutputRequest(Request.Data.Type type, T data) {
+    super(type, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/SaveReplayBufferRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/SaveReplayBufferRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SaveReplayBufferRequest extends Request {
+public class SaveReplayBufferRequest extends Request<Void> {
 
   @Builder
   private SaveReplayBufferRequest() {
-    super(Data.Type.SaveReplayBuffer);
+    super(Data.Type.SaveReplayBuffer, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StartOutputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StartOutputRequest.java
@@ -7,14 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartOutputRequest extends OutputRequest {
-
-  private final Data requestData;
+public class StartOutputRequest extends OutputRequest<OutputRequest.Data> {
 
   @Builder
   private StartOutputRequest(String outputName) {
-    super(Request.Data.Type.StartOutput);
-
-    this.requestData = Data.builder().outputName(outputName).build();
+    super(Request.Data.Type.StartOutput, Data.builder().outputName(outputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StartReplayBufferRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StartReplayBufferRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartReplayBufferRequest extends Request {
-
+public class StartReplayBufferRequest extends Request<Void> {
   @Builder
   private StartReplayBufferRequest() {
-    super(Data.Type.StartReplayBuffer);
+    super(Data.Type.StartReplayBuffer, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StopOutputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StopOutputRequest.java
@@ -7,14 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopOutputRequest extends OutputRequest {
-
-  private final Data requestData;
+public class StopOutputRequest extends OutputRequest<OutputRequest.Data> {
 
   @Builder
   private StopOutputRequest(String outputName) {
-    super(Request.Data.Type.StopOutput);
-
-    this.requestData = Data.builder().outputName(outputName).build();
+    super(Request.Data.Type.StopOutput, Data.builder().outputName(outputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StopReplayBufferRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/StopReplayBufferRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopReplayBufferRequest extends Request {
-
+public class StopReplayBufferRequest extends Request<Void> {
   @Builder
   private StopReplayBufferRequest() {
-    super(Data.Type.StopReplayBuffer);
+    super(Data.Type.StopReplayBuffer, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/ToggleOutputRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/ToggleOutputRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleOutputRequest extends OutputRequest {
-
-  private final Data requestData;
-
+public class ToggleOutputRequest extends OutputRequest<OutputRequest.Data> {
   @Builder
   private ToggleOutputRequest(String outputName) {
-    super(Request.Data.Type.ToggleOutput);
-
-    this.requestData = Data.builder().outputName(outputName).build();
+    super(Request.Data.Type.ToggleOutput, Data.builder().outputName(outputName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/ToggleReplayBufferRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/outputs/ToggleReplayBufferRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleReplayBufferRequest extends Request {
+public class ToggleReplayBufferRequest extends Request<Void> {
 
   @Builder
   private ToggleReplayBufferRequest() {
-    super(Data.Type.ToggleReplayBuffer);
+    super(Data.Type.ToggleReplayBuffer, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordDirectoryRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordDirectoryRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordDirectoryRequest extends Request {
+public class GetRecordDirectoryRequest extends Request<Void> {
 
   @Builder
   private GetRecordDirectoryRequest() {
-    super(Data.Type.GetRecordDirectory);
+    super(Data.Type.GetRecordDirectory, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordFilenameFormattingRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordFilenameFormattingRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordFilenameFormattingRequest extends Request {
+public class GetRecordFilenameFormattingRequest extends Request<Void> {
 
   @Builder
   private GetRecordFilenameFormattingRequest() {
-    super(Data.Type.GetRecordFilenameFormatting);
+    super(Data.Type.GetRecordFilenameFormatting, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordStatusRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/GetRecordStatusRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordStatusRequest extends Request {
+public class GetRecordStatusRequest extends Request<Void> {
 
   @Builder
   private GetRecordStatusRequest() {
-    super(Data.Type.GetRecordStatus);
+    super(Data.Type.GetRecordStatus, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/PauseRecordRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/PauseRecordRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class PauseRecordRequest extends Request {
+public class PauseRecordRequest extends Request<Void> {
 
   @Builder
   private PauseRecordRequest() {
-    super(Data.Type.PauseRecord);
+    super(Data.Type.PauseRecord, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/ResumeRecordRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/ResumeRecordRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ResumeRecordRequest extends Request {
+public class ResumeRecordRequest extends Request<Void> {
 
   @Builder
   private ResumeRecordRequest() {
-    super(Data.Type.ResumeRecord);
+    super(Data.Type.ResumeRecord, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/SetRecordDirectoryRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/SetRecordDirectoryRequest.java
@@ -8,16 +8,11 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetRecordDirectoryRequest extends Request {
-
-  private final Data requestData;
-
+public class SetRecordDirectoryRequest extends Request<SetRecordDirectoryRequest.Data> {
   @Builder
   private SetRecordDirectoryRequest(String recordDirectory, Boolean createIfNotExist) {
-    super(Request.Data.Type.SetRecordDirectory);
-
-    this.requestData = Data.builder().recordDirectory(recordDirectory)
-        .createIfNotExist(createIfNotExist).build();
+    super(Request.Data.Type.SetRecordDirectory, Data.builder().recordDirectory(recordDirectory)
+                                                    .createIfNotExist(createIfNotExist).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/SetRecordFilenameFormattingRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/SetRecordFilenameFormattingRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetRecordFilenameFormattingRequest extends Request {
-
-  private final Data requestData;
-
+public class SetRecordFilenameFormattingRequest extends Request<SetRecordFilenameFormattingRequest.Data> {
   @Builder
   private SetRecordFilenameFormattingRequest(String filenameFormatting) {
-    super(Request.Data.Type.SetRecordFilenameFormatting);
-
-    this.requestData = Data.builder().filenameFormatting(filenameFormatting).build();
+    super(Request.Data.Type.SetRecordFilenameFormatting, Data.builder().filenameFormatting(filenameFormatting).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/StartRecordRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/StartRecordRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartRecordRequest extends Request {
-
-  private final Data requestData;
-
+public class StartRecordRequest extends Request<StartRecordRequest.Data> {
   @Builder
   private StartRecordRequest(Boolean waitForResult) {
-    super(Request.Data.Type.StartRecord);
-
-    this.requestData = Data.builder().waitForResult(waitForResult).build();
+    super(Request.Data.Type.StartRecord, Data.builder().waitForResult(waitForResult).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/StopRecordRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/StopRecordRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopRecordRequest extends Request {
-
-  private final Data requestData;
-
+public class StopRecordRequest extends Request<StopRecordRequest.Data> {
   @Builder
   private StopRecordRequest(Boolean waitForResult) {
-    super(Request.Data.Type.StopRecord);
-
-    this.requestData = Data.builder().waitForResult(waitForResult).build();
+    super(Request.Data.Type.StopRecord, Data.builder().waitForResult(waitForResult).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/ToggleRecordPauseRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/ToggleRecordPauseRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleRecordPauseRequest extends Request {
-
+public class ToggleRecordPauseRequest extends Request<Void> {
   @Builder
   private ToggleRecordPauseRequest() {
-    super(Data.Type.ToggleRecordPause);
+    super(Data.Type.ToggleRecordPause, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/record/ToggleRecordRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/record/ToggleRecordRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleRecordRequest extends Request {
+public class ToggleRecordRequest extends Request<Void> {
 
   @Builder
   private ToggleRecordRequest() {
-    super(Data.Type.ToggleRecord);
+    super(Data.Type.ToggleRecord, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/CreateSceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/CreateSceneItemRequest.java
@@ -9,16 +9,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneItemRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class CreateSceneItemRequest extends SceneItemRequest<CreateSceneItemRequest.Data> {
   @Builder
   private CreateSceneItemRequest(String sceneName, String sourceName, Boolean sceneItemEnabled) {
-    super(Request.Data.Type.CreateSceneItem);
-
-    this.requestData = Data.builder().sceneName(sceneName).sourceName(sourceName)
-        .sceneItemEnabled(sceneItemEnabled).build();
+    super(Request.Data.Type.CreateSceneItem, Data.builder().sceneName(sceneName).sourceName(sourceName)
+                                                 .sceneItemEnabled(sceneItemEnabled).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/DuplicateSceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/DuplicateSceneItemRequest.java
@@ -9,23 +9,18 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class DuplicateSceneItemRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class DuplicateSceneItemRequest extends SceneItemRequest<DuplicateSceneItemRequest.Data> {
   @Builder
   private DuplicateSceneItemRequest(String sceneName, Integer sceneItemId,
-      String destinationSceneName) {
-    super(Request.Data.Type.DuplicateSceneItem);
-
-    this.requestData = Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-        .destinationSceneName(destinationSceneName).build();
+          String destinationSceneName) {
+    super(Request.Data.Type.DuplicateSceneItem, Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                                    .destinationSceneName(destinationSceneName).build());
   }
 
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  static class Data extends DataWithId {
+  static class Data extends SceneItemRequest.DataWithId {
 
     @NonNull
     private final String destinationSceneName;

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemColorRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemColorRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemColorRequest extends SceneItemRequest {
-
-  private final DataWithId requestData;
-
+public class GetSceneItemColorRequest extends SceneItemRequest<SceneItemRequest.DataWithId> {
   @Builder
   private GetSceneItemColorRequest(String sceneName, Integer sceneItemId) {
-    super(Request.Data.Type.GetSceneItemColor);
-
-    this.requestData = DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build();
+    super(Request.Data.Type.GetSceneItemColor, DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemEnabledRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemEnabledRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemEnabledRequest extends SceneItemRequest {
-
-  private final DataWithId requestData;
-
+public class GetSceneItemEnabledRequest extends SceneItemRequest<SceneItemRequest.DataWithId> {
   @Builder
   private GetSceneItemEnabledRequest(String sceneName, Integer sceneItemId) {
-    super(Request.Data.Type.GetSceneItemEnabled);
-
-    this.requestData = DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build();
+    super(Request.Data.Type.GetSceneItemEnabled, DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemListRequest.java
@@ -10,6 +10,6 @@ import lombok.ToString;
 public class GetSceneItemListRequest extends SceneItemRequest<SceneItemRequest.Data> {
   @Builder
   private GetSceneItemListRequest(String sceneName) {
-    super(Request.Data.Type.GetSceneItemList, Data.builder().sceneName(sceneName).build());
+    super(Request.Data.Type.GetSceneItemList, Data.dataBuilder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemListRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemListRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class GetSceneItemListRequest extends SceneItemRequest<SceneItemRequest.Data> {
   @Builder
   private GetSceneItemListRequest(String sceneName) {
-    super(Request.Data.Type.GetSceneItemList);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.GetSceneItemList, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemLockedRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/GetSceneItemLockedRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemLockedRequest extends SceneItemRequest {
-
-  private final DataWithId requestData;
-
+public class GetSceneItemLockedRequest extends SceneItemRequest<SceneItemRequest.DataWithId> {
   @Builder
   private GetSceneItemLockedRequest(String sceneName, Integer sceneItemId) {
-    super(Request.Data.Type.GetSceneItemLocked);
-
-    this.requestData = DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build();
+    super(Request.Data.Type.GetSceneItemLocked, DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/RemoveSceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/RemoveSceneItemRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneItemRequest extends SceneItemRequest {
-
-  private final DataWithId requestData;
-
+public class RemoveSceneItemRequest extends SceneItemRequest<SceneItemRequest.DataWithId> {
   @Builder
   private RemoveSceneItemRequest(String sceneName, Integer sceneItemId) {
-    super(Request.Data.Type.RemoveSceneItem);
-
-    this.requestData = DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build();
+    super(Request.Data.Type.RemoveSceneItem, DataWithId.builder().sceneName(sceneName).sceneItemId(sceneItemId).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
@@ -8,17 +8,15 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneItemRequest extends Request {
-
-  SceneItemRequest(Request.Data.Type type) {
-    super(type);
+abstract class SceneItemRequest<T extends SceneItemRequest.Data> extends Request<T> {
+  SceneItemRequest(Request.Data.Type type, T data) {
+    super(type, data);
   }
 
   @Getter
   @ToString
   @SuperBuilder
-  static class Data {
-
+  public static class Data {
     @NonNull
     private final String sceneName;
   }
@@ -26,8 +24,7 @@ abstract class SceneItemRequest extends Request {
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  static class DataWithId extends Data {
-
+  public static class DataWithId extends Data {
     @NonNull
     private final Integer sceneItemId;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
@@ -16,7 +16,7 @@ abstract class SceneItemRequest<T extends SceneItemRequest.Data> extends Request
 
   @Getter
   @ToString
-  @SuperBuilder
+  @SuperBuilder(builderMethodName = "dataBuilder")
   static class Data {
 
     @NonNull

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemRequest.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @ToString(callSuper = true)
 abstract class SceneItemRequest<T extends SceneItemRequest.Data> extends Request<T> {
+
   SceneItemRequest(Request.Data.Type type, T data) {
     super(type, data);
   }
@@ -16,7 +17,8 @@ abstract class SceneItemRequest<T extends SceneItemRequest.Data> extends Request
   @Getter
   @ToString
   @SuperBuilder
-  public static class Data {
+  static class Data {
+
     @NonNull
     private final String sceneName;
   }
@@ -24,7 +26,8 @@ abstract class SceneItemRequest<T extends SceneItemRequest.Data> extends Request
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  public static class DataWithId extends Data {
+  static class DataWithId extends Data {
+
     @NonNull
     private final Integer sceneItemId;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemEnabledRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemEnabledRequest.java
@@ -9,17 +9,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemEnabledRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class SetSceneItemEnabledRequest extends SceneItemRequest<SetSceneItemEnabledRequest.Data> {
   @Builder
   private SetSceneItemEnabledRequest(String sceneName, Integer sceneItemId,
-      Boolean sceneItemEnabled) {
-    super(Request.Data.Type.SetSceneItemEnabled);
-
-    this.requestData = Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-        .sceneItemEnabled(sceneItemEnabled).build();
+          Boolean sceneItemEnabled) {
+    super(Request.Data.Type.SetSceneItemEnabled, Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                                     .sceneItemEnabled(sceneItemEnabled).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemIndexRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemIndexRequest.java
@@ -9,22 +9,17 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemIndexRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class SetSceneItemIndexRequest extends SceneItemRequest<SetSceneItemIndexRequest.Data> {
   @Builder
   private SetSceneItemIndexRequest(String sceneName, Integer sceneItemId, Integer sceneItemIndex) {
-    super(Request.Data.Type.SetSceneItemIndex);
-
-    this.requestData = Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-        .sceneItemIndex(sceneItemIndex).build();
+    super(Request.Data.Type.SetSceneItemIndex, Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                                   .sceneItemIndex(sceneItemIndex).build());
   }
 
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  static class Data extends DataWithId {
+  static class Data extends SceneItemRequest.DataWithId {
 
     @NonNull
     private final Integer sceneItemIndex;

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemLockedRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sceneitems/SetSceneItemLockedRequest.java
@@ -9,23 +9,18 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemLockedRequest extends SceneItemRequest {
-
-  private final Data requestData;
-
+public class SetSceneItemLockedRequest extends SceneItemRequest<SetSceneItemLockedRequest.Data> {
   @Builder
   private SetSceneItemLockedRequest(String sceneName, Integer sceneItemId,
-      Boolean sceneItemLocked) {
-    super(Request.Data.Type.SetSceneItemLocked);
-
-    this.requestData = Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
-        .sceneItemLocked(sceneItemLocked).build();
+          Boolean sceneItemLocked) {
+    super(Request.Data.Type.SetSceneItemLocked, Data.builder().sceneName(sceneName).sceneItemId(sceneItemId)
+                                                    .sceneItemLocked(sceneItemLocked).build());
   }
 
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  static class Data extends DataWithId {
+  static class Data extends SceneItemRequest.DataWithId {
 
     @NonNull
     private final Boolean sceneItemLocked;

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/CreateSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/CreateSceneRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class CreateSceneRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private CreateSceneRequest(String sceneName) {
-    super(Request.Data.Type.CreateScene);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.CreateScene, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/DeleteSceneTransitionOverrideRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/DeleteSceneTransitionOverrideRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class DeleteSceneTransitionOverrideRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class DeleteSceneTransitionOverrideRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private DeleteSceneTransitionOverrideRequest(String sceneName) {
-    super(Request.Data.Type.DeleteSceneTransitionOverride);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.DeleteSceneTransitionOverride, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetCurrentPreviewSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetCurrentPreviewSceneRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetCurrentPreviewSceneRequest extends Request {
+public class GetCurrentPreviewSceneRequest extends Request<Void> {
 
   @Builder
   private GetCurrentPreviewSceneRequest() {
-    super(Data.Type.GetCurrentPreviewScene);
+    super(Data.Type.GetCurrentPreviewScene, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetCurrentProgramSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetCurrentProgramSceneRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetCurrentProgramSceneRequest extends Request {
+public class GetCurrentProgramSceneRequest extends Request<Void> {
 
   @Builder
   private GetCurrentProgramSceneRequest() {
-    super(Data.Type.GetCurrentProgramScene);
+    super(Data.Type.GetCurrentProgramScene, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetSceneListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetSceneListRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneListRequest extends Request {
+public class GetSceneListRequest extends Request<Void> {
 
   @Builder
   private GetSceneListRequest() {
-    super(Data.Type.GetSceneList);
+    super(Data.Type.GetSceneList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetSceneTransitionOverrideRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/GetSceneTransitionOverrideRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneTransitionOverrideRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class GetSceneTransitionOverrideRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private GetSceneTransitionOverrideRequest(String sceneName) {
-    super(Request.Data.Type.GetSceneTransitionOverride);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.GetSceneTransitionOverride, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/RemoveSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/RemoveSceneRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class RemoveSceneRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private RemoveSceneRequest(String sceneName) {
-    super(Request.Data.Type.RemoveScene);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.RemoveScene, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SceneRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SceneRequest extends Request {
+abstract class SceneRequest<T extends SceneRequest.Data> extends Request<T> {
 
-  SceneRequest(Request.Data.Type requestType) {
-    super(requestType);
+  SceneRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetCurrentPreviewSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetCurrentPreviewSceneRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentPreviewSceneRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class SetCurrentPreviewSceneRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private SetCurrentPreviewSceneRequest(String sceneName) {
-    super(Request.Data.Type.SetCurrentPreviewScene);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.SetCurrentPreviewScene, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetCurrentProgramSceneRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetCurrentProgramSceneRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentProgramSceneRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class SetCurrentProgramSceneRequest extends SceneRequest<SceneRequest.Data> {
   @Builder
   private SetCurrentProgramSceneRequest(String sceneName) {
-    super(Request.Data.Type.SetCurrentProgramScene);
-
-    this.requestData = Data.builder().sceneName(sceneName).build();
+    super(Request.Data.Type.SetCurrentProgramScene, Data.builder().sceneName(sceneName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneIndexRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneIndexRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneIndexRequest extends Request {
-
-  private final Data requestData;
-
+public class SetSceneIndexRequest extends Request<SetSceneIndexRequest.Data> {
   @Builder
   private SetSceneIndexRequest(String sceneName, Integer sceneIndex) {
-    super(Request.Data.Type.SetSceneIndex);
-
-    this.requestData = Data.builder().sceneName(sceneName).sceneIndex(sceneIndex).build();
+    super(Request.Data.Type.SetSceneIndex, Data.builder().sceneName(sceneName).sceneIndex(sceneIndex).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneNameRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneNameRequest.java
@@ -9,15 +9,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneNameRequest extends Request {
-
-  private final Data requestData;
-
+public class SetSceneNameRequest extends Request<SetSceneNameRequest.Data> {
   @Builder
   private SetSceneNameRequest(String sceneName, String newSceneName) {
-    super(Request.Data.Type.SetSceneName);
-
-    this.requestData = Data.builder().sceneName(sceneName).newSceneName(newSceneName).build();
+    super(Request.Data.Type.SetSceneName, Data.builder().sceneName(sceneName).newSceneName(newSceneName).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneTransitionOverrideRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/scenes/SetSceneTransitionOverrideRequest.java
@@ -8,17 +8,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneTransitionOverrideRequest extends SceneRequest {
-
-  private final Data requestData;
-
+public class SetSceneTransitionOverrideRequest extends SceneRequest<SetSceneTransitionOverrideRequest.Data> {
   @Builder
   private SetSceneTransitionOverrideRequest(String sceneName, String transitionName,
-      Integer transitionDuration) {
-    super(Request.Data.Type.SetSceneTransitionOverride);
-
-    this.requestData = Data.builder().sceneName(sceneName).transitionName(transitionName)
-        .transitionDuration(transitionDuration).build();
+          Integer transitionDuration) {
+    super(Request.Data.Type.SetSceneTransitionOverride, Data.builder().sceneName(sceneName).transitionName(transitionName)
+                                                            .transitionDuration(transitionDuration).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sources/GetSourceActiveRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sources/GetSourceActiveRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceActiveRequest extends SourceRequest {
-
-  private final Data requestData;
-
+public class GetSourceActiveRequest extends SourceRequest<SourceRequest.Data> {
   @Builder
   private GetSourceActiveRequest(String sourceName) {
-    super(Request.Data.Type.GetSourceActive);
-
-    this.requestData = Data.builder().sourceName(sourceName).build();
+    super(Request.Data.Type.GetSourceActive, Data.builder().sourceName(sourceName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sources/GetSourceScreenshotRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sources/GetSourceScreenshotRequest.java
@@ -7,24 +7,19 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceScreenshotRequest extends SourceScreenshotRequest {
-
-  private final Data requestData;
-
+public class GetSourceScreenshotRequest extends SourceScreenshotRequest<SourceScreenshotRequest.Data> {
   @Builder
   private GetSourceScreenshotRequest(String sourceName,
-      String imageFormat,
-      Integer imageWidth,
-      Integer imageHeight,
-      Integer imageCompressionQuality) {
-    super(Request.Data.Type.GetSourceScreenshot);
-
-    this.requestData = Data.builder()
-        .sourceName(sourceName)
-        .imageFormat(imageFormat)
-        .imageWidth(imageWidth)
-        .imageHeight(imageHeight)
-        .imageCompressionQuality(imageCompressionQuality)
-        .build();
+          String imageFormat,
+          Integer imageWidth,
+          Integer imageHeight,
+          Integer imageCompressionQuality) {
+    super(Request.Data.Type.GetSourceScreenshot, Data.builder()
+                                                     .sourceName(sourceName)
+                                                     .imageFormat(imageFormat)
+                                                     .imageWidth(imageWidth)
+                                                     .imageHeight(imageHeight)
+                                                     .imageCompressionQuality(imageCompressionQuality)
+                                                     .build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SaveSourceScreenshotRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SaveSourceScreenshotRequest.java
@@ -9,18 +9,13 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SaveSourceScreenshotRequest extends SourceScreenshotRequest {
-
-  private final Data requestData;
-
+public class SaveSourceScreenshotRequest extends SourceScreenshotRequest<SaveSourceScreenshotRequest.Data> {
   @Builder
   private SaveSourceScreenshotRequest(String sourceName, String imageFilePath, String imageFormat,
-      Integer imageWidth, Integer imageHeight, Integer imageCompressionQuality) {
-    super(Request.Data.Type.SaveSourceScreenshot);
-
-    this.requestData = Data.builder().sourceName(sourceName).imageFilePath(imageFilePath)
-        .imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight)
-        .imageCompressionQuality(imageCompressionQuality).build();
+          Integer imageWidth, Integer imageHeight, Integer imageCompressionQuality) {
+    super(Request.Data.Type.SaveSourceScreenshot, Data.builder().sourceName(sourceName).imageFilePath(imageFilePath)
+                                                      .imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight)
+                                                      .imageCompressionQuality(imageCompressionQuality).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SourceRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SourceRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SourceRequest extends Request {
+abstract class SourceRequest<T extends SourceRequest.Data> extends Request<T> {
 
-  SourceRequest(Request.Data.Type requestType) {
-    super(requestType);
+  SourceRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SourceScreenshotRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/sources/SourceScreenshotRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class SourceScreenshotRequest extends SourceRequest {
+abstract class SourceScreenshotRequest<T extends SourceScreenshotRequest.Data> extends SourceRequest<T> {
 
-  SourceScreenshotRequest(Request.Data.Type requestType) {
-    super(requestType);
+  SourceScreenshotRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/GetStreamServiceSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/GetStreamServiceSettingsRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStreamServiceSettingsRequest extends Request {
+public class GetStreamServiceSettingsRequest extends Request<Void> {
 
   @Builder
   private GetStreamServiceSettingsRequest() {
-    super(Data.Type.GetStreamServiceSettings);
+    super(Data.Type.GetStreamServiceSettings, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/GetStreamStatusRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/GetStreamStatusRequest.java
@@ -7,10 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStreamStatusRequest extends Request {
-
+public class GetStreamStatusRequest extends Request<Void> {
   @Builder
   private GetStreamStatusRequest() {
-    super(Data.Type.GetStreamStatus);
+    super(Data.Type.GetStreamStatus, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/SendStreamCaptionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/SendStreamCaptionRequest.java
@@ -8,22 +8,16 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SendStreamCaptionRequest extends Request {
-
-  private final Data requestData;
-
+public class SendStreamCaptionRequest extends Request<SendStreamCaptionRequest.Data> {
   @Builder
   private SendStreamCaptionRequest(String captionText) {
-    super(Request.Data.Type.SendStreamCaption);
-
-    this.requestData = Data.builder().captionText(captionText).build();
+    super(Request.Data.Type.SendStreamCaption, Data.builder().captionText(captionText).build());
   }
 
   @Getter
   @ToString
   @Builder
   static class Data {
-
     @NonNull
     private final String captionText;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/SetStreamServiceSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/SetStreamServiceSettingsRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.stream;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,16 +10,11 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetStreamServiceSettingsRequest extends Request {
-
-  private final Data requestData;
-
+public class SetStreamServiceSettingsRequest extends Request<SetStreamServiceSettingsRequest.Data> {
   @Builder
   private SetStreamServiceSettingsRequest(String streamServiceType, JsonObject serviceSettings) {
-    super(Request.Data.Type.SetStreamServiceSettings);
-
-    this.requestData = Data.builder().streamServiceType(streamServiceType)
-        .serviceSettings(serviceSettings).build();
+    super(Request.Data.Type.SetStreamServiceSettings, Data.builder().streamServiceType(streamServiceType)
+                                                          .serviceSettings(serviceSettings).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/StartStreamRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/StartStreamRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartStreamRequest extends Request {
+public class StartStreamRequest extends Request<Void> {
 
   @Builder
   private StartStreamRequest() {
-    super(Data.Type.StartStream);
+    super(Data.Type.StartStream, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/StopStreamRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/StopStreamRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopStreamRequest extends Request {
+public class StopStreamRequest extends Request<Void> {
 
   @Builder
   private StopStreamRequest() {
-    super(Data.Type.StopStream);
+    super(Data.Type.StopStream, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/stream/ToggleStreamRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/stream/ToggleStreamRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleStreamRequest extends Request {
+public class ToggleStreamRequest extends Request<Void> {
 
   @Builder
   private ToggleStreamRequest() {
-    super(Data.Type.ToggleStream);
+    super(Data.Type.ToggleStream, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetCurrentTransitionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetCurrentTransitionRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetCurrentTransitionRequest extends Request {
+public class GetCurrentTransitionRequest extends Request<Void> {
 
   @Builder
   private GetCurrentTransitionRequest() {
-    super(Data.Type.GetCurrentTransition);
+    super(Data.Type.GetCurrentTransition, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetTransitionListRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetTransitionListRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetTransitionListRequest extends Request {
+public class GetTransitionListRequest extends Request<Void> {
 
   @Builder
   private GetTransitionListRequest() {
-    super(Data.Type.GetTransitionList);
+    super(Data.Type.GetTransitionList, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetTransitionSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/GetTransitionSettingsRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class GetTransitionSettingsRequest extends TransitionRequest {
-
-  private final Data requestData;
-
+public class GetTransitionSettingsRequest extends TransitionRequest<TransitionRequest.Data> {
   @Builder
   private GetTransitionSettingsRequest(String transitionName) {
-    super(Request.Data.Type.GetTransitionSettings);
-
-    this.requestData = Data.builder().transitionName(transitionName).build();
+    super(Request.Data.Type.GetTransitionSettings, Data.builder().transitionName(transitionName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/ReleaseTbarRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/ReleaseTbarRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ReleaseTbarRequest extends Request {
+public class ReleaseTbarRequest extends Request<Void> {
 
   @Builder
   private ReleaseTbarRequest() {
-    super(Data.Type.ReleaseTbar);
+    super(Data.Type.ReleaseTbar, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetCurrentTransitionDurationRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetCurrentTransitionDurationRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentTransitionDurationRequest extends Request {
-
-  private final Data requestData;
-
+public class SetCurrentTransitionDurationRequest extends Request<SetCurrentTransitionDurationRequest.Data> {
   @Builder
   private SetCurrentTransitionDurationRequest(Integer transitionDuration) {
-    super(Request.Data.Type.SetCurrentTransitionDuration);
-
-    this.requestData = Data.builder().transitionDuration(transitionDuration).build();
+    super(Request.Data.Type.SetCurrentTransitionDuration, Data.builder().transitionDuration(transitionDuration).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetCurrentTransitionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetCurrentTransitionRequest.java
@@ -7,14 +7,9 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentTransitionRequest extends TransitionRequest {
-
-  private final Data requestData;
-
+public class SetCurrentTransitionRequest extends TransitionRequest<TransitionRequest.Data> {
   @Builder
   private SetCurrentTransitionRequest(String transitionName) {
-    super(Request.Data.Type.SetCurrentTransition);
-
-    this.requestData = Data.builder().transitionName(transitionName).build();
+    super(Request.Data.Type.SetCurrentTransition, Data.builder().transitionName(transitionName).build());
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetTbarPositionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetTbarPositionRequest.java
@@ -8,15 +8,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetTbarPositionRequest extends Request {
-
-  private final Data requestData;
-
+public class SetTbarPositionRequest extends Request<SetTbarPositionRequest.Data> {
   @Builder
   private SetTbarPositionRequest(Double position, Boolean release) {
-    super(Request.Data.Type.SetTbarPosition);
-
-    this.requestData = Data.builder().position(position).release(release).build();
+    super(Request.Data.Type.SetTbarPosition, Data.builder().position(position).release(release).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetTransitionSettingsRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/SetTransitionSettingsRequest.java
@@ -1,6 +1,7 @@
 package io.obswebsocket.community.client.message.request.transitions;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,16 +11,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class SetTransitionSettingsRequest extends TransitionRequest {
-
-  private final Data requestData;
-
+public class SetTransitionSettingsRequest extends TransitionRequest<SetTransitionSettingsRequest.Data> {
   @Builder
   private SetTransitionSettingsRequest(String transitionName, JsonObject transitionSettings) {
-    super(Request.Data.Type.SetTransitionSettings);
-
-    this.requestData = Data.builder().transitionName(transitionName)
-        .transitionSettings(transitionSettings).build();
+    super(Request.Data.Type.SetTransitionSettings, Data.builder().transitionName(transitionName)
+                                                       .transitionSettings(transitionSettings).build());
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/TransitionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/TransitionRequest.java
@@ -8,10 +8,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class TransitionRequest extends Request {
+abstract class TransitionRequest<T extends TransitionRequest.Data> extends Request<T> {
 
-  TransitionRequest(Request.Data.Type requestType) {
-    super(requestType);
+  TransitionRequest(Request.Data.Type requestType, T data) {
+    super(requestType, data);
   }
 
   @Getter

--- a/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/TriggerStudioModeTransitionRequest.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/request/transitions/TriggerStudioModeTransitionRequest.java
@@ -7,10 +7,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerStudioModeTransitionRequest extends Request {
+public class TriggerStudioModeTransitionRequest extends Request<Void> {
 
   @Builder
   private TriggerStudioModeTransitionRequest() {
-    super(Data.Type.TriggerStudioModeTransition);
+    super(Data.Type.TriggerStudioModeTransition, null);
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
@@ -1,7 +1,6 @@
 package io.obswebsocket.community.client.message.response;
 
 import com.google.gson.annotations.SerializedName;
-
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Getter;
@@ -16,7 +15,6 @@ public abstract class RequestResponse<T> extends Message {
 
   protected RequestResponse(Request.Data.Type requestType) {
     super(OperationCode.RequestResponse);
-    // this.messageData = Data.builder().requestType(requestType).build();
   }
 
   @SuperBuilder

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
@@ -1,5 +1,7 @@
 package io.obswebsocket.community.client.message.response;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.Message;
 import io.obswebsocket.community.client.message.request.Request;
 import lombok.Getter;
@@ -8,21 +10,23 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public abstract class RequestResponse extends Message {
-
-  private transient Data messageData;
+public abstract class RequestResponse<T> extends Message {
+  @SerializedName("d")
+  private Data<T> messageData;
 
   protected RequestResponse(Request.Data.Type requestType) {
     super(OperationCode.RequestResponse);
-
-    this.messageData = Data.builder().requestType(requestType).build();
+    // this.messageData = Data.builder().requestType(requestType).build();
   }
 
   @SuperBuilder
   @ToString(callSuper = true)
   @Getter
-  public static class Data extends Request.Data {
+  public static class Data<T> { // Would extend Request.Data, but that breaks the SuperBuilder
+    protected Request.Data.Type requestType;
+    protected String requestId;
     protected Status requestStatus;
+    private T responseData;
   }
 
   public boolean isSuccessful() {
@@ -32,7 +36,6 @@ public abstract class RequestResponse extends Message {
   @Getter
   @ToString
   public static class Status {
-
     protected Boolean result;
     protected Integer code;
     protected String comment;
@@ -156,7 +159,6 @@ public abstract class RequestResponse extends Message {
        * The combination of request parameters cannot be used to perform an action
        */
       CannotAct(703);
-
 
       private final int value;
 

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/CreateSceneCollectionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/CreateSceneCollectionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneCollectionResponse extends RequestResponse {
-
+public class CreateSceneCollectionResponse extends RequestResponse<Void> {
   public CreateSceneCollectionResponse() {
     super(Request.Data.Type.CreateSceneCollection);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetPersistentDataResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetPersistentDataResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.config;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetPersistentDataResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetPersistentDataResponse extends RequestResponse<GetPersistentDataResponse.Data> {
   public GetPersistentDataResponse() {
     super(Request.Data.Type.GetPersistentData);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private JsonObject data;  // TODO: type might change
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.config;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Profile;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProfileListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetProfileListResponse extends RequestResponse<GetProfileListResponse.Data> {
   public GetProfileListResponse() {
     super(Request.Data.Type.GetProfileList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<Profile> profiles;
     private String currentProfileName;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileParameterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileParameterResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProfileParameterResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetProfileParameterResponse extends RequestResponse<GetProfileParameterResponse.Data> {
   public GetProfileParameterResponse() {
     super(Request.Data.Type.GetProfileParameter);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String parameterValue;
     private String defaultParameterValue;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetSceneCollectionListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetSceneCollectionListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.config;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.SceneCollection;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneCollectionListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneCollectionListResponse extends RequestResponse<GetSceneCollectionListResponse.Data> {
   public GetSceneCollectionListResponse() {
     super(Request.Data.Type.GetSceneCollectionList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<SceneCollection> sceneCollections;
     private String currentSceneCollectionName;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetVideoSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetVideoSettingsResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetVideoSettingsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetVideoSettingsResponse extends RequestResponse<GetVideoSettingsResponse.Data> {
   public GetVideoSettingsResponse() {
     super(Request.Data.Type.GetVideoSettings);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer baseWidth;
     private Integer baseHeight;
     private Integer outputWidth;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/RemoveSceneCollectionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/RemoveSceneCollectionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneCollectionResponse extends RequestResponse {
-
+public class RemoveSceneCollectionResponse extends RequestResponse<Void> {
   public RemoveSceneCollectionResponse() {
     super(Request.Data.Type.RemoveSceneCollection);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetCurrentSceneCollectionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetCurrentSceneCollectionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentSceneCollectionResponse extends RequestResponse {
-
+public class SetCurrentSceneCollectionResponse extends RequestResponse<Void> {
   public SetCurrentSceneCollectionResponse() {
     super(Request.Data.Type.SetCurrentSceneCollection);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetPersistentDataResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetPersistentDataResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetPersistentDataResponse extends RequestResponse {
-
+public class SetPersistentDataResponse extends RequestResponse<Void> {
   public SetPersistentDataResponse() {
     super(Request.Data.Type.SetPersistentData);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetProfileParameterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/SetProfileParameterResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetProfileParameterResponse extends RequestResponse {
-
+public class SetProfileParameterResponse extends RequestResponse<Void> {
   public SetProfileParameterResponse() {
     super(Request.Data.Type.SetProfileParameter);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/CreateSourceFilterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/CreateSourceFilterResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSourceFilterResponse extends RequestResponse {
-
+public class CreateSourceFilterResponse extends RequestResponse<Void> {
   public CreateSourceFilterResponse() {
     super(Request.Data.Type.CreateSourceFilter);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.filters;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Filter;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceFilterListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSourceFilterListResponse extends RequestResponse<GetSourceFilterListResponse.Data> {
   public GetSourceFilterListResponse() {
     super(Request.Data.Type.GetSourceFilterList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<Filter> filters;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
@@ -5,7 +5,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Filter;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
@@ -15,7 +14,6 @@ public class GetSourceFilterResponse extends RequestResponse<GetSourceFilterResp
   }
 
   @Getter
-  @SuperBuilder
   public static class Data extends Filter {
     private String sourceName;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
@@ -5,14 +5,18 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Filter;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceFilterResponse extends RequestResponse {
-
-  private Filter responseData;
-
+public class GetSourceFilterResponse extends RequestResponse<GetSourceFilterResponse.Data> {
   public GetSourceFilterResponse() {
     super(Request.Data.Type.GetSourceFilter);
+  }
+
+  @Getter
+  @SuperBuilder
+  public static class Data extends Filter {
+    private String sourceName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/RemoveSourceFilterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/RemoveSourceFilterResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSourceFilterResponse extends RequestResponse {
-
+public class RemoveSourceFilterResponse extends RequestResponse<Void> {
   public RemoveSourceFilterResponse() {
     super(Request.Data.Type.RemoveSourceFilter);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterEnabledResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterEnabledResponse extends RequestResponse {
-
+public class SetSourceFilterEnabledResponse extends RequestResponse<Void> {
   public SetSourceFilterEnabledResponse() {
     super(Request.Data.Type.SetSourceFilterEnabled);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterIndexResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterIndexResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterIndexResponse extends RequestResponse {
-
+public class SetSourceFilterIndexResponse extends RequestResponse<Void> {
   public SetSourceFilterIndexResponse() {
     super(Request.Data.Type.SetSourceFilterIndex);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/SetSourceFilterSettingsResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSourceFilterSettingsResponse extends RequestResponse {
-
+public class SetSourceFilterSettingsResponse extends RequestResponse<Void> {
   public SetSourceFilterSettingsResponse() {
     super(Request.Data.Type.SetSourceFilterSettings);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/BroadcastCustomEventResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/BroadcastCustomEventResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class BroadcastCustomEventResponse extends RequestResponse {
-
+public class BroadcastCustomEventResponse extends RequestResponse<Void> {
   public BroadcastCustomEventResponse() {
     super(Request.Data.Type.BroadcastCustomEvent);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/CloseProjectorResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/CloseProjectorResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CloseProjectorResponse extends RequestResponse {
-
+public class CloseProjectorResponse extends RequestResponse<Void> {
   public CloseProjectorResponse() {
     super(Request.Data.Type.CloseProjector);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/CreateProfileResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/CreateProfileResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateProfileResponse extends RequestResponse {
-
+public class CreateProfileResponse extends RequestResponse<Void> {
   public CreateProfileResponse() {
     super(Request.Data.Type.CreateProfile);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetHotkeyListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetHotkeyListResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.general;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetHotkeyListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetHotkeyListResponse extends RequestResponse<GetHotkeyListResponse.Data> {
   public GetHotkeyListResponse() {
     super(Request.Data.Type.GetHotkeyList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<String> hotkeys;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetProjectorListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetProjectorListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.general;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Projector;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetProjectorListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetProjectorListResponse extends RequestResponse<GetProjectorListResponse.Data> {
   protected GetProjectorListResponse() {
     super(Request.Data.Type.GetProjectorList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<Projector> projectors;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStatsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStatsResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStatsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetStatsResponse extends RequestResponse<GetStatsResponse.Data> {
   public GetStatsResponse() {
     super(Request.Data.Type.GetStats);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Double cpuUsage;
     private Double memoryUsage;
     private Double availableDiskSpace;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStudioModeEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStudioModeEnabledResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStudioModeEnabledResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetStudioModeEnabledResponse extends RequestResponse<GetStudioModeEnabledResponse.Data> {
   public GetStudioModeEnabledResponse() {
     super(Request.Data.Type.GetStudioModeEnabled);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean studioModeEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetSystemStatsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetSystemStatsResponse.java
@@ -4,19 +4,18 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSystemStatsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSystemStatsResponse extends RequestResponse<GetSystemStatsResponse.Data> {
   private GetSystemStatsResponse() {
     super(Request.Data.Type.GetSystemStats);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
     // TODO: GetSystemStatsResponse data
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetVersionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetVersionResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.general;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetVersionResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetVersionResponse extends RequestResponse<GetVersionResponse.Data> {
   public GetVersionResponse() {
     super(Request.Data.Type.GetVersion);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer rpcVersion;
     private String obsWebSocketVersion;
     private String obsVersion;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/OpenProjectorResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/OpenProjectorResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class OpenProjectorResponse extends RequestResponse {
-
+public class OpenProjectorResponse extends RequestResponse<Void> {
   public OpenProjectorResponse() {
     super(Request.Data.Type.OpenProjector);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/RemoveProfileResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/RemoveProfileResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveProfileResponse extends RequestResponse {
-
+public class RemoveProfileResponse extends RequestResponse<Void> {
   public RemoveProfileResponse() {
     super(Request.Data.Type.RemoveProfile);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetCurrentProfileResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetCurrentProfileResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentProfileResponse extends RequestResponse {
-
+public class SetCurrentProfileResponse extends RequestResponse<Void> {
   public SetCurrentProfileResponse() {
     super(Request.Data.Type.SetCurrentProfile);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetStudioModeEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetStudioModeEnabledResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetStudioModeEnabledResponse extends RequestResponse {
-
+public class SetStudioModeEnabledResponse extends RequestResponse<Void> {
   public SetStudioModeEnabledResponse() {
     super(Request.Data.Type.SetStudioModeEnabled);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetVideoSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/SetVideoSettingsResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetVideoSettingsResponse extends RequestResponse {
-
+public class SetVideoSettingsResponse extends RequestResponse<Void> {
   public SetVideoSettingsResponse() {
     super(Request.Data.Type.SetVideoSettings);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/SleepResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/SleepResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SleepResponse extends RequestResponse {
-
+public class SleepResponse extends RequestResponse<Void> {
   public SleepResponse() {
     super(Request.Data.Type.Sleep);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/TriggerHotkeyByKeySequenceResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/TriggerHotkeyByKeySequenceResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerHotkeyByKeySequenceResponse extends RequestResponse {
-
+public class TriggerHotkeyByKeySequenceResponse extends RequestResponse<Void> {
   public TriggerHotkeyByKeySequenceResponse() {
     super(Request.Data.Type.TriggerHotkeyByKeySequence);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/TriggerHotkeyByNameResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/TriggerHotkeyByNameResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerHotkeyByNameResponse extends RequestResponse {
-
+public class TriggerHotkeyByNameResponse extends RequestResponse<Void> {
   public TriggerHotkeyByNameResponse() {
     super(Request.Data.Type.TriggerHotkeyByName);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/CreateInputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/CreateInputResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateInputResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class CreateInputResponse extends RequestResponse<CreateInputResponse.Data> {
   public CreateInputResponse() {
     super(Request.Data.Type.CreateInput);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioMonitorTypeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioMonitorTypeResponse.java
@@ -5,21 +5,19 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Input;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioMonitorTypeResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputAudioMonitorTypeResponse extends RequestResponse<GetInputAudioMonitorTypeResponse.Data> {
   public GetInputAudioMonitorTypeResponse() {
     super(Request.Data.Type.GetInputAudioMonitorType);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Input.MonitorType monitorType;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioSyncOffsetResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioSyncOffsetResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioSyncOffsetResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputAudioSyncOffsetResponse extends RequestResponse<GetInputAudioSyncOffsetResponse.Data> {
   public GetInputAudioSyncOffsetResponse() {
     super(Request.Data.Type.GetInputAudioSyncOffset);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Long inputAudioSyncOffset;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioTracksResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioTracksResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputAudioTracksResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputAudioTracksResponse extends RequestResponse<GetInputAudioTracksResponse.Data> {
   public GetInputAudioTracksResponse() {
     super(Request.Data.Type.GetInputAudioTracks);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     // TODO: investigate exact type
     private JsonObject inputAudioTracks;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputDefaultSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputDefaultSettingsResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputDefaultSettingsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputDefaultSettingsResponse extends RequestResponse<GetInputDefaultSettingsResponse.Data> {
   public GetInputDefaultSettingsResponse() {
     super(Request.Data.Type.GetInputDefaultSettings);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private JsonObject defaultInputSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputKindListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputKindListResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputKindListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputKindListResponse extends RequestResponse<GetInputKindListResponse.Data> {
   public GetInputKindListResponse() {
     super(Request.Data.Type.GetInputKindList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<String> inputKinds;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Input;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputListResponse extends RequestResponse<GetInputListResponse.Data> {
   public GetInputListResponse() {
     super(Request.Data.Type.GetInputList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<Input> inputs;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputMuteResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputMuteResponse.java
@@ -4,19 +4,18 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputMuteResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputMuteResponse extends RequestResponse<Void> {
   public GetInputMuteResponse() {
     super(Request.Data.Type.GetInputMute);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
 
     private Boolean inputMuted;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputPropertiesListPropertyItemsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputPropertiesListPropertyItemsResponse.java
@@ -1,18 +1,16 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class
-GetInputPropertiesListPropertyItemsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputPropertiesListPropertyItemsResponse extends RequestResponse<GetInputPropertiesListPropertyItemsResponse.Data> {
   public GetInputPropertiesListPropertyItemsResponse() {
     super(Request.Data.Type.GetInputPropertiesListPropertyItems);
   }
@@ -20,7 +18,6 @@ GetInputPropertiesListPropertyItemsResponse extends RequestResponse {
   @Getter
   @ToString
   public static class PropertyItem {
-
     private String itemName;
     private String itemValue;
     private Boolean itemEnabled;
@@ -28,8 +25,8 @@ GetInputPropertiesListPropertyItemsResponse extends RequestResponse {
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String listPropertyFormat;
     private List<PropertyItem> propertyItems;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputSettingsResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputSettingsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputSettingsResponse extends RequestResponse<GetInputSettingsResponse.Data> {
   public GetInputSettingsResponse() {
     super(Request.Data.Type.GetInputSettings);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private JsonObject inputSettings;
     private String inputKind;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputVolumeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputVolumeResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetInputVolumeResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetInputVolumeResponse extends RequestResponse<GetInputVolumeResponse.Data> {
   public GetInputVolumeResponse() {
     super(Request.Data.Type.GetInputVolume);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private float inputVolumeDb;
     private float inputVolumeMul;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetSpecialInputNamesResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetSpecialInputNamesResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.inputs;
 
 import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSpecialInputNamesResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSpecialInputNamesResponse extends RequestResponse<GetSpecialInputNamesResponse.Data> {
   public GetSpecialInputNamesResponse() {
     super(Request.Data.Type.GetSpecialInputNames);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     @SerializedName("desktop-1")
     private String desktop1;
     @SerializedName("desktop-2")

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/PressInputPropertiesButtonResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/PressInputPropertiesButtonResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class PressInputPropertiesButtonResponse extends RequestResponse {
-
+public class PressInputPropertiesButtonResponse extends RequestResponse<Void> {
   public PressInputPropertiesButtonResponse() {
     super(Request.Data.Type.PressInputPropertiesButton);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/RemoveInputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/RemoveInputResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveInputResponse extends RequestResponse {
-
+public class RemoveInputResponse extends RequestResponse<Void> {
   public RemoveInputResponse() {
     super(Request.Data.Type.RemoveInput);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputAudioMonitorTypeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputAudioMonitorTypeResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputAudioMonitorTypeResponse extends RequestResponse {
-
+public class SetInputAudioMonitorTypeResponse extends RequestResponse<Void> {
   public SetInputAudioMonitorTypeResponse() {
     super(Request.Data.Type.SetInputAudioMonitorType);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputAudioSyncOffsetResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputAudioSyncOffsetResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputAudioSyncOffsetResponse extends RequestResponse {
-
+public class SetInputAudioSyncOffsetResponse extends RequestResponse<Void> {
   public SetInputAudioSyncOffsetResponse() {
     super(Request.Data.Type.SetInputAudioSyncOffset);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputMuteResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputMuteResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputMuteResponse extends RequestResponse {
-
+public class SetInputMuteResponse extends RequestResponse<Void> {
   public SetInputMuteResponse() {
     super(Request.Data.Type.SetInputMute);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputNameResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputNameResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputNameResponse extends RequestResponse {
-
+public class SetInputNameResponse extends RequestResponse<Void> {
   public SetInputNameResponse() {
     super(Request.Data.Type.SetInputName);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputSettingsResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputSettingsResponse extends RequestResponse {
-
+public class SetInputSettingsResponse extends RequestResponse<Void> {
   public SetInputSettingsResponse() {
     super(Request.Data.Type.SetInputSettings);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputVolumeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/SetInputVolumeResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetInputVolumeResponse extends RequestResponse {
-
+public class SetInputVolumeResponse extends RequestResponse<Void> {
   public SetInputVolumeResponse() {
     super(Request.Data.Type.SetInputVolume);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/ToggleInputMuteResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/ToggleInputMuteResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleInputMuteResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleInputMuteResponse extends RequestResponse<ToggleInputMuteResponse.Data> {
   public ToggleInputMuteResponse() {
     super(Request.Data.Type.ToggleInputMute);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean inputMuted;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/GetMediaInputStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/GetMediaInputStatusResponse.java
@@ -1,17 +1,16 @@
 package io.obswebsocket.community.client.message.response.mediainputs;
 
 import com.google.gson.annotations.SerializedName;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetMediaInputStatusResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetMediaInputStatusResponse extends RequestResponse<GetMediaInputStatusResponse.Data> {
   public GetMediaInputStatusResponse() {
     super(Request.Data.Type.GetMediaInputStatus);
   }
@@ -39,8 +38,8 @@ public class GetMediaInputStatusResponse extends RequestResponse {
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private MediaState mediaState;
     private Long mediaDuration; // optional
     private Long mediaTimestamp; // optional

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/NextMediaInputPlaylistItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/NextMediaInputPlaylistItemResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class NextMediaInputPlaylistItemResponse extends RequestResponse {
-
+public class NextMediaInputPlaylistItemResponse extends RequestResponse<Void> {
   public NextMediaInputPlaylistItemResponse() {
     super(Request.Data.Type.NextMediaInputPlaylistItem);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/OffsetMediaInputTimecodeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/OffsetMediaInputTimecodeResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class OffsetMediaInputTimecodeResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class OffsetMediaInputTimecodeResponse extends RequestResponse<OffsetMediaInputTimecodeResponse.Data> {
   public OffsetMediaInputTimecodeResponse() {
     super(Request.Data.Type.OffsetMediaInputTimecode);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Long mediaTimestamp;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/PreviousMediaInputPlaylistItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/PreviousMediaInputPlaylistItemResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class PreviousMediaInputPlaylistItemResponse extends RequestResponse {
-
+public class PreviousMediaInputPlaylistItemResponse extends RequestResponse<Void> {
   public PreviousMediaInputPlaylistItemResponse() {
     super(Request.Data.Type.PreviousMediaInputPlaylistItem);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/RestartMediaInputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/RestartMediaInputResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RestartMediaInputResponse extends RequestResponse {
-
+public class RestartMediaInputResponse extends RequestResponse<Void> {
   public RestartMediaInputResponse() {
     super(Request.Data.Type.RestartMediaInput);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/SetMediaInputPauseStateResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/SetMediaInputPauseStateResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetMediaInputPauseStateResponse extends RequestResponse {
-
+public class SetMediaInputPauseStateResponse extends RequestResponse<Void> {
   public SetMediaInputPauseStateResponse() {
     super(Request.Data.Type.SetMediaInputPauseState);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/SetMediaInputTimecodeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/SetMediaInputTimecodeResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetMediaInputTimecodeResponse extends RequestResponse {
-
+public class SetMediaInputTimecodeResponse extends RequestResponse<Void> {
   public SetMediaInputTimecodeResponse() {
     super(Request.Data.Type.SetMediaInputTimecode);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/StopMediaInputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/StopMediaInputResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopMediaInputResponse extends RequestResponse {
-
+public class StopMediaInputResponse extends RequestResponse<Void> {
   public StopMediaInputResponse() {
     super(Request.Data.Type.StopMediaInput);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetLastReplayBufferReplayResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetLastReplayBufferReplayResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetLastReplayBufferReplayResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetLastReplayBufferReplayResponse extends RequestResponse<GetLastReplayBufferReplayResponse.Data> {
   public GetLastReplayBufferReplayResponse() {
     super(Request.Data.Type.GetLastReplayBufferReplay);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String savedReplayPath;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.outputs;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Output;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetOutputListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetOutputListResponse extends RequestResponse<GetOutputListResponse.Data> {
   public GetOutputListResponse() {
     super(Request.Data.Type.GetOutputList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<Output> outputs;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetReplayBufferStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetReplayBufferStatusResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetReplayBufferStatusResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetReplayBufferStatusResponse extends RequestResponse<GetReplayBufferStatusResponse.Data> {
   public GetReplayBufferStatusResponse() {
     super(Request.Data.Type.GetReplayBufferStatus);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean replayBufferActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/SaveReplayBufferResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/SaveReplayBufferResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SaveReplayBufferResponse extends RequestResponse {
-
+public class SaveReplayBufferResponse extends RequestResponse<Void> {
   public SaveReplayBufferResponse() {
     super(Request.Data.Type.SaveReplayBuffer);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StartOutputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StartOutputResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartOutputResponse extends RequestResponse {
-
+public class StartOutputResponse extends RequestResponse<Void> {
   public StartOutputResponse() {
     super(Request.Data.Type.StartOutput);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StartReplayBufferResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StartReplayBufferResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartReplayBufferResponse extends RequestResponse {
-
+public class StartReplayBufferResponse extends RequestResponse<Void> {
   public StartReplayBufferResponse() {
     super(Request.Data.Type.StartReplayBuffer);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StopOutputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StopOutputResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopOutputResponse extends RequestResponse {
-
+public class StopOutputResponse extends RequestResponse<Void> {
   public StopOutputResponse() {
     super(Request.Data.Type.StopOutput);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StopReplayBufferResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/StopReplayBufferResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopReplayBufferResponse extends RequestResponse {
-
+public class StopReplayBufferResponse extends RequestResponse<Void> {
   public StopReplayBufferResponse() {
     super(Request.Data.Type.StopReplayBuffer);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleOutputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleOutputResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleOutputResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleOutputResponse extends RequestResponse<ToggleOutputResponse.Data> {
   public ToggleOutputResponse() {
     super(Request.Data.Type.ToggleOutput);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleReplayBufferResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleReplayBufferResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleReplayBufferResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleReplayBufferResponse extends RequestResponse<ToggleReplayBufferResponse.Data> {
   public ToggleReplayBufferResponse() {
     super(Request.Data.Type.ToggleReplayBuffer);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean replayBufferActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordDirectoryResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordDirectoryResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.record;
 
+import java.io.File;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
-import java.io.File;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordDirectoryResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetRecordDirectoryResponse extends RequestResponse<GetRecordDirectoryResponse.Data> {
   public GetRecordDirectoryResponse() {
     super(Request.Data.Type.GetRecordDirectory);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private File recordDirectory;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordFilenameFormattingResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordFilenameFormattingResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordFilenameFormattingResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetRecordFilenameFormattingResponse extends RequestResponse<Void> {
   public GetRecordFilenameFormattingResponse() {
     super(Request.Data.Type.GetRecordFilenameFormatting);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String filenameFormatting;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordStatusResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetRecordStatusResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetRecordStatusResponse extends RequestResponse<GetRecordStatusResponse.Data> {
   public GetRecordStatusResponse() {
     super(Request.Data.Type.GetRecordStatus);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputActive;
     private Boolean outputPaused;
     private Long outputTimecode;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/PauseRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/PauseRecordResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class PauseRecordResponse extends RequestResponse {
-
+public class PauseRecordResponse extends RequestResponse<Void> {
   public PauseRecordResponse() {
     super(Request.Data.Type.PauseRecord);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/ResumeRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/ResumeRecordResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ResumeRecordResponse extends RequestResponse {
-
+public class ResumeRecordResponse extends RequestResponse<Void> {
   public ResumeRecordResponse() {
     super(Request.Data.Type.ResumeRecord);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/SetRecordDirectoryResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/SetRecordDirectoryResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetRecordDirectoryResponse extends RequestResponse {
-
+public class SetRecordDirectoryResponse extends RequestResponse<Void> {
   public SetRecordDirectoryResponse() {
     super(Request.Data.Type.SetRecordDirectory);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/SetRecordFilenameFormattingResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/SetRecordFilenameFormattingResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetRecordFilenameFormattingResponse extends RequestResponse {
-
+public class SetRecordFilenameFormattingResponse extends RequestResponse<Void> {
   public SetRecordFilenameFormattingResponse() {
     super(Request.Data.Type.SetRecordFilenameFormatting);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/StartRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/StartRecordResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartRecordResponse extends RequestResponse {
-
+public class StartRecordResponse extends RequestResponse<Void> {
   public StartRecordResponse() {
     super(Request.Data.Type.StartRecord);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/StopRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/StopRecordResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopRecordResponse extends RequestResponse {
-
+public class StopRecordResponse extends RequestResponse<Void> {
   public StopRecordResponse() {
     super(Request.Data.Type.StopRecord);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/ToggleRecordPauseResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/ToggleRecordPauseResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleRecordPauseResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleRecordPauseResponse extends RequestResponse<Void> {
   public ToggleRecordPauseResponse() {
     super(Request.Data.Type.ToggleRecordPause);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputPaused;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/ToggleRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/ToggleRecordResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleRecordResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleRecordResponse extends RequestResponse<ToggleRecordResponse.Data> {
   public ToggleRecordResponse() {
     super(Request.Data.Type.ToggleRecord);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/CreateSceneItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/CreateSceneItemResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneItemResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class CreateSceneItemResponse extends RequestResponse<CreateSceneItemResponse.Data> {
   public CreateSceneItemResponse() {
     super(Request.Data.Type.CreateSceneItem);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/DuplicateSceneItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/DuplicateSceneItemResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class DuplicateSceneItemResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class DuplicateSceneItemResponse extends RequestResponse<DuplicateSceneItemResponse.Data> {
   public DuplicateSceneItemResponse() {
     super(Request.Data.Type.DuplicateSceneItem);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemColorResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemColorResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemColorResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneItemColorResponse extends RequestResponse<GetSceneItemColorResponse.Data> {
   public GetSceneItemColorResponse() {
     super(Request.Data.Type.GetSceneItemColor);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Integer sceneItemColor;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemEnabledResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemEnabledResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneItemEnabledResponse extends RequestResponse<GetSceneItemEnabledResponse.Data> {
   public GetSceneItemEnabledResponse() {
     super(Request.Data.Type.GetSceneItemEnabled);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean sceneItemEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.sceneitems;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.SceneItem;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneItemListResponse extends RequestResponse<GetSceneItemListResponse.Data> {
   public GetSceneItemListResponse() {
     super(Request.Data.Type.GetSceneItemList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private List<SceneItem> sceneItems;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemLockedResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemLockedResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneItemLockedResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneItemLockedResponse extends RequestResponse<Void> {
   public GetSceneItemLockedResponse() {
     super(Request.Data.Type.GetSceneItemLocked);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean sceneItemLocked;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/RemoveSceneItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/RemoveSceneItemResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneItemResponse extends RequestResponse {
-
+public class RemoveSceneItemResponse extends RequestResponse<Void> {
   public RemoveSceneItemResponse() {
     super(Request.Data.Type.RemoveSceneItem);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemEnabledResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemEnabledResponse extends RequestResponse {
-
+public class SetSceneItemEnabledResponse extends RequestResponse<Void> {
   public SetSceneItemEnabledResponse() {
     super(Request.Data.Type.SetSceneItemEnabled);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemIndexResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemIndexResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemIndexResponse extends RequestResponse {
-
+public class SetSceneItemIndexResponse extends RequestResponse<Void> {
   public SetSceneItemIndexResponse() {
     super(Request.Data.Type.SetSceneItemIndex);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemLockedResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/SetSceneItemLockedResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneItemLockedResponse extends RequestResponse {
-
+public class SetSceneItemLockedResponse extends RequestResponse<Void> {
   public SetSceneItemLockedResponse() {
     super(Request.Data.Type.SetSceneItemLocked);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/CreateSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/CreateSceneResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class CreateSceneResponse extends RequestResponse {
-
+public class CreateSceneResponse extends RequestResponse<Void> {
   public CreateSceneResponse() {
     super(Request.Data.Type.CreateScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/CurrentSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/CurrentSceneResponse.java
@@ -4,19 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-abstract class CurrentSceneResponse extends RequestResponse {
-
+abstract class CurrentSceneResponse extends RequestResponse<CurrentSceneResponse.Data> {
   CurrentSceneResponse(Request.Data.Type requestType) {
     super(requestType);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   static class Data {
-
     private String sceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/DeleteSceneTransitionOverrideResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/DeleteSceneTransitionOverrideResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class DeleteSceneTransitionOverrideResponse extends RequestResponse {
-
+public class DeleteSceneTransitionOverrideResponse extends RequestResponse<Void> {
   public DeleteSceneTransitionOverrideResponse() {
     super(Request.Data.Type.DeleteSceneTransitionOverride);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentPreviewSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentPreviewSceneResponse.java
@@ -7,9 +7,6 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class GetCurrentPreviewSceneResponse extends CurrentSceneResponse {
-
-  private Data responseData;
-
   public GetCurrentPreviewSceneResponse() {
     super(Request.Data.Type.GetCurrentPreviewScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentProgramSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentProgramSceneResponse.java
@@ -7,9 +7,6 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class GetCurrentProgramSceneResponse extends CurrentSceneResponse {
-
-  private Data responseData;
-
   public GetCurrentProgramSceneResponse() {
     super(Request.Data.Type.GetCurrentProgramScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneListResponse.java
@@ -1,22 +1,17 @@
 package io.obswebsocket.community.client.message.response.scenes;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Scene;
-import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneListResponse extends RequestResponse {
-
-  @SerializedName("d")
-  private Data messageData;
-
+public class GetSceneListResponse extends RequestResponse<GetSceneListResponse.Data> {
   public GetSceneListResponse() {
     super(Request.Data.Type.GetSceneList);
   }
@@ -24,16 +19,9 @@ public class GetSceneListResponse extends RequestResponse {
   @Getter
   @ToString(callSuper = true)
   @SuperBuilder
-  public static class Data extends RequestResponse.Data {
-    private SpecificData responseData;
-
-    @AllArgsConstructor
-    @Getter
-    @ToString
-    public static class SpecificData {
-      private final String currentProgramSceneName;
-      private final String currentPreviewSceneName;
-      private final List<Scene> scenes;
-    }
+  public static class Data {
+    private String currentProgramSceneName;
+    private String currentPreviewSceneName;
+    private List<Scene> scenes;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneTransitionOverrideResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneTransitionOverrideResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSceneTransitionOverrideResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSceneTransitionOverrideResponse extends RequestResponse<GetSceneTransitionOverrideResponse.Data> {
   public GetSceneTransitionOverrideResponse() {
     super(Request.Data.Type.GetSceneTransitionOverride);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String transitionName;
     private Integer transitionDuration;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/RemoveSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/RemoveSceneResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class RemoveSceneResponse extends RequestResponse {
-
+public class RemoveSceneResponse extends RequestResponse<Void> {
   public RemoveSceneResponse() {
     super(Request.Data.Type.RemoveScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetCurrentPreviewSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetCurrentPreviewSceneResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentPreviewSceneResponse extends RequestResponse {
-
+public class SetCurrentPreviewSceneResponse extends RequestResponse<Void> {
   public SetCurrentPreviewSceneResponse() {
     super(Request.Data.Type.SetCurrentPreviewScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetCurrentProgramSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetCurrentProgramSceneResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentProgramSceneResponse extends RequestResponse {
-
+public class SetCurrentProgramSceneResponse extends RequestResponse<Void> {
   public SetCurrentProgramSceneResponse() {
     super(Request.Data.Type.SetCurrentProgramScene);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneIndexResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneIndexResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneIndexResponse extends RequestResponse {
-
+public class SetSceneIndexResponse extends RequestResponse<Void> {
   public SetSceneIndexResponse() {
     super(Request.Data.Type.SetSceneIndex);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneNameResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneNameResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneNameResponse extends RequestResponse {
-
+public class SetSceneNameResponse extends RequestResponse<Void> {
   public SetSceneNameResponse() {
     super(Request.Data.Type.SetSceneName);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneTransitionOverrideResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/SetSceneTransitionOverrideResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetSceneTransitionOverrideResponse extends RequestResponse {
-
+public class SetSceneTransitionOverrideResponse extends RequestResponse<Void> {
   public SetSceneTransitionOverrideResponse() {
     super(Request.Data.Type.SetSceneTransitionOverride);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceActiveResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceActiveResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceActiveResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSourceActiveResponse extends RequestResponse<GetSourceActiveResponse.Data> {
   public GetSourceActiveResponse() {
     super(Request.Data.Type.GetSourceActive);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean videoActive;
     private Boolean videoShowing;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceScreenshotResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceScreenshotResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetSourceScreenshotResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetSourceScreenshotResponse extends RequestResponse<GetSourceScreenshotResponse.Data> {
   public GetSourceScreenshotResponse() {
     super(Request.Data.Type.GetSourceScreenshot);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String imageData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/SaveSourceScreenshotResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/SaveSourceScreenshotResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SaveSourceScreenshotResponse extends RequestResponse {
-
+public class SaveSourceScreenshotResponse extends RequestResponse<Void> {
   public SaveSourceScreenshotResponse() {
     super(Request.Data.Type.SaveSourceScreenshot);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamServiceSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamServiceSettingsResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.stream;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStreamServiceSettingsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetStreamServiceSettingsResponse extends RequestResponse<GetStreamServiceSettingsResponse.Data> {
   public GetStreamServiceSettingsResponse() {
     super(Request.Data.Type.GetStreamServiceSettings);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String streamServiceType;
     private JsonObject serviceSettings;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamStatusResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetStreamStatusResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetStreamStatusResponse extends RequestResponse<GetStreamStatusResponse.Data> {
   public GetStreamStatusResponse() {
     super(Request.Data.Type.GetStreamStatus);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputActive;
     private Boolean outputReconnecting;
     private String outputTimecode;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/SendStreamCaptionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/SendStreamCaptionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SendStreamCaptionResponse extends RequestResponse {
-
+public class SendStreamCaptionResponse extends RequestResponse<Void> {
   public SendStreamCaptionResponse() {
     super(Request.Data.Type.SendStreamCaption);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/SetStreamServiceSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/SetStreamServiceSettingsResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetStreamServiceSettingsResponse extends RequestResponse {
-
+public class SetStreamServiceSettingsResponse extends RequestResponse<Void> {
   public SetStreamServiceSettingsResponse() {
     super(Request.Data.Type.SetStreamServiceSettings);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/StartStreamResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/StartStreamResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StartStreamResponse extends RequestResponse {
-
+public class StartStreamResponse extends RequestResponse<Void> {
   public StartStreamResponse() {
     super(Request.Data.Type.StartStream);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/StopStreamResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/StopStreamResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class StopStreamResponse extends RequestResponse {
-
+public class StopStreamResponse extends RequestResponse<Void> {
   public StopStreamResponse() {
     super(Request.Data.Type.StopStream);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/ToggleStreamResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/ToggleStreamResponse.java
@@ -4,21 +4,19 @@ import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class ToggleStreamResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class ToggleStreamResponse extends RequestResponse<ToggleStreamResponse.Data> {
   public ToggleStreamResponse() {
     super(Request.Data.Type.ToggleStream);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentTransitionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentTransitionResponse.java
@@ -5,21 +5,19 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Transition;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetCurrentTransitionResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetCurrentTransitionResponse extends RequestResponse<GetCurrentTransitionResponse.Data> {
   public GetCurrentTransitionResponse() {
     super(Request.Data.Type.GetTransitionList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data extends Transition {
-
     private Double transitionDuration;
     private Double transitionPosition; // optional
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentTransitionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentTransitionResponse.java
@@ -5,7 +5,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Transition;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
@@ -16,7 +15,6 @@ public class GetCurrentTransitionResponse extends RequestResponse<GetCurrentTran
 
   @Getter
   @ToString
-  @SuperBuilder
   public static class Data extends Transition {
     private Double transitionDuration;
     private Double transitionPosition; // optional

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionListResponse.java
@@ -1,26 +1,25 @@
 package io.obswebsocket.community.client.message.response.transitions;
 
+import java.util.List;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Transition;
-import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetTransitionListResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetTransitionListResponse extends RequestResponse<GetTransitionListResponse.Data> {
   public GetTransitionListResponse() {
     super(Request.Data.Type.GetTransitionList);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private String currentTransitionName;
     private List<Transition> transitions;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionSettingsResponse.java
@@ -1,25 +1,24 @@
 package io.obswebsocket.community.client.message.response.transitions;
 
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
-public class GetTransitionSettingsResponse extends RequestResponse {
-
-  private Data responseData;
-
+public class GetTransitionSettingsResponse extends RequestResponse<GetTransitionSettingsResponse.Data> {
   public GetTransitionSettingsResponse() {
     super(Request.Data.Type.GetTransitionSettings);
   }
 
   @Getter
   @ToString
+  @SuperBuilder
   public static class Data {
-
     private JsonObject transitionSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/ReleaseTbarResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/ReleaseTbarResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class ReleaseTbarResponse extends RequestResponse {
-
+public class ReleaseTbarResponse extends RequestResponse<Void> {
   public ReleaseTbarResponse() {
     super(Request.Data.Type.ReleaseTbar);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetCurrentTransitionDurationResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetCurrentTransitionDurationResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentTransitionDurationResponse extends RequestResponse {
-
+public class SetCurrentTransitionDurationResponse extends RequestResponse<Void> {
   public SetCurrentTransitionDurationResponse() {
     super(Request.Data.Type.SetCurrentTransitionDuration);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetCurrentTransitionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetCurrentTransitionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetCurrentTransitionResponse extends RequestResponse {
-
+public class SetCurrentTransitionResponse extends RequestResponse<Void> {
   public SetCurrentTransitionResponse() {
     super(Request.Data.Type.SetCurrentTransition);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetTbarPositionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetTbarPositionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetTbarPositionResponse extends RequestResponse {
-
+public class SetTbarPositionResponse extends RequestResponse<Void> {
   public SetTbarPositionResponse() {
     super(Request.Data.Type.SetTbarPosition);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetTransitionSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/SetTransitionSettingsResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class SetTransitionSettingsResponse extends RequestResponse {
-
+public class SetTransitionSettingsResponse extends RequestResponse<Void> {
   public SetTransitionSettingsResponse() {
     super(Request.Data.Type.SetTransitionSettings);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/TriggerStudioModeTransitionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/TriggerStudioModeTransitionResponse.java
@@ -7,8 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class TriggerStudioModeTransitionResponse extends RequestResponse {
-
+public class TriggerStudioModeTransitionResponse extends RequestResponse<Void> {
   public TriggerStudioModeTransitionResponse() {
     super(Request.Data.Type.TriggerStudioModeTransition);
   }

--- a/client/src/main/java/io/obswebsocket/community/client/model/Filter.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Filter.java
@@ -1,16 +1,13 @@
 package io.obswebsocket.community.client.model;
 
 import com.google.gson.JsonObject;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @ToString
-@SuperBuilder
 public class Filter {
   private String filterName;
   private Boolean filterEnabled;

--- a/client/src/main/java/io/obswebsocket/community/client/model/Filter.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Filter.java
@@ -1,15 +1,17 @@
 package io.obswebsocket.community.client.model;
 
 import com.google.gson.JsonObject;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @ToString
+@SuperBuilder
 public class Filter {
-
   private String filterName;
   private Boolean filterEnabled;
   private Integer filterIndex;

--- a/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
@@ -10,26 +10,8 @@ import lombok.ToString;
 @Setter
 @ToString
 public class Scene {
+
   private String sceneName;
   private Integer sceneIndex;
-  private Boolean isGroup; // maybe a new feature?
-
-  public boolean getIsGroup() {
-    return Boolean.TRUE.equals(isGroup);
-  }
-
-  // Sources on scenes has moved to the separate GetSceneItemList request
-//    private List<Source> sources;
-
-//    public List<Source> getSourcesIncludingGroupChildren() {
-//        List<Source> allSources = new ArrayList<>();
-//        this.sources.forEach(source -> {
-//            allSources.add(source);
-//            if (source.getGroupChildren() != null && source.getGroupChildren().size() > 0) {
-//                allSources.addAll(source.getGroupChildren());
-//            }
-//        });
-//
-//        return allSources;
-//    }
+  private boolean isGroup; // maybe a new feature?
 }

--- a/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
@@ -10,10 +10,13 @@ import lombok.ToString;
 @Setter
 @ToString
 public class Scene {
-
   private String sceneName;
   private Integer sceneIndex;
   private Boolean isGroup; // maybe a new feature?
+
+  public boolean getIsGroup() {
+    return Boolean.TRUE.equals(isGroup);
+  }
 
   // Sources on scenes has moved to the separate GetSceneItemList request
 //    private List<Source> sources;

--- a/client/src/main/java/io/obswebsocket/community/client/model/Transition.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Transition.java
@@ -3,12 +3,10 @@ package io.obswebsocket.community.client.model;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @ToString
-@SuperBuilder
 public class Transition {
   private String transitionName;
   private String transitionKind;

--- a/client/src/main/java/io/obswebsocket/community/client/model/Transition.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Transition.java
@@ -3,12 +3,13 @@ package io.obswebsocket.community.client.model;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @ToString
+@SuperBuilder
 public class Transition {
-
   private String transitionName;
   private String transitionKind;
   private Boolean transitionFixed;

--- a/client/src/test/java/io/obswebsocket/community/client/OBSCommunicatorTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/OBSCommunicatorTest.java
@@ -15,6 +15,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
 import io.obswebsocket.community.client.authenticator.Authenticator;
 import io.obswebsocket.community.client.listener.event.OBSEventListener;
 import io.obswebsocket.community.client.listener.lifecycle.ReasonThrowable;
@@ -32,15 +42,6 @@ import io.obswebsocket.community.client.message.response.RequestBatchResponse;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.message.response.general.GetVersionResponse;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import org.eclipse.jetty.websocket.api.Session;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class OBSCommunicatorTest extends AbstractSerializationTest {
 
@@ -56,11 +57,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     MessageTranslator messageTranslator = mock(MessageTranslator.class);
     OBSCommunicator obsCommunicator = spy(new OBSCommunicator(
-        messageTranslator,
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            messageTranslator,
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     ));
 
     // and given a session is established
@@ -76,7 +77,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getThrowable()).isInstanceOf(IllegalStateException.class);
     assertThat(captor.getValue().getThrowable())
-        .hasMessage("Server doesn't support this client's RPC version");
+            .hasMessage("Server doesn't support this client's RPC version");
   }
 
   @Test
@@ -84,13 +85,13 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given the communicator is listening for errors
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .lifecycle()
-        .onError((reasonThrowable) -> {
-          System.out.println(reasonThrowable);
-          actualTestResult.set(reasonThrowable.getReason());
-        })
-        .and()
-        .build();
+                                               .lifecycle()
+                                               .onError((reasonThrowable) -> {
+                                                 System.out.println(reasonThrowable);
+                                                 actualTestResult.set(reasonThrowable.getReason());
+                                               })
+                                               .and()
+                                               .build();
 
     // When a null message is supplied
     String message = null;
@@ -98,7 +99,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Then an error will have been received
     assertThat(actualTestResult.get())
-        .containsIgnoringCase("Received message was deserializable but had unknown format");
+            .containsIgnoringCase("Received message was deserializable but had unknown format");
   }
 
   @Test
@@ -106,10 +107,10 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given the communicator is listening for errors
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .lifecycle()
-        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
-        .and()
-        .build();
+                                               .lifecycle()
+                                               .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+                                               .and()
+                                               .build();
 
     // When an invalid JSON message is supplied
     String message = "{x}";
@@ -125,10 +126,10 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given the communicator is listening for errors
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .lifecycle()
-        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
-        .and()
-        .build();
+                                               .lifecycle()
+                                               .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+                                               .and()
+                                               .build();
 
     // When a serializable (but unrecognized) object is supplied
     String message = "x";
@@ -137,7 +138,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Then an error will be triggered
     assertEquals("Received message was deserializable but had unknown format",
-        actualTestResult.get());
+            actualTestResult.get());
   }
 
   @Test
@@ -145,21 +146,21 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given the communicator is listening for errors
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .lifecycle()
-        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
-        .and()
-        .build();
+                                               .lifecycle()
+                                               .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+                                               .and()
+                                               .build();
 
     // When a valid, but unrecognized, JSON object is supplied
     String message = "{\n"
-        + "\t'op': -1\n"
-        + "}";
+            + "\t'op': -1\n"
+            + "}";
     assertTrue(isDeserializable(message));
     connector.onMessage(message);
 
     // Then an error will be triggered
     assertEquals("Received message was deserializable but had unknown format",
-        actualTestResult.get());
+            actualTestResult.get());
   }
 
   @Test
@@ -167,22 +168,22 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given the communicator is listening for errors
     AtomicReference<String> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .lifecycle()
-        .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
-        .and()
-        .build();
+                                               .lifecycle()
+                                               .onError((reasonThrowable) -> actualTestResult.set(reasonThrowable.getReason()))
+                                               .and()
+                                               .build();
 
     // When a valid, but unrecognized, JSON object is supplied
     String message = "{\n"
-        + "\t'op': 5,\n"
-        + "\t'eventType': 'SomethingGibberish'\n"
-        + "}";
+            + "\t'op': 5,\n"
+            + "\t'eventType': 'SomethingGibberish'\n"
+            + "}";
     assertTrue(isDeserializable(message));
     connector.onMessage(message);
 
     // Then an error will be triggered
     assertEquals("Received message was deserializable but had unknown format",
-        actualTestResult.get());
+            actualTestResult.get());
   }
 
   @Test
@@ -199,11 +200,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // When a message is provided to the communicator
     OBSCommunicator connector = new OBSCommunicator(
-        messageTranslator,
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        mock(ObsRequestListener.class),
-        eventListener
+            messageTranslator,
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            mock(ObsRequestListener.class),
+            eventListener
     );
     connector.onMessage("doesntmatter");
 
@@ -225,11 +226,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // And a communicator with a session
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        requestListener,
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            requestListener,
+            mock(OBSEventListener.class)
     );
     connector.onConnect(mock(Session.class, RETURNS_DEEP_STUBS));
 
@@ -246,11 +247,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a connector
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // and no session
@@ -263,7 +264,7 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     ArgumentCaptor<ReasonThrowable> captor = ArgumentCaptor.forClass(ReasonThrowable.class);
     verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getReason())
-        .isEqualTo("Could not send message; no session established");
+            .isEqualTo("Could not send message; no session established");
 
   }
 
@@ -273,11 +274,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a connector
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // and no session
@@ -285,14 +286,14 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // When a requestBatch is sent
     RequestBatch requestBatch = mock(RequestBatch.class);
-    when(requestBatch.getRequests()).thenReturn(Arrays.asList(mock(Request.class)));
+    when(requestBatch.getRequests()).thenReturn(Collections.singletonList(mock(Request.class)));
     connector.sendRequestBatch(requestBatch, mock(Consumer.class));
 
     // Then an error was invoked
     ArgumentCaptor<ReasonThrowable> captor = ArgumentCaptor.forClass(ReasonThrowable.class);
     verify(lifecycleListener).onError(captor.capture());
     assertThat(captor.getValue().getReason())
-        .isEqualTo("Could not send message; no session established");
+            .isEqualTo("Could not send message; no session established");
 
   }
 
@@ -310,11 +311,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // When a message is provided to the communicator
     OBSCommunicator connector = new OBSCommunicator(
-        messageTranslator,
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        requestListener,
-        mock(OBSEventListener.class)
+            messageTranslator,
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            requestListener,
+            mock(OBSEventListener.class)
     );
     connector.onMessage("doesntmatter");
 
@@ -336,11 +337,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // And a communicator with a session
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        requestListener,
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            requestListener,
+            mock(OBSEventListener.class)
     );
     connector.onConnect(mock(Session.class, RETURNS_DEEP_STUBS));
 
@@ -356,11 +357,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Given a connector
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // empty batch requests are invalid
@@ -393,11 +394,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // When a message is provided to the communicator
     OBSCommunicator connector = new OBSCommunicator(
-        messageTranslator,
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        requestListener,
-        mock(OBSEventListener.class)
+            messageTranslator,
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            requestListener,
+            mock(OBSEventListener.class)
     );
     connector.onMessage("doesntmatter");
 
@@ -410,30 +411,32 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a communicator
     AtomicReference<GetVersionResponse> actualTestResult = new AtomicReference<>();
     OBSCommunicator connector = OBSCommunicator.builder()
-        .build();
+                                               .build();
 
     // And a GetVersionRequest is sent through it
     GetVersionRequest getVersionRequest = GetVersionRequest.builder().build();
     try {
       connector.sendRequest(getVersionRequest,
-          getVersionResponse -> actualTestResult.set((GetVersionResponse) getVersionResponse));
+              getVersionResponse -> actualTestResult.set((GetVersionResponse) getVersionResponse));
     } catch (Exception ignored) {
     }
 
     // When a valid GetVersionResponse JSON object is supplied
     String message = "{\n"
-        + "\t'op': 7,\n"
-        + "\t'requestType': 'GetVersion',\n"
-        + "\t'requestId': '" + getVersionRequest.getRequestId() + "',\n"
-        + "\t'responseData': {\n"
-        + "\t\t'obsVersion': '27.0.0'\n"
-        + "\t}\n"
-        + "}";
+            + "  'op': 7,\n"
+            + "  'd': {\n"
+            + "    'requestType': 'GetVersion',\n"
+            + "    'requestId': '" + getVersionRequest.getRequestId() + "',\n"
+            + "    'responseData': {\n"
+            + "      'obsVersion': '27.0.0'\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
     assertTrue(isDeserializable(message));
     connector.onMessage(message);
 
     // Then we will get the response
-    assertEquals("27.0.0", actualTestResult.get().getResponseData().getObsVersion());
+    assertEquals("27.0.0", actualTestResult.get().getMessageData().getResponseData().getObsVersion());
   }
 
   @Test
@@ -441,11 +444,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Given a communicator
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        mock(CommunicatorLifecycleListener.class),
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            mock(CommunicatorLifecycleListener.class),
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // And given a session is established
@@ -457,8 +460,8 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
 
     // Then the connection is closed
     verify(session).close(
-        4000,
-        "An exception was thrown with message: some exception"
+            4000,
+            "An exception was thrown with message: some exception"
     );
 
   }
@@ -469,11 +472,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a communicator
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // And given a session is established
@@ -501,11 +504,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a communicator
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // And a session is established
@@ -525,11 +528,11 @@ class OBSCommunicatorTest extends AbstractSerializationTest {
     // Given a communicator
     CommunicatorLifecycleListener lifecycleListener = mock(CommunicatorLifecycleListener.class);
     OBSCommunicator connector = new OBSCommunicator(
-        mock(MessageTranslator.class),
-        mock(Authenticator.class),
-        lifecycleListener,
-        mock(ObsRequestListener.class),
-        mock(OBSEventListener.class)
+            mock(MessageTranslator.class),
+            mock(Authenticator.class),
+            lifecycleListener,
+            mock(ObsRequestListener.class),
+            mock(OBSEventListener.class)
     );
 
     // And a session is established

--- a/client/src/test/java/io/obswebsocket/community/client/message/event/transitions/TransitionsEventsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/event/transitions/TransitionsEventsSerializationTest.java
@@ -1,25 +1,25 @@
 package io.obswebsocket.community.client.message.event.transitions;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class TransitionsEventsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getPersistentDataRequest() {
-    TransitionStartedEvent transitionStartedEvent = new TransitionStartedEvent(
-        "transition-started");
+    TransitionStartedEvent transitionStartedEvent = new TransitionStartedEvent();
 
     String json = "{\n"
-        + "\t'op': 5,\n"
-        + "\t'd': {\n"
-        + "\t\t'eventType': 'TransitionStarted',\n"
-        + "\t\t'eventIntent': " + (1 << 4) + ",\n"
-        + "\t\t'eventData': {\n"
-        + "\t\t\t'transitionName': 'transition-started'\n"
-        + "\t\t}\n"
-        + "\t}\n"
-        + "}";
+            + "\t'op': 5,\n"
+            + "\t'd': {\n"
+            + "\t\t'eventType': 'TransitionStarted',\n"
+            + "\t\t'eventIntent': " + (1 << 4) + ",\n"
+            + "\t\t'eventData': {\n"
+            + "\t\t\t'transitionName': 'transition-started'\n"
+            + "\t\t}\n"
+            + "\t}\n"
+            + "}";
 
     assertSerializationAndDeserialization(json, transitionStartedEvent);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/event/transitions/TransitionsEventsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/event/transitions/TransitionsEventsSerializationTest.java
@@ -8,7 +8,7 @@ public class TransitionsEventsSerializationTest extends AbstractSerializationTes
 
   @Test
   void getPersistentDataRequest() {
-    TransitionStartedEvent transitionStartedEvent = new TransitionStartedEvent();
+    TransitionStartedEvent transitionStartedEvent = new TransitionStartedEvent(TransitionEvent.SpecificData.builder().transitionName("transition-started").build());
 
     String json = "{\n"
             + "\t'op': 5,\n"

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/RequestSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/RequestSerializationTest.java
@@ -2,11 +2,13 @@ package io.obswebsocket.community.client.message.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
-import io.obswebsocket.community.client.message.request.general.SleepRequest;
 import java.util.Arrays;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
+import io.obswebsocket.community.client.message.request.general.SleepRequest;
 
 public class RequestSerializationTest extends AbstractSerializationTest {
 
@@ -16,7 +18,7 @@ public class RequestSerializationTest extends AbstractSerializationTest {
     assertThat(deserializeTo("{}", Request.class)).isNull();
     assertThat(deserializeTo("{'op':6}", Request.class)).isNull();
     assertThat(deserializeTo("{'op':6, 'requestType':'SomethingGibberish'}",
-        Request.class)).isNull();
+            Request.class)).isNull();
   }
 
   @Test
@@ -24,31 +26,31 @@ public class RequestSerializationTest extends AbstractSerializationTest {
     SleepRequest sleepRequest1000 = SleepRequest.builder().sleepMillis(1000L).build();
     SleepRequest sleepRequest2000 = SleepRequest.builder().sleepMillis(2000L).build();
     RequestBatch requestBatch = RequestBatch.builder().haltOnFailure(false)
-        .requests(Arrays.asList(sleepRequest1000, sleepRequest2000)).build();
+                                            .requests(Arrays.asList(sleepRequest1000, sleepRequest2000)).build();
 
     String json = "{\n" +
-        "  'requestId': " + requestBatch.getRequestId() + ",\n" +
-        "  'haltOnFailure': false,\n" +
-        "  'requests': [\n" +
-        "    {\n" +
-        "      'requestData': {\n" +
-        "        'sleepMillis': 1000\n" +
-        "      },\n" +
-        "      'requestType': 'Sleep',\n" +
-        "      'requestId': " + sleepRequest1000.getRequestId() + ",\n" +
-        "      'op': 6\n" +
-        "    },\n" +
-        "    {\n" +
-        "      'requestData': {\n" +
-        "        'sleepMillis': 2000\n" +
-        "      },\n" +
-        "      'requestType': 'Sleep',\n" +
-        "      'requestId': " + sleepRequest2000.getRequestId() + ",\n" +
-        "      'op': 6\n" +
-        "    }\n" +
-        "  ],\n" +
-        "  'op': 8\n" +
-        "}";
+            "  'requestId': " + requestBatch.getRequestId() + ",\n" +
+            "  'haltOnFailure': false,\n" +
+            "  'requests': [\n" +
+            "    {'d': {\n" +
+            "      'requestData': {\n" +
+            "        'sleepMillis': 1000\n" +
+            "      },\n" +
+            "      'requestType': 'Sleep',\n" +
+            "      'requestId': " + sleepRequest1000.getRequestId() + "},\n" +
+            "      'op': 6\n" +
+            "    },\n" +
+            "    {'d': {\n" +
+            "      'requestData': {\n" +
+            "        'sleepMillis': 2000\n" +
+            "      },\n" +
+            "      'requestType': 'Sleep',\n" +
+            "      'requestId': " + sleepRequest2000.getRequestId() + "},\n" +
+            "      'op': 6\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  'op': 8\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, requestBatch);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/filters/FiltersRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/filters/FiltersRequestsSerializationTest.java
@@ -32,7 +32,7 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
                                                                                    .filterSettings(filterSettings)
                                                                                    .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'filterName': 'Filter Name',\n" +
             "\t\t'filterIndex': 3,\n" +
@@ -45,7 +45,7 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'CreateSourceFilter',\n" +
-            "\t'requestId': " + createSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + createSourceFilterRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -93,13 +93,13 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
                                                                           .filterName("Filter Name")
                                                                           .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'filterName': 'Filter Name',\n" +
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'GetSourceFilter',\n" +
-            "\t'requestId': " + getSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getSourceFilterRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -112,12 +112,12 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
                                                                                       .sourceName("Source name")
                                                                                       .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'GetSourceFilterList',\n" +
-            "\t'requestId': " + getSourceFilterListRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getSourceFilterListRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -131,13 +131,13 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
                                                                                    .filterName("Filter name")
                                                                                    .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'filterName': 'Filter name',\n" +
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'RemoveSourceFilter',\n" +
-            "\t'requestId': " + removeSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + removeSourceFilterRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -153,14 +153,14 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
             .filterEnabled(false)
             .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'filterName': 'Filter name',\n" +
             "\t\t'filterEnabled': false,\n" +
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'SetSourceFilterEnabled',\n" +
-            "\t'requestId': " + setSourceFilterEnabledRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setSourceFilterEnabledRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -181,7 +181,7 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
             .filterSettings(filterSettings)
             .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'filterName': 'Filter name',\n" +
             "\t\t'filterSettings': {\n" +
@@ -192,7 +192,7 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
             "\t\t'sourceName': 'Source name'\n" +
             "\t},\n" +
             "\t'requestType': 'SetSourceFilterSettings',\n" +
-            "\t'requestId': " + setSourceFilterSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setSourceFilterSettingsRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/filters/FiltersRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/filters/FiltersRequestsSerializationTest.java
@@ -3,15 +3,17 @@ package io.obswebsocket.community.client.message.request.filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import io.obswebsocket.community.client.message.Message.OperationCode;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.translator.GsonMessageTranslator;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import org.json.JSONException;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class FiltersRequestsSerializationTest extends AbstractSerializationTest {
 
@@ -23,55 +25,55 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
     filterSettings.addProperty("randomIntegerSetting", 113);
 
     CreateSourceFilterRequest createSourceFilterRequest = CreateSourceFilterRequest.builder()
-        .sourceName("Source name")
-        .filterName("Filter Name")
-        .filterIndex(3)
-        .filterKind("Filter kind")
-        .filterSettings(filterSettings)
-        .build();
+                                                                                   .sourceName("Source name")
+                                                                                   .filterName("Filter Name")
+                                                                                   .filterIndex(3)
+                                                                                   .filterKind("Filter kind")
+                                                                                   .filterSettings(filterSettings)
+                                                                                   .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filterName': 'Filter Name',\n" +
-        "\t\t'filterIndex': 3,\n" +
-        "\t\t'filterKind': 'Filter kind',\n" +
-        "\t\t'filterSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': false,\n" +
-        "\t\t\t'randomIntegerSetting': 113\n" +
-        "\t\t},\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'CreateSourceFilter',\n" +
-        "\t'requestId': " + createSourceFilterRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'filterName': 'Filter Name',\n" +
+            "\t\t'filterIndex': 3,\n" +
+            "\t\t'filterKind': 'Filter kind',\n" +
+            "\t\t'filterSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': false,\n" +
+            "\t\t\t'randomIntegerSetting': 113\n" +
+            "\t\t},\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'CreateSourceFilter',\n" +
+            "\t'requestId': " + createSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     CreateSourceFilterRequest actualObject = translator
-        .fromJson(json, CreateSourceFilterRequest.class);
+            .fromJson(json, CreateSourceFilterRequest.class);
 
-    assertThat(actualObject.getRequestData().getSourceName())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getSourceName());
-    assertThat(actualObject.getRequestData().getFilterName())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getFilterName());
-    assertThat(actualObject.getRequestData().getFilterIndex())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getFilterIndex());
-    assertThat(actualObject.getRequestData().getFilterKind())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getFilterKind());
+    assertThat(actualObject.getData().getRequestData().getSourceName())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getSourceName());
+    assertThat(actualObject.getData().getRequestData().getFilterName())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getFilterName());
+    assertThat(actualObject.getData().getRequestData().getFilterIndex())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getFilterIndex());
+    assertThat(actualObject.getData().getRequestData().getFilterKind())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getFilterKind());
     assertThat(
-        actualObject.getRequestData().getFilterSettings().get("randomStringSetting").getAsString())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getFilterSettings()
-            .get("randomStringSetting").getAsString());
-    assertThat(actualObject.getRequestData().getFilterSettings().get("randomBooleanSetting")
-        .getAsBoolean()).isEqualTo(
-        createSourceFilterRequest.getRequestData().getFilterSettings().get("randomBooleanSetting")
-            .getAsBoolean());
+            actualObject.getData().getRequestData().getFilterSettings().get("randomStringSetting").getAsString())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getFilterSettings()
+                                                .get("randomStringSetting").getAsString());
+    assertThat(actualObject.getData().getRequestData().getFilterSettings().get("randomBooleanSetting")
+                           .getAsBoolean()).isEqualTo(
+            createSourceFilterRequest.getData().getRequestData().getFilterSettings().get("randomBooleanSetting")
+                                     .getAsBoolean());
     assertThat(
-        actualObject.getRequestData().getFilterSettings().get("randomIntegerSetting").getAsInt())
-        .isEqualTo(createSourceFilterRequest.getRequestData().getFilterSettings()
-            .get("randomIntegerSetting").getAsInt());
+            actualObject.getData().getRequestData().getFilterSettings().get("randomIntegerSetting").getAsInt())
+            .isEqualTo(createSourceFilterRequest.getData().getRequestData().getFilterSettings()
+                                                .get("randomIntegerSetting").getAsInt());
     assertThat(actualObject.getRequestId()).isEqualTo(createSourceFilterRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.CreateSourceFilter);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
@@ -87,19 +89,19 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void getSourceFilterRequest() {
     GetSourceFilterRequest getSourceFilterRequest = GetSourceFilterRequest.builder()
-        .sourceName("Source name")
-        .filterName("Filter Name")
-        .build();
+                                                                          .sourceName("Source name")
+                                                                          .filterName("Filter Name")
+                                                                          .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filterName': 'Filter Name',\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSourceFilter',\n" +
-        "\t'requestId': " + getSourceFilterRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'filterName': 'Filter Name',\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSourceFilter',\n" +
+            "\t'requestId': " + getSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSourceFilterRequest);
   }
@@ -107,17 +109,17 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void getSourceFilterListRequest() {
     GetSourceFilterListRequest getSourceFilterListRequest = GetSourceFilterListRequest.builder()
-        .sourceName("Source name")
-        .build();
+                                                                                      .sourceName("Source name")
+                                                                                      .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSourceFilterList',\n" +
-        "\t'requestId': " + getSourceFilterListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSourceFilterList',\n" +
+            "\t'requestId': " + getSourceFilterListRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSourceFilterListRequest);
   }
@@ -125,19 +127,19 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void removeSourceFilterRequest() {
     RemoveSourceFilterRequest removeSourceFilterRequest = RemoveSourceFilterRequest.builder()
-        .sourceName("Source name")
-        .filterName("Filter name")
-        .build();
+                                                                                   .sourceName("Source name")
+                                                                                   .filterName("Filter name")
+                                                                                   .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filterName': 'Filter name',\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'RemoveSourceFilter',\n" +
-        "\t'requestId': " + removeSourceFilterRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'filterName': 'Filter name',\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'RemoveSourceFilter',\n" +
+            "\t'requestId': " + removeSourceFilterRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, removeSourceFilterRequest);
   }
@@ -145,22 +147,22 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void setSourceFilterEnabledRequest() {
     SetSourceFilterEnabledRequest setSourceFilterEnabledRequest = SetSourceFilterEnabledRequest
-        .builder()
-        .sourceName("Source name")
-        .filterName("Filter name")
-        .filterEnabled(false)
-        .build();
+            .builder()
+            .sourceName("Source name")
+            .filterName("Filter name")
+            .filterEnabled(false)
+            .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filterName': 'Filter name',\n" +
-        "\t\t'filterEnabled': false,\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSourceFilterEnabled',\n" +
-        "\t'requestId': " + setSourceFilterEnabledRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'filterName': 'Filter name',\n" +
+            "\t\t'filterEnabled': false,\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSourceFilterEnabled',\n" +
+            "\t'requestId': " + setSourceFilterEnabledRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSourceFilterEnabledRequest);
   }
@@ -173,50 +175,50 @@ public class FiltersRequestsSerializationTest extends AbstractSerializationTest 
     filterSettings.addProperty("randomIntegerSetting", 1);
 
     SetSourceFilterSettingsRequest setSourceFilterSettingsRequest = SetSourceFilterSettingsRequest
-        .builder()
-        .sourceName("Source name")
-        .filterName("Filter name")
-        .filterSettings(filterSettings)
-        .build();
+            .builder()
+            .sourceName("Source name")
+            .filterName("Filter name")
+            .filterSettings(filterSettings)
+            .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filterName': 'Filter name',\n" +
-        "\t\t'filterSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': false,\n" +
-        "\t\t\t'randomIntegerSetting': 1\n" +
-        "\t\t},\n" +
-        "\t\t'sourceName': 'Source name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSourceFilterSettings',\n" +
-        "\t'requestId': " + setSourceFilterSettingsRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'filterName': 'Filter name',\n" +
+            "\t\t'filterSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': false,\n" +
+            "\t\t\t'randomIntegerSetting': 1\n" +
+            "\t\t},\n" +
+            "\t\t'sourceName': 'Source name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSourceFilterSettings',\n" +
+            "\t'requestId': " + setSourceFilterSettingsRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     SetSourceFilterSettingsRequest actualObject = translator
-        .fromJson(json, SetSourceFilterSettingsRequest.class);
+            .fromJson(json, SetSourceFilterSettingsRequest.class);
 
-    assertThat(actualObject.getRequestData().getSourceName())
-        .isEqualTo(setSourceFilterSettingsRequest.getRequestData().getSourceName());
-    assertThat(actualObject.getRequestData().getFilterName())
-        .isEqualTo(setSourceFilterSettingsRequest.getRequestData().getFilterName());
+    assertThat(actualObject.getData().getRequestData().getSourceName())
+            .isEqualTo(setSourceFilterSettingsRequest.getData().getRequestData().getSourceName());
+    assertThat(actualObject.getData().getRequestData().getFilterName())
+            .isEqualTo(setSourceFilterSettingsRequest.getData().getRequestData().getFilterName());
     assertThat(
-        actualObject.getRequestData().getFilterSettings().get("randomStringSetting").getAsString())
-        .isEqualTo(setSourceFilterSettingsRequest.getRequestData().getFilterSettings()
-            .get("randomStringSetting").getAsString());
-    assertThat(actualObject.getRequestData().getFilterSettings().get("randomBooleanSetting")
-        .getAsBoolean()).isEqualTo(
-        setSourceFilterSettingsRequest.getRequestData().getFilterSettings()
-            .get("randomBooleanSetting").getAsBoolean());
+            actualObject.getData().getRequestData().getFilterSettings().get("randomStringSetting").getAsString())
+            .isEqualTo(setSourceFilterSettingsRequest.getData().getRequestData().getFilterSettings()
+                                                     .get("randomStringSetting").getAsString());
+    assertThat(actualObject.getData().getRequestData().getFilterSettings().get("randomBooleanSetting")
+                           .getAsBoolean()).isEqualTo(
+            setSourceFilterSettingsRequest.getData().getRequestData().getFilterSettings()
+                                          .get("randomBooleanSetting").getAsBoolean());
     assertThat(
-        actualObject.getRequestData().getFilterSettings().get("randomIntegerSetting").getAsInt())
-        .isEqualTo(setSourceFilterSettingsRequest.getRequestData().getFilterSettings()
-            .get("randomIntegerSetting").getAsInt());
+            actualObject.getData().getRequestData().getFilterSettings().get("randomIntegerSetting").getAsInt())
+            .isEqualTo(setSourceFilterSettingsRequest.getData().getRequestData().getFilterSettings()
+                                                     .get("randomIntegerSetting").getAsInt());
     assertThat(actualObject.getRequestId())
-        .isEqualTo(setSourceFilterSettingsRequest.getRequestId());
+            .isEqualTo(setSourceFilterSettingsRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.SetSourceFilterSettings);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
     try {

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/general/GeneralRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/general/GeneralRequestsSerializationTest.java
@@ -23,9 +23,9 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   void getVersionRequest() {
     GetVersionRequest getVersionRequest = GetVersionRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetVersion',\n" +
-            "\t'requestId': " + getVersionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getVersionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -42,14 +42,14 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     BroadcastCustomEventRequest broadcastCustomEventRequest = BroadcastCustomEventRequest.builder()
                                                                                          .requestData(eventData).build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'customEventType': 'customEvent',\n" +
             "\t\t'boolean': true,\n" +
             "\t\t'integer': 10\n" +
             "\t},\n" +
             "\t'requestType': 'BroadcastCustomEvent',\n" +
-            "\t'requestId': " + broadcastCustomEventRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + broadcastCustomEventRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -80,9 +80,9 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   void getSystemStatsRequest() {
     GetSystemStatsRequest getSystemStatsRequest = GetSystemStatsRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetSystemStats',\n" +
-            "\t'requestId': " + getSystemStatsRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getSystemStatsRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -93,9 +93,9 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   void getHotkeyListRequest() {
     GetHotkeyListRequest getHotkeyListRequest = GetHotkeyListRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetHotkeyList',\n" +
-            "\t'requestId': " + getHotkeyListRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getHotkeyListRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -107,9 +107,9 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     GetStudioModeEnabledRequest getStudioModeEnabledRequest = GetStudioModeEnabledRequest.builder()
                                                                                          .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetStudioModeEnabled',\n" +
-            "\t'requestId': " + getStudioModeEnabledRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getStudioModeEnabledRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}\n";
 
@@ -120,9 +120,9 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   void getProjectorListRequest() {
     GetProjectorListRequest getProjectorListRequest = GetProjectorListRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetProjectorList',\n" +
-            "\t'requestId': " + getProjectorListRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getProjectorListRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}\n";
 
@@ -138,7 +138,7 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
                                                                     .sourceName("Source String name")
                                                                     .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'projectorType': 'MULTIVIEW',\n" +
             "\t\t'projectorMonitor': 1,\n" +
@@ -146,7 +146,7 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
             "\t\t'sourceName': 'Source String name'\n" +
             "\t},\n" +
             "\t'requestType': 'OpenProjector',\n" +
-            "\t'requestId': " + openProjectorRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + openProjectorRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -159,12 +159,12 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
                                                                        .projectorName("projector 1")
                                                                        .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'projectorName': 'projector 1'\n" +
             "\t},\n" +
             "\t'requestType': 'CloseProjector',\n" +
-            "\t'requestId': " + closeProjectorRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + closeProjectorRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -176,12 +176,12 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     SetStudioModeEnabledRequest setStudioModeEnabledRequest = SetStudioModeEnabledRequest.builder()
                                                                                          .studioModeEnabled(false).build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'studioModeEnabled': false\n" +
             "\t},\n" +
             "\t'requestType': 'SetStudioModeEnabled',\n" +
-            "\t'requestId': " + setStudioModeEnabledRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setStudioModeEnabledRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -192,12 +192,12 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   void sleepRequest() {
     SleepRequest sleepRequest1000 = SleepRequest.builder().sleepMillis(1000L).build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'sleepMillis': 1000\n" +
             "\t},\n" +
             "\t'requestType': 'Sleep',\n" +
-            "\t'requestId': " + sleepRequest1000.getRequestId() + ",\n" +
+            "\t'requestId': " + sleepRequest1000.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -211,12 +211,12 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     TriggerHotkeyByNameRequest triggerHotkeyByNameRequest = TriggerHotkeyByNameRequest.builder()
                                                                                       .hotkeyName("Hotkey").build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'hotkeyName': 'Hotkey'\n" +
             "\t},\n" +
             "\t'requestType': 'TriggerHotkeyByName',\n" +
-            "\t'requestId': " + triggerHotkeyByNameRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + triggerHotkeyByNameRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -234,7 +234,7 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
                                                                         .build()
             ).build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'keyId': 'KeyId1',\n" +
             "\t\t'keyModifiers': {\n" +
@@ -245,7 +245,7 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
             "\t\t}\n" +
             "\t},\n" +
             "\t'requestType': 'TriggerHotkeyByName',\n" +
-            "\t'requestId': " + triggerHotkeyByKeySequenceRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + triggerHotkeyByKeySequenceRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/general/GeneralRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/general/GeneralRequestsSerializationTest.java
@@ -3,17 +3,19 @@ package io.obswebsocket.community.client.message.request.general;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.assertj.core.api.Assertions;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import io.obswebsocket.community.client.message.Message.OperationCode;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.model.Projector;
 import io.obswebsocket.community.client.translator.GsonMessageTranslator;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import org.assertj.core.api.Assertions;
-import org.json.JSONException;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class GeneralRequestsSerializationTest extends AbstractSerializationTest {
 
@@ -22,10 +24,10 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     GetVersionRequest getVersionRequest = GetVersionRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetVersion',\n" +
-        "\t'requestId': " + getVersionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetVersion',\n" +
+            "\t'requestId': " + getVersionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getVersionRequest);
   }
@@ -38,31 +40,31 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     eventData.addProperty("integer", 10);
 
     BroadcastCustomEventRequest broadcastCustomEventRequest = BroadcastCustomEventRequest.builder()
-        .requestData(eventData).build();
+                                                                                         .requestData(eventData).build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'customEventType': 'customEvent',\n" +
-        "\t\t'boolean': true,\n" +
-        "\t\t'integer': 10\n" +
-        "\t},\n" +
-        "\t'requestType': 'BroadcastCustomEvent',\n" +
-        "\t'requestId': " + broadcastCustomEventRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'customEventType': 'customEvent',\n" +
+            "\t\t'boolean': true,\n" +
+            "\t\t'integer': 10\n" +
+            "\t},\n" +
+            "\t'requestType': 'BroadcastCustomEvent',\n" +
+            "\t'requestId': " + broadcastCustomEventRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     BroadcastCustomEventRequest actualObject = translator
-        .fromJson(json, BroadcastCustomEventRequest.class);
-    assertThat(actualObject.getRequestData().get("customEventType").getAsString())
-        .isEqualTo("customEvent");
-    assertThat(actualObject.getRequestData().get("boolean").getAsBoolean()).isEqualTo(true);
-    assertThat(actualObject.getRequestData().get("integer").getAsInt()).isEqualTo(10);
+            .fromJson(json, BroadcastCustomEventRequest.class);
+    assertThat(actualObject.getData().getRequestData().get("customEventType").getAsString())
+            .isEqualTo("customEvent");
+    assertThat(actualObject.getData().getRequestData().get("boolean").getAsBoolean()).isEqualTo(true);
+    assertThat(actualObject.getData().getRequestData().get("integer").getAsInt()).isEqualTo(10);
     Assertions.assertThat(actualObject.getRequestId())
-        .isEqualTo(broadcastCustomEventRequest.getRequestId());
+              .isEqualTo(broadcastCustomEventRequest.getRequestId());
     Assertions.assertThat(actualObject.getRequestType())
-        .isEqualTo(Request.Data.Type.BroadcastCustomEvent);
+              .isEqualTo(Request.Data.Type.BroadcastCustomEvent);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
     try {
       String actualJson = translator.toJson(broadcastCustomEventRequest);
@@ -79,10 +81,10 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     GetSystemStatsRequest getSystemStatsRequest = GetSystemStatsRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetSystemStats',\n" +
-        "\t'requestId': " + getSystemStatsRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetSystemStats',\n" +
+            "\t'requestId': " + getSystemStatsRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSystemStatsRequest);
   }
@@ -92,10 +94,10 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     GetHotkeyListRequest getHotkeyListRequest = GetHotkeyListRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetHotkeyList',\n" +
-        "\t'requestId': " + getHotkeyListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetHotkeyList',\n" +
+            "\t'requestId': " + getHotkeyListRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getHotkeyListRequest);
   }
@@ -103,13 +105,13 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void getStudioModeEnabledRequest() {
     GetStudioModeEnabledRequest getStudioModeEnabledRequest = GetStudioModeEnabledRequest.builder()
-        .build();
+                                                                                         .build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetStudioModeEnabled',\n" +
-        "\t'requestId': " + getStudioModeEnabledRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}\n";
+            "\t'requestType': 'GetStudioModeEnabled',\n" +
+            "\t'requestId': " + getStudioModeEnabledRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}\n";
 
     assertSerializationAndDeserialization(json, getStudioModeEnabledRequest);
   }
@@ -119,10 +121,10 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     GetProjectorListRequest getProjectorListRequest = GetProjectorListRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetProjectorList',\n" +
-        "\t'requestId': " + getProjectorListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}\n";
+            "\t'requestType': 'GetProjectorList',\n" +
+            "\t'requestId': " + getProjectorListRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}\n";
 
     assertSerializationAndDeserialization(json, getProjectorListRequest);
   }
@@ -130,23 +132,23 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void openProjectorRequest() {
     OpenProjectorRequest openProjectorRequest = OpenProjectorRequest.builder()
-        .projectorType(Projector.Type.MULTIVIEW)
-        .projectorGeometry("GeometryString")
-        .projectorMonitor(1)
-        .sourceName("Source String name")
-        .build();
+                                                                    .projectorType(Projector.Type.MULTIVIEW)
+                                                                    .projectorGeometry("GeometryString")
+                                                                    .projectorMonitor(1)
+                                                                    .sourceName("Source String name")
+                                                                    .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'projectorType': 'MULTIVIEW',\n" +
-        "\t\t'projectorMonitor': 1,\n" +
-        "\t\t'projectorGeometry': 'GeometryString',\n" +
-        "\t\t'sourceName': 'Source String name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'OpenProjector',\n" +
-        "\t'requestId': " + openProjectorRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'projectorType': 'MULTIVIEW',\n" +
+            "\t\t'projectorMonitor': 1,\n" +
+            "\t\t'projectorGeometry': 'GeometryString',\n" +
+            "\t\t'sourceName': 'Source String name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'OpenProjector',\n" +
+            "\t'requestId': " + openProjectorRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, openProjectorRequest);
   }
@@ -154,17 +156,17 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void closeProjectorRequest() {
     CloseProjectorRequest closeProjectorRequest = CloseProjectorRequest.builder()
-        .projectorName("projector 1")
-        .build();
+                                                                       .projectorName("projector 1")
+                                                                       .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'projectorName': 'projector 1'\n" +
-        "\t},\n" +
-        "\t'requestType': 'CloseProjector',\n" +
-        "\t'requestId': " + closeProjectorRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'projectorName': 'projector 1'\n" +
+            "\t},\n" +
+            "\t'requestType': 'CloseProjector',\n" +
+            "\t'requestId': " + closeProjectorRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, closeProjectorRequest);
   }
@@ -172,16 +174,16 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void setStudioModeEnabledRequest() {
     SetStudioModeEnabledRequest setStudioModeEnabledRequest = SetStudioModeEnabledRequest.builder()
-        .studioModeEnabled(false).build();
+                                                                                         .studioModeEnabled(false).build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'studioModeEnabled': false\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetStudioModeEnabled',\n" +
-        "\t'requestId': " + setStudioModeEnabledRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'studioModeEnabled': false\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetStudioModeEnabled',\n" +
+            "\t'requestId': " + setStudioModeEnabledRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setStudioModeEnabledRequest);
   }
@@ -191,13 +193,13 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
     SleepRequest sleepRequest1000 = SleepRequest.builder().sleepMillis(1000L).build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sleepMillis': 1000\n" +
-        "\t},\n" +
-        "\t'requestType': 'Sleep',\n" +
-        "\t'requestId': " + sleepRequest1000.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'sleepMillis': 1000\n" +
+            "\t},\n" +
+            "\t'requestType': 'Sleep',\n" +
+            "\t'requestId': " + sleepRequest1000.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     Request request = deserializeTo(json, Request.class);
     assertThat(request).isNotNull();
@@ -207,16 +209,16 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void triggerHotkeyByNameRequest() {
     TriggerHotkeyByNameRequest triggerHotkeyByNameRequest = TriggerHotkeyByNameRequest.builder()
-        .hotkeyName("Hotkey").build();
+                                                                                      .hotkeyName("Hotkey").build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'hotkeyName': 'Hotkey'\n" +
-        "\t},\n" +
-        "\t'requestType': 'TriggerHotkeyByName',\n" +
-        "\t'requestId': " + triggerHotkeyByNameRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'hotkeyName': 'Hotkey'\n" +
+            "\t},\n" +
+            "\t'requestType': 'TriggerHotkeyByName',\n" +
+            "\t'requestId': " + triggerHotkeyByNameRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, triggerHotkeyByNameRequest);
   }
@@ -224,28 +226,28 @@ public class GeneralRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void triggerHotkeyByKeySequenceRequest() {
     TriggerHotkeyByKeySequenceRequest triggerHotkeyByKeySequenceRequest = TriggerHotkeyByKeySequenceRequest
-        .builder()
-        .keyId("KeyId1")
-        .keyModifiers(TriggerHotkeyByKeySequenceRequest.KeyModifiers.builder()
-            .alt(true)
-            .shift(true)
-            .build()
-        ).build();
+            .builder()
+            .keyId("KeyId1")
+            .keyModifiers(TriggerHotkeyByKeySequenceRequest.KeyModifiers.builder()
+                                                                        .alt(true)
+                                                                        .shift(true)
+                                                                        .build()
+            ).build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'keyId': 'KeyId1',\n" +
-        "\t\t'keyModifiers': {\n" +
-        "\t\t\t'shift': true,\n" +
-        "\t\t\t'alt': true,\n" +
-        "\t\t\t'control': false,\n" +
-        "\t\t\t'command': false\n" +
-        "\t\t}\n" +
-        "\t},\n" +
-        "\t'requestType': 'TriggerHotkeyByName',\n" +
-        "\t'requestId': " + triggerHotkeyByKeySequenceRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'keyId': 'KeyId1',\n" +
+            "\t\t'keyModifiers': {\n" +
+            "\t\t\t'shift': true,\n" +
+            "\t\t\t'alt': true,\n" +
+            "\t\t\t'control': false,\n" +
+            "\t\t\t'command': false\n" +
+            "\t\t}\n" +
+            "\t},\n" +
+            "\t'requestType': 'TriggerHotkeyByName',\n" +
+            "\t'requestId': " + triggerHotkeyByKeySequenceRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, triggerHotkeyByKeySequenceRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/inputs/InputsRequestSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/inputs/InputsRequestSerializationTest.java
@@ -3,16 +3,18 @@ package io.obswebsocket.community.client.message.request.inputs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import io.obswebsocket.community.client.message.Message.OperationCode;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.model.Input;
 import io.obswebsocket.community.client.translator.GsonMessageTranslator;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import org.json.JSONException;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
@@ -24,54 +26,54 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
     inputSettings.addProperty("randomIntegerSetting", 32);
 
     CreateInputRequest createInputRequest = CreateInputRequest.builder()
-        .inputName("Mic Input")
-        .inputKind("input kind")
-        .sceneName("scene")
-        .inputSettings(inputSettings)
-        .sceneItemEnabled(true)
-        .build();
+                                                              .inputName("Mic Input")
+                                                              .inputKind("input kind")
+                                                              .sceneName("scene")
+                                                              .inputSettings(inputSettings)
+                                                              .sceneItemEnabled(true)
+                                                              .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'CreateInput',\n" +
-        "\t'requestId': " + createInputRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputKind': 'input kind',\n" +
-        "\t\t'sceneName': 'scene',\n" +
-        "\t\t'inputSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': false,\n" +
-        "\t\t\t'randomIntegerSetting': 32\n" +
-        "\t\t},\n" +
-        "\t\t'sceneItemEnabled': true,\n" +
-        "\t\t'inputName': 'Mic Input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'CreateInput',\n" +
+            "\t'requestId': " + createInputRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputKind': 'input kind',\n" +
+            "\t\t'sceneName': 'scene',\n" +
+            "\t\t'inputSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': false,\n" +
+            "\t\t\t'randomIntegerSetting': 32\n" +
+            "\t\t},\n" +
+            "\t\t'sceneItemEnabled': true,\n" +
+            "\t\t'inputName': 'Mic Input'\n" +
+            "\t}\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     CreateInputRequest actualObject = translator.fromJson(json, CreateInputRequest.class);
 
-    assertThat(actualObject.getRequestData().getInputKind())
-        .isEqualTo(createInputRequest.getRequestData().getInputKind());
-    assertThat(actualObject.getRequestData().getSceneName())
-        .isEqualTo(createInputRequest.getRequestData().getSceneName());
-    assertThat(actualObject.getRequestData().getSceneItemEnabled())
-        .isEqualTo(createInputRequest.getRequestData().getSceneItemEnabled());
+    assertThat(actualObject.getData().getRequestData().getInputKind())
+            .isEqualTo(createInputRequest.getData().getRequestData().getInputKind());
+    assertThat(actualObject.getData().getRequestData().getSceneName())
+            .isEqualTo(createInputRequest.getData().getRequestData().getSceneName());
+    assertThat(actualObject.getData().getRequestData().getSceneItemEnabled())
+            .isEqualTo(createInputRequest.getData().getRequestData().getSceneItemEnabled());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomStringSetting").getAsString())
-        .isEqualTo(createInputRequest.getRequestData().getInputSettings().get("randomStringSetting")
-            .getAsString());
+            actualObject.getData().getRequestData().getInputSettings().get("randomStringSetting").getAsString())
+            .isEqualTo(createInputRequest.getData().getRequestData().getInputSettings().get("randomStringSetting")
+                                         .getAsString());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomBooleanSetting").getAsBoolean())
-        .isEqualTo(
-            createInputRequest.getRequestData().getInputSettings().get("randomBooleanSetting")
-                .getAsBoolean());
+            actualObject.getData().getRequestData().getInputSettings().get("randomBooleanSetting").getAsBoolean())
+            .isEqualTo(
+                    createInputRequest.getData().getRequestData().getInputSettings().get("randomBooleanSetting")
+                                      .getAsBoolean());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomIntegerSetting").getAsInt())
-        .isEqualTo(
-            createInputRequest.getRequestData().getInputSettings().get("randomIntegerSetting")
-                .getAsInt());
+            actualObject.getData().getRequestData().getInputSettings().get("randomIntegerSetting").getAsInt())
+            .isEqualTo(
+                    createInputRequest.getData().getRequestData().getInputSettings().get("randomIntegerSetting")
+                                      .getAsInt());
     assertThat(actualObject.getRequestId()).isEqualTo(createInputRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.CreateInput);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
@@ -87,18 +89,18 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputDefaultSettings() {
     GetInputDefaultSettingsRequest getInputDefaultSettingsRequest = GetInputDefaultSettingsRequest
-        .builder()
-        .inputKind("input kind")
-        .build();
+            .builder()
+            .inputKind("input kind")
+            .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputDefaultSettings',\n" +
-        "\t'requestId': " + getInputDefaultSettingsRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputKind': 'input kind'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputDefaultSettings',\n" +
+            "\t'requestId': " + getInputDefaultSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputKind': 'input kind'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputDefaultSettingsRequest);
   }
@@ -106,17 +108,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputListRequest() {
     GetInputListRequest getInputListRequest = GetInputListRequest.builder()
-        .inputKind("input kind")
-        .build();
+                                                                 .inputKind("input kind")
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputList',\n" +
-        "\t'requestId': " + getInputListRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputKind': 'input kind'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputList',\n" +
+            "\t'requestId': " + getInputListRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputKind': 'input kind'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputListRequest);
   }
@@ -124,17 +126,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputKindListRequest() {
     GetInputKindListRequest getInputKindListRequest = GetInputKindListRequest.builder()
-        .unversioned(false)
-        .build();
+                                                                             .unversioned(false)
+                                                                             .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputKindList',\n" +
-        "\t'requestId': " + getInputKindListRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'unversioned': false\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputKindList',\n" +
+            "\t'requestId': " + getInputKindListRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'unversioned': false\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputKindListRequest);
   }
@@ -142,17 +144,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputAudioMonitorTypeRequest() {
     GetInputAudioMonitorTypeRequest getInputAudioMonitorTypeRequest = GetInputAudioMonitorTypeRequest.builder()
-        .inputName("input")
-        .build();
+                                                                                                     .inputName("input")
+                                                                                                     .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputAudioMonitorType',\n" +
-        "\t'requestId': " + getInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputAudioMonitorType',\n" +
+            "\t'requestId': " + getInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputAudioMonitorTypeRequest);
   }
@@ -160,17 +162,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputMuteRequest() {
     GetInputMuteRequest getInputMuteRequest = GetInputMuteRequest.builder()
-        .inputName("input")
-        .build();
+                                                                 .inputName("input")
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputMute',\n" +
-        "\t'requestId': " + getInputMuteRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputMute',\n" +
+            "\t'requestId': " + getInputMuteRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputMuteRequest);
   }
@@ -178,17 +180,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputSettingsRequest() {
     GetInputSettingsRequest getInputSettingsRequest = GetInputSettingsRequest.builder()
-        .inputName("input")
-        .build();
+                                                                             .inputName("input")
+                                                                             .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputSettings',\n" +
-        "\t'requestId': " + getInputSettingsRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputSettings',\n" +
+            "\t'requestId': " + getInputSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputSettingsRequest);
   }
@@ -196,17 +198,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputAudioTracksRequest() {
     GetInputAudioTracksRequest getInputAudioTracks = GetInputAudioTracksRequest.builder()
-        .inputName("input")
-        .build();
+                                                                               .inputName("input")
+                                                                               .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputAudioTracks',\n" +
-        "\t'requestId': " + getInputAudioTracks.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputAudioTracks',\n" +
+            "\t'requestId': " + getInputAudioTracks.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputAudioTracks);
   }
@@ -214,17 +216,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void getInputVolumeRequest() {
     GetInputVolumeRequest getInputVolumeRequest = GetInputVolumeRequest.builder()
-        .inputName("input")
-        .build();
+                                                                       .inputName("input")
+                                                                       .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetInputVolume',\n" +
-        "\t'requestId': " + getInputVolumeRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'GetInputVolume',\n" +
+            "\t'requestId': " + getInputVolumeRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getInputVolumeRequest);
   }
@@ -232,19 +234,19 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void setInputAudioMonitorTypeRequest() {
     SetInputAudioMonitorTypeRequest setInputAudioMonitorTypeRequest = SetInputAudioMonitorTypeRequest.builder()
-        .inputName("input")
-        .monitorType(Input.MonitorType.MONITOR_AND_OUTPUT)
-        .build();
+                                                                                                     .inputName("input")
+                                                                                                     .monitorType(Input.MonitorType.MONITOR_AND_OUTPUT)
+                                                                                                     .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetInputAudioMonitorType',\n" +
-        "\t'requestId': " + setInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'monitorType': 'monitorAndOutput',\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'SetInputAudioMonitorType',\n" +
+            "\t'requestId': " + setInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'monitorType': 'monitorAndOutput',\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setInputAudioMonitorTypeRequest);
   }
@@ -252,19 +254,19 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void setInputMuteRequest() {
     SetInputMuteRequest setInputMuteRequest = SetInputMuteRequest.builder()
-        .inputName("input")
-        .inputMuted(true)
-        .build();
+                                                                 .inputName("input")
+                                                                 .inputMuted(true)
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetInputMute',\n" +
-        "\t'requestId': " + setInputMuteRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputMuted': true,\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'SetInputMute',\n" +
+            "\t'requestId': " + setInputMuteRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputMuted': true,\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setInputMuteRequest);
   }
@@ -272,19 +274,19 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void setInputNameRequest() {
     SetInputNameRequest setInputNameRequest = SetInputNameRequest.builder()
-        .inputName("input")
-        .newInputName("awesome new input name")
-        .build();
+                                                                 .inputName("input")
+                                                                 .newInputName("awesome new input name")
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetInputName',\n" +
-        "\t'requestId': " + setInputNameRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'newInputName': 'awesome new input name',\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'SetInputName',\n" +
+            "\t'requestId': " + setInputNameRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'newInputName': 'awesome new input name',\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setInputNameRequest);
   }
@@ -297,49 +299,49 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
     inputSettings.addProperty("randomIntegerSetting", 18);
 
     SetInputSettingsRequest setInputSettingsRequest = SetInputSettingsRequest.builder()
-        .inputName("input")
-        .inputSettings(inputSettings)
-        .overlay(true)
-        .build();
+                                                                             .inputName("input")
+                                                                             .inputSettings(inputSettings)
+                                                                             .overlay(true)
+                                                                             .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetInputSettings',\n" +
-        "\t'requestId': " + setInputSettingsRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': true,\n" +
-        "\t\t\t'randomIntegerSetting': 18\n" +
-        "\t\t},\n" +
-        "\t\t'overlay': true,\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'SetInputSettings',\n" +
+            "\t'requestId': " + setInputSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': true,\n" +
+            "\t\t\t'randomIntegerSetting': 18\n" +
+            "\t\t},\n" +
+            "\t\t'overlay': true,\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     SetInputSettingsRequest actualObject = translator.fromJson(json, SetInputSettingsRequest.class);
 
-    assertThat(actualObject.getRequestData().getInputName())
-        .isEqualTo(setInputSettingsRequest.getRequestData().getInputName());
-    assertThat(actualObject.getRequestData().getOverlay())
-        .isEqualTo(setInputSettingsRequest.getRequestData().getOverlay());
+    assertThat(actualObject.getData().getRequestData().getInputName())
+            .isEqualTo(setInputSettingsRequest.getData().getRequestData().getInputName());
+    assertThat(actualObject.getData().getRequestData().getOverlay())
+            .isEqualTo(setInputSettingsRequest.getData().getRequestData().getOverlay());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomStringSetting").getAsString())
-        .isEqualTo(
-            setInputSettingsRequest.getRequestData().getInputSettings().get("randomStringSetting")
-                .getAsString());
+            actualObject.getData().getRequestData().getInputSettings().get("randomStringSetting").getAsString())
+            .isEqualTo(
+                    setInputSettingsRequest.getData().getRequestData().getInputSettings().get("randomStringSetting")
+                                           .getAsString());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomBooleanSetting").getAsBoolean())
-        .isEqualTo(
-            setInputSettingsRequest.getRequestData().getInputSettings().get("randomBooleanSetting")
-                .getAsBoolean());
+            actualObject.getData().getRequestData().getInputSettings().get("randomBooleanSetting").getAsBoolean())
+            .isEqualTo(
+                    setInputSettingsRequest.getData().getRequestData().getInputSettings().get("randomBooleanSetting")
+                                           .getAsBoolean());
     assertThat(
-        actualObject.getRequestData().getInputSettings().get("randomIntegerSetting").getAsInt())
-        .isEqualTo(
-            setInputSettingsRequest.getRequestData().getInputSettings().get("randomIntegerSetting")
-                .getAsInt());
+            actualObject.getData().getRequestData().getInputSettings().get("randomIntegerSetting").getAsInt())
+            .isEqualTo(
+                    setInputSettingsRequest.getData().getRequestData().getInputSettings().get("randomIntegerSetting")
+                                           .getAsInt());
     assertThat(actualObject.getRequestId()).isEqualTo(setInputSettingsRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.SetInputSettings);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
@@ -355,21 +357,21 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void setInputVolumeRequest() {
     SetInputVolumeRequest setInputVolumeRequest = SetInputVolumeRequest.builder()
-        .inputName("input")
-        .inputVolumeDb(12f)
-        .inputVolumeMul(2f)
-        .build();
+                                                                       .inputName("input")
+                                                                       .inputVolumeDb(12f)
+                                                                       .inputVolumeMul(2f)
+                                                                       .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetInputVolume',\n" +
-        "\t'requestId': " + setInputVolumeRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputVolumeDb': 12.0,\n" +
-        "\t\t'inputVolumeMul': 2.0,\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'SetInputVolume',\n" +
+            "\t'requestId': " + setInputVolumeRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputVolumeDb': 12.0,\n" +
+            "\t\t'inputVolumeMul': 2.0,\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setInputVolumeRequest);
   }
@@ -377,17 +379,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void toggleInputMuteRequest() {
     ToggleInputMuteRequest toggleInputMuteRequest = ToggleInputMuteRequest.builder()
-        .inputName("input")
-        .build();
+                                                                          .inputName("input")
+                                                                          .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'ToggleInputMute',\n" +
-        "\t'requestId': " + toggleInputMuteRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'ToggleInputMute',\n" +
+            "\t'requestId': " + toggleInputMuteRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, toggleInputMuteRequest);
   }
@@ -395,17 +397,17 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
   @Test
   void removeInputRequest() {
     RemoveInputRequest removeInputRequest = RemoveInputRequest.builder()
-        .inputName("input 1")
-        .build();
+                                                              .inputName("input 1")
+                                                              .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'RemoveInput',\n" +
-        "\t'requestId': " + removeInputRequest.getRequestId() + ",\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'input 1'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'requestType': 'RemoveInput',\n" +
+            "\t'requestId': " + removeInputRequest.getRequestId() + ",\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'input 1'\n" +
+            "\t}\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, removeInputRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/inputs/InputsRequestSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/inputs/InputsRequestSerializationTest.java
@@ -35,7 +35,7 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'CreateInput',\n" +
+            "\t'd': {'requestType': 'CreateInput',\n" +
             "\t'requestId': " + createInputRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputKind': 'input kind',\n" +
@@ -47,7 +47,7 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
             "\t\t},\n" +
             "\t\t'sceneItemEnabled': true,\n" +
             "\t\t'inputName': 'Mic Input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
@@ -95,11 +95,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputDefaultSettings',\n" +
+            "\t'd': {'requestType': 'GetInputDefaultSettings',\n" +
             "\t'requestId': " + getInputDefaultSettingsRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputKind': 'input kind'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputDefaultSettingsRequest);
@@ -113,11 +113,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputList',\n" +
+            "\t'd': {'requestType': 'GetInputList',\n" +
             "\t'requestId': " + getInputListRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputKind': 'input kind'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputListRequest);
@@ -131,11 +131,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputKindList',\n" +
+            "\t'd': {'requestType': 'GetInputKindList',\n" +
             "\t'requestId': " + getInputKindListRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'unversioned': false\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputKindListRequest);
@@ -149,11 +149,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputAudioMonitorType',\n" +
+            "\t'd': {'requestType': 'GetInputAudioMonitorType',\n" +
             "\t'requestId': " + getInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputAudioMonitorTypeRequest);
@@ -167,11 +167,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputMute',\n" +
+            "\t'd': {'requestType': 'GetInputMute',\n" +
             "\t'requestId': " + getInputMuteRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputMuteRequest);
@@ -185,11 +185,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputSettings',\n" +
+            "\t'd': {'requestType': 'GetInputSettings',\n" +
             "\t'requestId': " + getInputSettingsRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputSettingsRequest);
@@ -203,11 +203,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputAudioTracks',\n" +
+            "\t'd': {'requestType': 'GetInputAudioTracks',\n" +
             "\t'requestId': " + getInputAudioTracks.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputAudioTracks);
@@ -221,11 +221,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'GetInputVolume',\n" +
+            "\t'd': {'requestType': 'GetInputVolume',\n" +
             "\t'requestId': " + getInputVolumeRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, getInputVolumeRequest);
@@ -240,12 +240,12 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'SetInputAudioMonitorType',\n" +
+            "\t'd': {'requestType': 'SetInputAudioMonitorType',\n" +
             "\t'requestId': " + setInputAudioMonitorTypeRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'monitorType': 'monitorAndOutput',\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, setInputAudioMonitorTypeRequest);
@@ -260,12 +260,12 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'SetInputMute',\n" +
+            "\t'd': {'requestType': 'SetInputMute',\n" +
             "\t'requestId': " + setInputMuteRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputMuted': true,\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, setInputMuteRequest);
@@ -280,12 +280,12 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'SetInputName',\n" +
+            "\t'd': {'requestType': 'SetInputName',\n" +
             "\t'requestId': " + setInputNameRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'newInputName': 'awesome new input name',\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, setInputNameRequest);
@@ -306,7 +306,7 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'SetInputSettings',\n" +
+            "\t'd': {'requestType': 'SetInputSettings',\n" +
             "\t'requestId': " + setInputSettingsRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputSettings': {\n" +
@@ -316,7 +316,7 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
             "\t\t},\n" +
             "\t\t'overlay': true,\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
@@ -364,13 +364,13 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'SetInputVolume',\n" +
+            "\t'd': {'requestType': 'SetInputVolume',\n" +
             "\t'requestId': " + setInputVolumeRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputVolumeDb': 12.0,\n" +
             "\t\t'inputVolumeMul': 2.0,\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, setInputVolumeRequest);
@@ -384,11 +384,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'ToggleInputMute',\n" +
+            "\t'd': {'requestType': 'ToggleInputMute',\n" +
             "\t'requestId': " + toggleInputMuteRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, toggleInputMuteRequest);
@@ -402,11 +402,11 @@ public class InputsRequestSerializationTest extends AbstractSerializationTest {
 
     String json = "{\n" +
             "\t'op': 6,\n" +
-            "\t'requestType': 'RemoveInput',\n" +
+            "\t'd': {'requestType': 'RemoveInput',\n" +
             "\t'requestId': " + removeInputRequest.getRequestId() + ",\n" +
             "\t'requestData': {\n" +
             "\t\t'inputName': 'input 1'\n" +
-            "\t}\n" +
+            "\t}}\n" +
             "}";
 
     assertSerializationAndDeserialization(json, removeInputRequest);

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/mediainputs/MediaInputRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/mediainputs/MediaInputRequestsSerializationTest.java
@@ -1,24 +1,25 @@
 package io.obswebsocket.community.client.message.request.mediainputs;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class MediaInputRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getMediaInputStatusRequest() {
     GetMediaInputStatusRequest getMediaInputStatusRequest = GetMediaInputStatusRequest.builder()
-        .inputName("Media Input")
-        .build();
+                                                                                      .inputName("Media Input")
+                                                                                      .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetMediaInputStatus',\n" +
-        "\t'requestId': " + getMediaInputStatusRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetMediaInputStatus',\n" +
+            "\t'requestId': " + getMediaInputStatusRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getMediaInputStatusRequest);
   }
@@ -26,18 +27,18 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void nextMediaInputPlaylistItemRequest() {
     NextMediaInputPlaylistItemRequest nextMediaInputPlaylistItemRequest = NextMediaInputPlaylistItemRequest
-        .builder()
-        .inputName("Media Input")
-        .build();
+            .builder()
+            .inputName("Media Input")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'NextMediaInputPlaylistItem',\n" +
-        "\t'requestId': " + nextMediaInputPlaylistItemRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'NextMediaInputPlaylistItem',\n" +
+            "\t'requestId': " + nextMediaInputPlaylistItemRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, nextMediaInputPlaylistItemRequest);
   }
@@ -45,18 +46,18 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void previousMediaInputPlaylistItemRequest() {
     PreviousMediaInputPlaylistItemRequest previousMediaInputPlaylistItemRequest = PreviousMediaInputPlaylistItemRequest
-        .builder()
-        .inputName("Media Input")
-        .build();
+            .builder()
+            .inputName("Media Input")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'PreviousMediaInputPlaylistItem',\n" +
-        "\t'requestId': " + previousMediaInputPlaylistItemRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'PreviousMediaInputPlaylistItem',\n" +
+            "\t'requestId': " + previousMediaInputPlaylistItemRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, previousMediaInputPlaylistItemRequest);
   }
@@ -64,17 +65,17 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void stopMediaInputRequest() {
     StopMediaInputRequest stopMediaInputRequest = StopMediaInputRequest.builder()
-        .inputName("Media Input")
-        .build();
+                                                                       .inputName("Media Input")
+                                                                       .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'StopMediaInput',\n" +
-        "\t'requestId': " + stopMediaInputRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'StopMediaInput',\n" +
+            "\t'requestId': " + stopMediaInputRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, stopMediaInputRequest);
   }
@@ -82,20 +83,20 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void offsetMediaInputTimecodeRequest() {
     OffsetMediaInputTimecodeRequest offsetMediaInputTimecodeRequest = OffsetMediaInputTimecodeRequest
-        .builder()
-        .inputName("Media Input")
-        .timestampOffset(98329L)
-        .build();
+            .builder()
+            .inputName("Media Input")
+            .timestampOffset(98329L)
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'timestampOffset': 98329,\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'OffsetMediaInputTimecode',\n" +
-        "\t'requestId': " + offsetMediaInputTimecodeRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'timestampOffset': 98329,\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'OffsetMediaInputTimecode',\n" +
+            "\t'requestId': " + offsetMediaInputTimecodeRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, offsetMediaInputTimecodeRequest);
   }
@@ -103,20 +104,20 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void setMediaInputTimecodeRequest() {
     SetMediaInputTimecodeRequest setMediaInputTimecodeRequest = SetMediaInputTimecodeRequest
-        .builder()
-        .inputName("Media Input")
-        .mediaTimestamp(988975L)
-        .build();
+            .builder()
+            .inputName("Media Input")
+            .mediaTimestamp(988975L)
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'mediaTimestamp': 988975,\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetMediaInputTimecode',\n" +
-        "\t'requestId': " + setMediaInputTimecodeRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'mediaTimestamp': 988975,\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetMediaInputTimecode',\n" +
+            "\t'requestId': " + setMediaInputTimecodeRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setMediaInputTimecodeRequest);
   }
@@ -124,20 +125,20 @@ public class MediaInputRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void setMediaInputPauseStateRequest() {
     SetMediaInputPauseStateRequest setMediaInputPauseStateRequest = SetMediaInputPauseStateRequest
-        .builder()
-        .inputName("Media Input")
-        .pause(false)
-        .build();
+            .builder()
+            .inputName("Media Input")
+            .pause(false)
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'pause': false,\n" +
-        "\t\t'inputName': 'Media Input'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetMediaInputPauseState',\n" +
-        "\t'requestId': " + setMediaInputPauseStateRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'pause': false,\n" +
+            "\t\t'inputName': 'Media Input'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetMediaInputPauseState',\n" +
+            "\t'requestId': " + setMediaInputPauseStateRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setMediaInputPauseStateRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/outputs/OutputsRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/outputs/OutputsRequestsSerializationTest.java
@@ -1,20 +1,21 @@
 package io.obswebsocket.community.client.message.request.outputs;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class OutputsRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getLastReplayBufferReplayRequest() {
     GetLastReplayBufferReplayRequest getLastReplayBufferReplayRequest = GetLastReplayBufferReplayRequest
-        .builder().build();
+            .builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetLastReplayBufferReplay',\n" +
-        "\t'requestId': " + getLastReplayBufferReplayRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetLastReplayBufferReplay',\n" +
+            "\t'requestId': " + getLastReplayBufferReplayRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getLastReplayBufferReplayRequest);
   }
@@ -23,11 +24,11 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   void getOutputListRequest() {
     GetOutputListRequest getOutputListRequest = GetOutputListRequest.builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetOutputList',\n" +
-        "\t'requestId': " + getOutputListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetOutputList',\n" +
+            "\t'requestId': " + getOutputListRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getOutputListRequest);
   }
@@ -35,13 +36,13 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void getReplayBufferStatusRequest() {
     GetReplayBufferStatusRequest getReplayBufferStatusRequest = GetReplayBufferStatusRequest
-        .builder().build();
+            .builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetReplayBufferStatus',\n" +
-        "\t'requestId': " + getReplayBufferStatusRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetReplayBufferStatus',\n" +
+            "\t'requestId': " + getReplayBufferStatusRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getReplayBufferStatusRequest);
   }
@@ -50,11 +51,11 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   void saveReplayBufferRequest() {
     SaveReplayBufferRequest saveReplayBufferRequest = SaveReplayBufferRequest.builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'SaveReplayBuffer',\n" +
-        "\t'requestId': " + saveReplayBufferRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'SaveReplayBuffer',\n" +
+            "\t'requestId': " + saveReplayBufferRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, saveReplayBufferRequest);
   }
@@ -63,11 +64,11 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   void stopReplayBufferRequest() {
     StopReplayBufferRequest stopReplayBufferRequest = StopReplayBufferRequest.builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'StopReplayBuffer',\n" +
-        "\t'requestId': " + stopReplayBufferRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'StopReplayBuffer',\n" +
+            "\t'requestId': " + stopReplayBufferRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, stopReplayBufferRequest);
   }
@@ -75,13 +76,13 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void toggleReplayBufferRequest() {
     ToggleReplayBufferRequest toggleReplayBufferRequest = ToggleReplayBufferRequest.builder()
-        .build();
+                                                                                   .build();
 
-    String json = "{\n" +
-        "\t'requestType': 'ToggleReplayBuffer',\n" +
-        "\t'requestId': " + toggleReplayBufferRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'ToggleReplayBuffer',\n" +
+            "\t'requestId': " + toggleReplayBufferRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, toggleReplayBufferRequest);
   }
@@ -89,17 +90,17 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void startOutputRequest() {
     StartOutputRequest startOutputRequest = StartOutputRequest.builder()
-        .outputName("Output")
-        .build();
+                                                              .outputName("Output")
+                                                              .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'outputName': 'Output'\n" +
-        "\t},\n" +
-        "\t'requestType': 'StartOutput',\n" +
-        "\t'requestId': " + startOutputRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'outputName': 'Output'\n" +
+            "\t},\n" +
+            "\t'requestType': 'StartOutput',\n" +
+            "\t'requestId': " + startOutputRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, startOutputRequest);
   }
@@ -107,17 +108,17 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void stopOutputRequest() {
     StopOutputRequest stopOutputRequest = StopOutputRequest.builder()
-        .outputName("Output")
-        .build();
+                                                           .outputName("Output")
+                                                           .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'outputName': 'Output'\n" +
-        "\t},\n" +
-        "\t'requestType': 'StopOutput',\n" +
-        "\t'requestId': " + stopOutputRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'outputName': 'Output'\n" +
+            "\t},\n" +
+            "\t'requestType': 'StopOutput',\n" +
+            "\t'requestId': " + stopOutputRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, stopOutputRequest);
   }
@@ -125,17 +126,17 @@ public class OutputsRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void toggleOutputRequest() {
     ToggleOutputRequest toggleOutputRequest = ToggleOutputRequest.builder()
-        .outputName("Output")
-        .build();
+                                                                 .outputName("Output")
+                                                                 .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'outputName': 'Output'\n" +
-        "\t},\n" +
-        "\t'requestType': 'ToggleOutput',\n" +
-        "\t'requestId': " + toggleOutputRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'outputName': 'Output'\n" +
+            "\t},\n" +
+            "\t'requestType': 'ToggleOutput',\n" +
+            "\t'requestId': " + toggleOutputRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, toggleOutputRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/record/RecordRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/record/RecordRequestsSerializationTest.java
@@ -1,20 +1,21 @@
 package io.obswebsocket.community.client.message.request.record;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class RecordRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getRecordStatusRequest() {
     GetRecordStatusRequest getRecordStatusRequest = GetRecordStatusRequest.builder()
-        .build();
+                                                                          .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetRecordStatus',\n" +
-        "\t'requestId': '" + getRecordStatusRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'GetRecordStatus',\n" +
+            "\t'requestId': '" + getRecordStatusRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, getRecordStatusRequest);
   }
@@ -22,13 +23,13 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void toggleRecordRequest() {
     ToggleRecordRequest toggleRecordRequest = ToggleRecordRequest.builder()
-        .build();
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'ToggleRecord',\n" +
-        "\t'requestId': '" + toggleRecordRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'ToggleRecord',\n" +
+            "\t'requestId': '" + toggleRecordRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, toggleRecordRequest);
   }
@@ -36,17 +37,17 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void startRecordRequest() {
     StartRecordRequest startRecordRequest = StartRecordRequest.builder()
-        .waitForResult(true)
-        .build();
+                                                              .waitForResult(true)
+                                                              .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'StartRecord',\n" +
-        "\t'requestId': '" + startRecordRequest.getRequestId() + "',\n" +
-        "\t'requestData': {\n" +
-        "\t\t'waitForResult': true\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'StartRecord',\n" +
+            "\t'requestId': '" + startRecordRequest.getRequestId() + "',\n" +
+            "\t'requestData': {\n" +
+            "\t\t'waitForResult': true\n" +
+            "\t}\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, startRecordRequest);
   }
@@ -54,17 +55,17 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void stopRecordRequest() {
     StopRecordRequest stopRecordRequest = StopRecordRequest.builder()
-        .waitForResult(false)
-        .build();
+                                                           .waitForResult(false)
+                                                           .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'StopRecord',\n" +
-        "\t'requestId': '" + stopRecordRequest.getRequestId() + "',\n" +
-        "\t'requestData': {\n" +
-        "\t\t'waitForResult': false\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'StopRecord',\n" +
+            "\t'requestId': '" + stopRecordRequest.getRequestId() + "',\n" +
+            "\t'requestData': {\n" +
+            "\t\t'waitForResult': false\n" +
+            "\t}\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, stopRecordRequest);
   }
@@ -72,13 +73,13 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void toggleRecordPauseRequest() {
     ToggleRecordPauseRequest toggleRecordPauseRequest = ToggleRecordPauseRequest.builder()
-        .build();
+                                                                                .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'ToggleRecordPause',\n" +
-        "\t'requestId': '" + toggleRecordPauseRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'ToggleRecordPause',\n" +
+            "\t'requestId': '" + toggleRecordPauseRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, toggleRecordPauseRequest);
   }
@@ -86,13 +87,13 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void pauseRecordRequest() {
     PauseRecordRequest pauseRecordRequest = PauseRecordRequest.builder()
-        .build();
+                                                              .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'PauseRecord',\n" +
-        "\t'requestId': '" + pauseRecordRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'PauseRecord',\n" +
+            "\t'requestId': '" + pauseRecordRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, pauseRecordRequest);
   }
@@ -100,13 +101,13 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void resumeRecordRequest() {
     ResumeRecordRequest resumeRecordRequest = ResumeRecordRequest.builder()
-        .build();
+                                                                 .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'ResumeRecord',\n" +
-        "\t'requestId': '" + resumeRecordRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'ResumeRecord',\n" +
+            "\t'requestId': '" + resumeRecordRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, resumeRecordRequest);
   }
@@ -114,13 +115,13 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void getRecordDirectoryRequest() {
     GetRecordDirectoryRequest getRecordDirectoryRequest = GetRecordDirectoryRequest.builder()
-        .build();
+                                                                                   .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetRecordDirectory',\n" +
-        "\t'requestId': '" + getRecordDirectoryRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'GetRecordDirectory',\n" +
+            "\t'requestId': '" + getRecordDirectoryRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, getRecordDirectoryRequest);
   }
@@ -128,19 +129,19 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setRecordDirectoryRequest() {
     SetRecordDirectoryRequest getRecordDirectoryRequest = SetRecordDirectoryRequest.builder()
-        .recordDirectory("./")
-        .createIfNotExist(true)
-        .build();
+                                                                                   .recordDirectory("./")
+                                                                                   .createIfNotExist(true)
+                                                                                   .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetRecordDirectory',\n" +
-        "\t'requestId': '" + getRecordDirectoryRequest.getRequestId() + "',\n" +
-        "\t'requestData': {\n" +
-        "\t\t'recordDirectory': './',\n" +
-        "\t\t'createIfNotExist': true\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'SetRecordDirectory',\n" +
+            "\t'requestId': '" + getRecordDirectoryRequest.getRequestId() + "',\n" +
+            "\t'requestData': {\n" +
+            "\t\t'recordDirectory': './',\n" +
+            "\t\t'createIfNotExist': true\n" +
+            "\t}\n" +
+            "}}";
 
     System.out.println(json);
 
@@ -150,14 +151,14 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void getRecordFilenameFormattingRequest() {
     GetRecordFilenameFormattingRequest getRecordFilenameFormattingRequest = GetRecordFilenameFormattingRequest
-        .builder()
-        .build();
+            .builder()
+            .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'GetRecordFilenameFormatting',\n" +
-        "\t'requestId': '" + getRecordFilenameFormattingRequest.getRequestId() + "'\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'GetRecordFilenameFormatting',\n" +
+            "\t'requestId': '" + getRecordFilenameFormattingRequest.getRequestId() + "'\n" +
+            "}}";
 
     assertSerializationAndDeserialization(json, getRecordFilenameFormattingRequest);
   }
@@ -165,18 +166,18 @@ public class RecordRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setRecordFilenameFormattingRequest() {
     SetRecordFilenameFormattingRequest setRecordFilenameFormattingRequest = SetRecordFilenameFormattingRequest
-        .builder()
-        .filenameFormatting("$1 $2")
-        .build();
+            .builder()
+            .filenameFormatting("$1 $2")
+            .build();
 
     String json = "{\n" +
-        "\t'op': 6,\n" +
-        "\t'requestType': 'SetRecordFilenameFormatting',\n" +
-        "\t'requestId': '" + setRecordFilenameFormattingRequest.getRequestId() + "',\n" +
-        "\t'requestData': {\n" +
-        "\t\t'filenameFormatting': '$1 $2'\n" +
-        "\t}\n" +
-        "}";
+            "\t'op': 6,\n" +
+            "\t'd': {'requestType': 'SetRecordFilenameFormatting',\n" +
+            "\t'requestId': '" + setRecordFilenameFormattingRequest.getRequestId() + "',\n" +
+            "\t'requestData': {\n" +
+            "\t\t'filenameFormatting': '$1 $2'\n" +
+            "\t}\n" +
+            "}}";
 
     System.out.println(json);
 

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemsRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/sceneitems/SceneItemsRequestsSerializationTest.java
@@ -1,28 +1,29 @@
 package io.obswebsocket.community.client.message.request.sceneitems;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class SceneItemsRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void createSceneItemRequest() {
     CreateSceneItemRequest createSceneItemRequest = CreateSceneItemRequest.builder()
-        .sceneName("Scene name")
-        .sourceName("Source name")
-        .sceneItemEnabled(false)
-        .build();
+                                                                          .sceneName("Scene name")
+                                                                          .sourceName("Source name")
+                                                                          .sceneItemEnabled(false)
+                                                                          .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name',\n" +
-        "\t\t'sourceName': 'Source name',\n" +
-        "\t\t'sceneItemEnabled': false\n" +
-        "\t},\n" +
-        "\t'requestType': 'CreateSceneItem',\n" +
-        "\t'requestId': " + createSceneItemRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name',\n" +
+            "\t\t'sourceName': 'Source name',\n" +
+            "\t\t'sceneItemEnabled': false\n" +
+            "\t},\n" +
+            "\t'requestType': 'CreateSceneItem',\n" +
+            "\t'requestId': " + createSceneItemRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, createSceneItemRequest);
   }
@@ -30,21 +31,21 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void duplicateSceneItemRequest() {
     DuplicateSceneItemRequest duplicateSceneItemRequest = DuplicateSceneItemRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .destinationSceneName("new SceneItem")
-        .build();
+                                                                                   .sceneName("Scene name")
+                                                                                   .sceneItemId(1234)
+                                                                                   .destinationSceneName("new SceneItem")
+                                                                                   .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'destinationSceneName': 'new SceneItem',\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'DuplicateSceneItem',\n" +
-        "\t'requestId': " + duplicateSceneItemRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'destinationSceneName': 'new SceneItem',\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'DuplicateSceneItem',\n" +
+            "\t'requestId': " + duplicateSceneItemRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, duplicateSceneItemRequest);
   }
@@ -52,19 +53,19 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void getSceneItemColorRequest() {
     GetSceneItemColorRequest getSceneItemColorRequest = GetSceneItemColorRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .build();
+                                                                                .sceneName("Scene name")
+                                                                                .sceneItemId(1234)
+                                                                                .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSceneItemColor',\n" +
-        "\t'requestId': " + getSceneItemColorRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSceneItemColor',\n" +
+            "\t'requestId': " + getSceneItemColorRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneItemColorRequest);
   }
@@ -72,19 +73,19 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void getSceneItemEnabledRequest() {
     GetSceneItemEnabledRequest getSceneItemEnabledRequest = GetSceneItemEnabledRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .build();
+                                                                                      .sceneName("Scene name")
+                                                                                      .sceneItemId(1234)
+                                                                                      .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSceneItemEnabled',\n" +
-        "\t'requestId': " + getSceneItemEnabledRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSceneItemEnabled',\n" +
+            "\t'requestId': " + getSceneItemEnabledRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneItemEnabledRequest);
   }
@@ -92,17 +93,17 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void getSceneItemListRequest() {
     GetSceneItemListRequest getSceneItemListRequest = GetSceneItemListRequest.builder()
-        .sceneName("Scene name")
-        .build();
+                                                                             .sceneName("Scene name")
+                                                                             .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSceneItemList',\n" +
-        "\t'requestId': " + getSceneItemListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSceneItemList',\n" +
+            "\t'requestId': " + getSceneItemListRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneItemListRequest);
   }
@@ -110,19 +111,19 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void getSceneItemLockedRequest() {
     GetSceneItemLockedRequest getSceneItemLockedRequest = GetSceneItemLockedRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .build();
+                                                                                   .sceneName("Scene name")
+                                                                                   .sceneItemId(1234)
+                                                                                   .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSceneItemLocked',\n" +
-        "\t'requestId': " + getSceneItemLockedRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSceneItemLocked',\n" +
+            "\t'requestId': " + getSceneItemLockedRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneItemLockedRequest);
   }
@@ -130,19 +131,19 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void removeSceneItemRequest() {
     RemoveSceneItemRequest removeSceneItemRequest = RemoveSceneItemRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .build();
+                                                                          .sceneName("Scene name")
+                                                                          .sceneItemId(1234)
+                                                                          .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'RemoveSceneItem',\n" +
-        "\t'requestId': " + removeSceneItemRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'RemoveSceneItem',\n" +
+            "\t'requestId': " + removeSceneItemRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, removeSceneItemRequest);
   }
@@ -150,21 +151,21 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void setSceneItemEnabledRequest() {
     SetSceneItemEnabledRequest setSceneItemEnabledRequest = SetSceneItemEnabledRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .sceneItemEnabled(true)
-        .build();
+                                                                                      .sceneName("Scene name")
+                                                                                      .sceneItemId(1234)
+                                                                                      .sceneItemEnabled(true)
+                                                                                      .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemEnabled': true,\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneItemEnabled',\n" +
-        "\t'requestId': " + setSceneItemEnabledRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemEnabled': true,\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneItemEnabled',\n" +
+            "\t'requestId': " + setSceneItemEnabledRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneItemEnabledRequest);
   }
@@ -172,21 +173,21 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void setSceneItemIndexRequest() {
     SetSceneItemIndexRequest setSceneItemIndexRequest = SetSceneItemIndexRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .sceneItemIndex(2)
-        .build();
+                                                                                .sceneName("Scene name")
+                                                                                .sceneItemId(1234)
+                                                                                .sceneItemIndex(2)
+                                                                                .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemIndex': 2,\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneItemIndex',\n" +
-        "\t'requestId': " + setSceneItemIndexRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemIndex': 2,\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneItemIndex',\n" +
+            "\t'requestId': " + setSceneItemIndexRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneItemIndexRequest);
   }
@@ -194,21 +195,21 @@ public class SceneItemsRequestsSerializationTest extends AbstractSerializationTe
   @Test
   void setSceneItemLockedRequest() {
     SetSceneItemLockedRequest setSceneItemLockedRequest = SetSceneItemLockedRequest.builder()
-        .sceneName("Scene name")
-        .sceneItemId(1234)
-        .sceneItemLocked(false)
-        .build();
+                                                                                   .sceneName("Scene name")
+                                                                                   .sceneItemId(1234)
+                                                                                   .sceneItemLocked(false)
+                                                                                   .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneItemLocked': false,\n" +
-        "\t\t'sceneItemId': 1234,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneItemLocked',\n" +
-        "\t'requestId': " + setSceneItemLockedRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneItemLocked': false,\n" +
+            "\t\t'sceneItemId': 1234,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneItemLocked',\n" +
+            "\t'requestId': " + setSceneItemLockedRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneItemLockedRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/scenes/ScenesRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/scenes/ScenesRequestsSerializationTest.java
@@ -1,24 +1,25 @@
 package io.obswebsocket.community.client.message.request.scenes;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void createSceneRequest() {
     CreateSceneRequest createSceneRequest = CreateSceneRequest.builder()
-        .sceneName("Scene name")
-        .build();
+                                                              .sceneName("Scene name")
+                                                              .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'CreateScene',\n" +
-        "\t'requestId': " + createSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'CreateScene',\n" +
+            "\t'requestId': " + createSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, createSceneRequest);
   }
@@ -26,18 +27,18 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void deleteSceneTransitionOverrideRequest() {
     DeleteSceneTransitionOverrideRequest deleteSceneTransitionOverrideRequest = DeleteSceneTransitionOverrideRequest
-        .builder()
-        .sceneName("Scene name")
-        .build();
+            .builder()
+            .sceneName("Scene name")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'DeleteSceneTransitionOverride',\n" +
-        "\t'requestId': " + deleteSceneTransitionOverrideRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'DeleteSceneTransitionOverride',\n" +
+            "\t'requestId': " + deleteSceneTransitionOverrideRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, deleteSceneTransitionOverrideRequest);
   }
@@ -45,28 +46,27 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void getCurrentPreviewSceneRequest() {
     GetCurrentPreviewSceneRequest getCurrentPreviewSceneRequest = GetCurrentPreviewSceneRequest
-        .builder().build();
+            .builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetCurrentPreviewScene',\n" +
-        "\t'requestId': " + getCurrentPreviewSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetCurrentPreviewScene',\n" +
+            "\t'requestId': " + getCurrentPreviewSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getCurrentPreviewSceneRequest);
   }
 
-
   @Test
   void getCurrentProgramSceneRequest() {
     GetCurrentProgramSceneRequest getCurrentProgramSceneRequest = GetCurrentProgramSceneRequest
-        .builder().build();
+            .builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetCurrentProgramScene',\n" +
-        "\t'requestId': " + getCurrentProgramSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetCurrentProgramScene',\n" +
+            "\t'requestId': " + getCurrentProgramSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getCurrentProgramSceneRequest);
   }
@@ -75,11 +75,11 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   void getSceneListRequest() {
     GetSceneListRequest getSceneListRequest = GetSceneListRequest.builder().build();
 
-    String json = "{\n" +
-        "\t'requestType': 'GetSceneList',\n" +
-        "\t'requestId': " + getSceneListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestType': 'GetSceneList',\n" +
+            "\t'requestId': " + getSceneListRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneListRequest);
   }
@@ -87,18 +87,18 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void getSceneTransitionOverrideRequest() {
     GetSceneTransitionOverrideRequest getSceneTransitionOverrideRequest = GetSceneTransitionOverrideRequest
-        .builder()
-        .sceneName("Scene name")
-        .build();
+            .builder()
+            .sceneName("Scene name")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSceneTransitionOverride',\n" +
-        "\t'requestId': " + getSceneTransitionOverrideRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSceneTransitionOverride',\n" +
+            "\t'requestId': " + getSceneTransitionOverrideRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSceneTransitionOverrideRequest);
   }
@@ -106,17 +106,17 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void removeSceneRequest() {
     RemoveSceneRequest removeSceneRequest = RemoveSceneRequest.builder()
-        .sceneName("Scene name")
-        .build();
+                                                              .sceneName("Scene name")
+                                                              .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'RemoveScene',\n" +
-        "\t'requestId': " + removeSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'RemoveScene',\n" +
+            "\t'requestId': " + removeSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, removeSceneRequest);
   }
@@ -124,18 +124,18 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setCurrentPreviewSceneRequest() {
     SetCurrentPreviewSceneRequest setCurrentPreviewSceneRequest = SetCurrentPreviewSceneRequest
-        .builder()
-        .sceneName("Scene name")
-        .build();
+            .builder()
+            .sceneName("Scene name")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetCurrentPreviewScene',\n" +
-        "\t'requestId': " + setCurrentPreviewSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetCurrentPreviewScene',\n" +
+            "\t'requestId': " + setCurrentPreviewSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setCurrentPreviewSceneRequest);
   }
@@ -143,18 +143,18 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setCurrentProgramSceneRequest() {
     SetCurrentProgramSceneRequest setCurrentProgramSceneRequest = SetCurrentProgramSceneRequest
-        .builder()
-        .sceneName("Scene name")
-        .build();
+            .builder()
+            .sceneName("Scene name")
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetCurrentProgramScene',\n" +
-        "\t'requestId': " + setCurrentProgramSceneRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetCurrentProgramScene',\n" +
+            "\t'requestId': " + setCurrentProgramSceneRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setCurrentProgramSceneRequest);
   }
@@ -162,19 +162,19 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setSceneIndexRequest() {
     SetSceneIndexRequest setSceneIndexRequest = SetSceneIndexRequest.builder()
-        .sceneName("Scene name")
-        .sceneIndex(0)
-        .build();
+                                                                    .sceneName("Scene name")
+                                                                    .sceneIndex(0)
+                                                                    .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sceneName': 'Scene name',\n" +
-        "\t\t'sceneIndex': 0\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneIndex',\n" +
-        "\t'requestId': " + setSceneIndexRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sceneName': 'Scene name',\n" +
+            "\t\t'sceneIndex': 0\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneIndex',\n" +
+            "\t'requestId': " + setSceneIndexRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneIndexRequest);
   }
@@ -182,19 +182,19 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setSceneNameRequest() {
     SetSceneNameRequest setSceneNameRequest = SetSceneNameRequest.builder()
-        .sceneName("Scene name")
-        .newSceneName("New Scene name")
-        .build();
+                                                                 .sceneName("Scene name")
+                                                                 .newSceneName("New Scene name")
+                                                                 .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'newSceneName': 'New Scene name',\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneName',\n" +
-        "\t'requestId': " + setSceneNameRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'newSceneName': 'New Scene name',\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneName',\n" +
+            "\t'requestId': " + setSceneNameRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneNameRequest);
   }
@@ -202,22 +202,22 @@ public class ScenesRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void setSceneTransitionOverrideRequest() {
     SetSceneTransitionOverrideRequest setSceneTransitionOverrideRequest = SetSceneTransitionOverrideRequest
-        .builder()
-        .sceneName("Scene name")
-        .transitionName("Transition Name")
-        .transitionDuration(3)
-        .build();
+            .builder()
+            .sceneName("Scene name")
+            .transitionName("Transition Name")
+            .transitionDuration(3)
+            .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'transitionName': 'Transition Name',\n" +
-        "\t\t'transitionDuration': 3,\n" +
-        "\t\t'sceneName': 'Scene name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetSceneTransitionOverride',\n" +
-        "\t'requestId': " + setSceneTransitionOverrideRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'transitionName': 'Transition Name',\n" +
+            "\t\t'transitionDuration': 3,\n" +
+            "\t\t'sceneName': 'Scene name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetSceneTransitionOverride',\n" +
+            "\t'requestId': " + setSceneTransitionOverrideRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setSceneTransitionOverrideRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/sources/SourcesRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/sources/SourcesRequestsSerializationTest.java
@@ -1,23 +1,24 @@
 package io.obswebsocket.community.client.message.request.sources;
 
-import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import org.junit.jupiter.api.Test;
+
+import io.obswebsocket.community.client.message.AbstractSerializationTest;
 
 public class SourcesRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getSourceActiveRequest() {
     GetSourceActiveRequest getSourceActiveRequest = GetSourceActiveRequest.builder()
-        .sourceName("source").build();
+                                                                          .sourceName("source").build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'sourceName': 'source'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSourceActive',\n" +
-        "\t'requestId': " + getSourceActiveRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'sourceName': 'source'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSourceActive',\n" +
+            "\t'requestId': " + getSourceActiveRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSourceActiveRequest);
   }
@@ -25,25 +26,25 @@ public class SourcesRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void getSourceScreenshotRequest() {
     GetSourceScreenshotRequest getSourceScreenshotRequest = GetSourceScreenshotRequest.builder()
-        .sourceName("source")
-        .imageFormat("png")
-        .imageWidth(1920)
-        .imageHeight(1080)
-        .imageCompressionQuality(-1)
-        .build();
+                                                                                      .sourceName("source")
+                                                                                      .imageFormat("png")
+                                                                                      .imageWidth(1920)
+                                                                                      .imageHeight(1080)
+                                                                                      .imageCompressionQuality(-1)
+                                                                                      .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'imageFormat': 'png',\n" +
-        "\t\t'imageWidth': 1920,\n" +
-        "\t\t'imageHeight': 1080,\n" +
-        "\t\t'imageCompressionQuality': -1,\n" +
-        "\t\t'sourceName': 'source'\n" +
-        "\t},\n" +
-        "\t'requestType': 'GetSourceScreenshot',\n" +
-        "\t'requestId': " + getSourceScreenshotRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'imageFormat': 'png',\n" +
+            "\t\t'imageWidth': 1920,\n" +
+            "\t\t'imageHeight': 1080,\n" +
+            "\t\t'imageCompressionQuality': -1,\n" +
+            "\t\t'sourceName': 'source'\n" +
+            "\t},\n" +
+            "\t'requestType': 'GetSourceScreenshot',\n" +
+            "\t'requestId': " + getSourceScreenshotRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getSourceScreenshotRequest);
   }
@@ -51,27 +52,27 @@ public class SourcesRequestsSerializationTest extends AbstractSerializationTest 
   @Test
   void saveSourceScreenshotRequest() {
     SaveSourceScreenshotRequest saveSourceScreenshotRequest = SaveSourceScreenshotRequest.builder()
-        .sourceName("source")
-        .imageFilePath("C:/path/to/this/image.png")
-        .imageFormat("png")
-        .imageWidth(1920)
-        .imageHeight(1080)
-        .imageCompressionQuality(-1)
-        .build();
+                                                                                         .sourceName("source")
+                                                                                         .imageFilePath("C:/path/to/this/image.png")
+                                                                                         .imageFormat("png")
+                                                                                         .imageWidth(1920)
+                                                                                         .imageHeight(1080)
+                                                                                         .imageCompressionQuality(-1)
+                                                                                         .build();
 
-    String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'imageFilePath': 'C:/path/to/this/image.png',\n" +
-        "\t\t'imageFormat': 'png',\n" +
-        "\t\t'imageWidth': 1920,\n" +
-        "\t\t'imageHeight': 1080,\n" +
-        "\t\t'imageCompressionQuality': -1,\n" +
-        "\t\t'sourceName': 'source'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SaveSourceScreenshot',\n" +
-        "\t'requestId': " + saveSourceScreenshotRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+    String json = "{'d': {\n" +
+            "\t'requestData': {\n" +
+            "\t\t'imageFilePath': 'C:/path/to/this/image.png',\n" +
+            "\t\t'imageFormat': 'png',\n" +
+            "\t\t'imageWidth': 1920,\n" +
+            "\t\t'imageHeight': 1080,\n" +
+            "\t\t'imageCompressionQuality': -1,\n" +
+            "\t\t'sourceName': 'source'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SaveSourceScreenshot',\n" +
+            "\t'requestId': " + saveSourceScreenshotRequest.getRequestId() + "},\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, saveSourceScreenshotRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/stream/StreamRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/stream/StreamRequestsSerializationTest.java
@@ -22,9 +22,9 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
     GetStreamServiceSettingsRequest getStreamServiceSettingsRequest = GetStreamServiceSettingsRequest
             .builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetStreamServiceSettings',\n" +
-            "\t'requestId': " + getStreamServiceSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getStreamServiceSettingsRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -35,9 +35,9 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
   void getStreamStatusRequest() {
     GetStreamStatusRequest getStreamStatusRequest = GetStreamStatusRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetStreamStatus',\n" +
-            "\t'requestId': " + getStreamStatusRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getStreamStatusRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -50,12 +50,12 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
                                                                                 .captionText("Some random caption text")
                                                                                 .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'captionText': 'Some random caption text'\n" +
             "\t},\n" +
             "\t'requestType': 'SendStreamCaption',\n" +
-            "\t'requestId': " + sendStreamCaptionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + sendStreamCaptionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -75,7 +75,7 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
             .serviceSettings(serviceSettings)
             .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'streamServiceType': 'Test Type',\n" +
             "\t\t'serviceSettings': {\n" +
@@ -85,7 +85,7 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
             "\t\t}\n" +
             "\t},\n" +
             "\t'requestType': 'SetStreamServiceSettings',\n" +
-            "\t'requestId': " + setStreamServiceSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setStreamServiceSettingsRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -123,9 +123,9 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
   void startStreamRequest() {
     StartStreamRequest startStreamRequest = StartStreamRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'StartStream',\n" +
-            "\t'requestId': " + startStreamRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + startStreamRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -136,9 +136,9 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
   void toggleStreamRequest() {
     ToggleStreamRequest toggleStreamRequest = ToggleStreamRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'ToggleStream',\n" +
-            "\t'requestId': " + toggleStreamRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + toggleStreamRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/stream/StreamRequestsSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/stream/StreamRequestsSerializationTest.java
@@ -3,28 +3,30 @@ package io.obswebsocket.community.client.message.request.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import io.obswebsocket.community.client.message.Message.OperationCode;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.translator.GsonMessageTranslator;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import org.json.JSONException;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class StreamRequestsSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getStreamServiceSettingsRequest() {
     GetStreamServiceSettingsRequest getStreamServiceSettingsRequest = GetStreamServiceSettingsRequest
-        .builder().build();
+            .builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetStreamServiceSettings',\n" +
-        "\t'requestId': " + getStreamServiceSettingsRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetStreamServiceSettings',\n" +
+            "\t'requestId': " + getStreamServiceSettingsRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getStreamServiceSettingsRequest);
   }
@@ -34,10 +36,10 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
     GetStreamStatusRequest getStreamStatusRequest = GetStreamStatusRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetStreamStatus',\n" +
-        "\t'requestId': " + getStreamStatusRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetStreamStatus',\n" +
+            "\t'requestId': " + getStreamStatusRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getStreamStatusRequest);
   }
@@ -45,17 +47,17 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
   @Test
   void sendStreamCaptionRequest() {
     SendStreamCaptionRequest sendStreamCaptionRequest = SendStreamCaptionRequest.builder()
-        .captionText("Some random caption text")
-        .build();
+                                                                                .captionText("Some random caption text")
+                                                                                .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'captionText': 'Some random caption text'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SendStreamCaption',\n" +
-        "\t'requestId': " + sendStreamCaptionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'captionText': 'Some random caption text'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SendStreamCaption',\n" +
+            "\t'requestId': " + sendStreamCaptionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, sendStreamCaptionRequest);
   }
@@ -68,44 +70,44 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
     serviceSettings.addProperty("randomIntegerSetting", 129);
 
     SetStreamServiceSettingsRequest setStreamServiceSettingsRequest = SetStreamServiceSettingsRequest
-        .builder()
-        .streamServiceType("Test Type")
-        .serviceSettings(serviceSettings)
-        .build();
+            .builder()
+            .streamServiceType("Test Type")
+            .serviceSettings(serviceSettings)
+            .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'streamServiceType': 'Test Type',\n" +
-        "\t\t'serviceSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': true,\n" +
-        "\t\t\t'randomIntegerSetting': 129\n" +
-        "\t\t}\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetStreamServiceSettings',\n" +
-        "\t'requestId': " + setStreamServiceSettingsRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'streamServiceType': 'Test Type',\n" +
+            "\t\t'serviceSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': true,\n" +
+            "\t\t\t'randomIntegerSetting': 129\n" +
+            "\t\t}\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetStreamServiceSettings',\n" +
+            "\t'requestId': " + setStreamServiceSettingsRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     SetStreamServiceSettingsRequest actualObject = translator
-        .fromJson(json, SetStreamServiceSettingsRequest.class);
+            .fromJson(json, SetStreamServiceSettingsRequest.class);
 
     assertThat(
-        actualObject.getRequestData().getServiceSettings().get("randomStringSetting").getAsString())
-        .isEqualTo(setStreamServiceSettingsRequest.getRequestData().getServiceSettings()
-            .get("randomStringSetting").getAsString());
-    assertThat(actualObject.getRequestData().getServiceSettings().get("randomBooleanSetting")
-        .getAsBoolean()).isEqualTo(
-        setStreamServiceSettingsRequest.getRequestData().getServiceSettings()
-            .get("randomBooleanSetting").getAsBoolean());
+            actualObject.getData().getRequestData().getServiceSettings().get("randomStringSetting").getAsString())
+            .isEqualTo(setStreamServiceSettingsRequest.getData().getRequestData().getServiceSettings()
+                                                      .get("randomStringSetting").getAsString());
+    assertThat(actualObject.getData().getRequestData().getServiceSettings().get("randomBooleanSetting")
+                           .getAsBoolean()).isEqualTo(
+            setStreamServiceSettingsRequest.getData().getRequestData().getServiceSettings()
+                                           .get("randomBooleanSetting").getAsBoolean());
     assertThat(
-        actualObject.getRequestData().getServiceSettings().get("randomIntegerSetting").getAsInt())
-        .isEqualTo(setStreamServiceSettingsRequest.getRequestData().getServiceSettings()
-            .get("randomIntegerSetting").getAsInt());
+            actualObject.getData().getRequestData().getServiceSettings().get("randomIntegerSetting").getAsInt())
+            .isEqualTo(setStreamServiceSettingsRequest.getData().getRequestData().getServiceSettings()
+                                                      .get("randomIntegerSetting").getAsInt());
     assertThat(actualObject.getRequestId())
-        .isEqualTo(setStreamServiceSettingsRequest.getRequestId());
+            .isEqualTo(setStreamServiceSettingsRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.SetStreamServiceSettings);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
     try {
@@ -122,10 +124,10 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
     StartStreamRequest startStreamRequest = StartStreamRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'StartStream',\n" +
-        "\t'requestId': " + startStreamRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'StartStream',\n" +
+            "\t'requestId': " + startStreamRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, startStreamRequest);
   }
@@ -135,10 +137,10 @@ public class StreamRequestsSerializationTest extends AbstractSerializationTest {
     ToggleStreamRequest toggleStreamRequest = ToggleStreamRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'ToggleStream',\n" +
-        "\t'requestId': " + toggleStreamRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'ToggleStream',\n" +
+            "\t'requestId': " + toggleStreamRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, toggleStreamRequest);
   }

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/transitions/TransitionsRequestSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/transitions/TransitionsRequestSerializationTest.java
@@ -22,9 +22,9 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
     GetCurrentTransitionRequest getCurrentTransitionRequest = GetCurrentTransitionRequest.builder()
                                                                                          .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetCurrentTransition',\n" +
-            "\t'requestId': " + getCurrentTransitionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getCurrentTransitionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -35,9 +35,9 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   void getTransitionListRequest() {
     GetTransitionListRequest getTransitionListRequest = GetTransitionListRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'GetTransitionList',\n" +
-            "\t'requestId': " + getTransitionListRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + getTransitionListRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -48,9 +48,9 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   void releaseTbarRequest() {
     ReleaseTbarRequest releaseTbarRequest = ReleaseTbarRequest.builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'ReleaseTbar',\n" +
-            "\t'requestId': " + releaseTbarRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + releaseTbarRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -64,12 +64,12 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
             .transitionDuration(120)
             .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'transitionDuration': 120\n" +
             "\t},\n" +
             "\t'requestType': 'SetCurrentTransitionDuration',\n" +
-            "\t'requestId': " + setCurrentTransitionDurationRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setCurrentTransitionDurationRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -82,12 +82,12 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
                                                                                          .transitionName("Cool transition")
                                                                                          .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'transitionName': 'Cool transition'\n" +
             "\t},\n" +
             "\t'requestType': 'SetCurrentTransition',\n" +
-            "\t'requestId': " + setCurrentTransitionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setCurrentTransitionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -101,13 +101,13 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
                                                                           .release(true)
                                                                           .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'position': 2.6,\n" +
             "\t\t'release': true\n" +
             "\t},\n" +
             "\t'requestType': 'SetTbarPosition',\n" +
-            "\t'requestId': " + setTbarPositionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setTbarPositionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -127,7 +127,7 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
             .transitionSettings(transitionSettings)
             .build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestData': {\n" +
             "\t\t'transitionSettings': {\n" +
             "\t\t\t'randomStringSetting': 'randomString',\n" +
@@ -137,7 +137,7 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
             "\t\t'transitionName': 'Transition name'\n" +
             "\t},\n" +
             "\t'requestType': 'SetTransitionSettings',\n" +
-            "\t'requestId': " + setTransitionSettingsRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + setTransitionSettingsRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 
@@ -177,9 +177,9 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
     TriggerStudioModeTransitionRequest triggerStudioModeTransitionRequest = TriggerStudioModeTransitionRequest
             .builder().build();
 
-    String json = "{\n" +
+    String json = "{'d': {\n" +
             "\t'requestType': 'TriggerStudioModeTransition',\n" +
-            "\t'requestId': " + triggerStudioModeTransitionRequest.getRequestId() + ",\n" +
+            "\t'requestId': " + triggerStudioModeTransitionRequest.getRequestId() + "},\n" +
             "\t'op': 6\n" +
             "}";
 

--- a/client/src/test/java/io/obswebsocket/community/client/message/request/transitions/TransitionsRequestSerializationTest.java
+++ b/client/src/test/java/io/obswebsocket/community/client/message/request/transitions/TransitionsRequestSerializationTest.java
@@ -3,28 +3,30 @@ package io.obswebsocket.community.client.message.request.transitions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.JsonObject;
+
 import io.obswebsocket.community.client.message.AbstractSerializationTest;
 import io.obswebsocket.community.client.message.Message.OperationCode;
 import io.obswebsocket.community.client.message.request.Request;
 import io.obswebsocket.community.client.translator.GsonMessageTranslator;
 import io.obswebsocket.community.client.translator.MessageTranslator;
-import org.json.JSONException;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class TransitionsRequestSerializationTest extends AbstractSerializationTest {
 
   @Test
   void getCurrentTransitionRequest() {
     GetCurrentTransitionRequest getCurrentTransitionRequest = GetCurrentTransitionRequest.builder()
-        .build();
+                                                                                         .build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetCurrentTransition',\n" +
-        "\t'requestId': " + getCurrentTransitionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetCurrentTransition',\n" +
+            "\t'requestId': " + getCurrentTransitionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getCurrentTransitionRequest);
   }
@@ -34,10 +36,10 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
     GetTransitionListRequest getTransitionListRequest = GetTransitionListRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'GetTransitionList',\n" +
-        "\t'requestId': " + getTransitionListRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'GetTransitionList',\n" +
+            "\t'requestId': " + getTransitionListRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, getTransitionListRequest);
   }
@@ -47,10 +49,10 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
     ReleaseTbarRequest releaseTbarRequest = ReleaseTbarRequest.builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'ReleaseTbar',\n" +
-        "\t'requestId': " + releaseTbarRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'ReleaseTbar',\n" +
+            "\t'requestId': " + releaseTbarRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, releaseTbarRequest);
   }
@@ -58,18 +60,18 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   @Test
   void setCurrentTransitionDurationRequest() {
     SetCurrentTransitionDurationRequest setCurrentTransitionDurationRequest = SetCurrentTransitionDurationRequest
-        .builder()
-        .transitionDuration(120)
-        .build();
+            .builder()
+            .transitionDuration(120)
+            .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'transitionDuration': 120\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetCurrentTransitionDuration',\n" +
-        "\t'requestId': " + setCurrentTransitionDurationRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'transitionDuration': 120\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetCurrentTransitionDuration',\n" +
+            "\t'requestId': " + setCurrentTransitionDurationRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setCurrentTransitionDurationRequest);
   }
@@ -77,17 +79,17 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   @Test
   void setCurrentTransitionRequest() {
     SetCurrentTransitionRequest setCurrentTransitionRequest = SetCurrentTransitionRequest.builder()
-        .transitionName("Cool transition")
-        .build();
+                                                                                         .transitionName("Cool transition")
+                                                                                         .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'transitionName': 'Cool transition'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetCurrentTransition',\n" +
-        "\t'requestId': " + setCurrentTransitionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'transitionName': 'Cool transition'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetCurrentTransition',\n" +
+            "\t'requestId': " + setCurrentTransitionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setCurrentTransitionRequest);
   }
@@ -95,19 +97,19 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   @Test
   void setTbarPositionRequest() {
     SetTbarPositionRequest setTbarPositionRequest = SetTbarPositionRequest.builder()
-        .position(2.6)
-        .release(true)
-        .build();
+                                                                          .position(2.6)
+                                                                          .release(true)
+                                                                          .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'position': 2.6,\n" +
-        "\t\t'release': true\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetTbarPosition',\n" +
-        "\t'requestId': " + setTbarPositionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'position': 2.6,\n" +
+            "\t\t'release': true\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetTbarPosition',\n" +
+            "\t'requestId': " + setTbarPositionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, setTbarPositionRequest);
   }
@@ -120,44 +122,44 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
     transitionSettings.addProperty("randomIntegerSetting", 123);
 
     SetTransitionSettingsRequest setTransitionSettingsRequest = SetTransitionSettingsRequest
-        .builder()
-        .transitionName("Transition name")
-        .transitionSettings(transitionSettings)
-        .build();
+            .builder()
+            .transitionName("Transition name")
+            .transitionSettings(transitionSettings)
+            .build();
 
     String json = "{\n" +
-        "\t'requestData': {\n" +
-        "\t\t'transitionSettings': {\n" +
-        "\t\t\t'randomStringSetting': 'randomString',\n" +
-        "\t\t\t'randomBooleanSetting': true,\n" +
-        "\t\t\t'randomIntegerSetting': 123\n" +
-        "\t\t},\n" +
-        "\t\t'transitionName': 'Transition name'\n" +
-        "\t},\n" +
-        "\t'requestType': 'SetTransitionSettings',\n" +
-        "\t'requestId': " + setTransitionSettingsRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestData': {\n" +
+            "\t\t'transitionSettings': {\n" +
+            "\t\t\t'randomStringSetting': 'randomString',\n" +
+            "\t\t\t'randomBooleanSetting': true,\n" +
+            "\t\t\t'randomIntegerSetting': 123\n" +
+            "\t\t},\n" +
+            "\t\t'transitionName': 'Transition name'\n" +
+            "\t},\n" +
+            "\t'requestType': 'SetTransitionSettings',\n" +
+            "\t'requestId': " + setTransitionSettingsRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     MessageTranslator translator = new GsonMessageTranslator();
 
     SetTransitionSettingsRequest actualObject = translator
-        .fromJson(json, SetTransitionSettingsRequest.class);
+            .fromJson(json, SetTransitionSettingsRequest.class);
 
-    assertThat(actualObject.getRequestData().getTransitionName())
-        .isEqualTo(setTransitionSettingsRequest.getRequestData().getTransitionName());
-    assertThat(actualObject.getRequestData().getTransitionSettings().get("randomStringSetting")
-        .getAsString()).isEqualTo(
-        setTransitionSettingsRequest.getRequestData().getTransitionSettings()
-            .get("randomStringSetting").getAsString());
-    assertThat(actualObject.getRequestData().getTransitionSettings().get("randomBooleanSetting")
-        .getAsBoolean()).isEqualTo(
-        setTransitionSettingsRequest.getRequestData().getTransitionSettings()
-            .get("randomBooleanSetting").getAsBoolean());
-    assertThat(actualObject.getRequestData().getTransitionSettings().get("randomIntegerSetting")
-        .getAsBoolean()).isEqualTo(
-        setTransitionSettingsRequest.getRequestData().getTransitionSettings()
-            .get("randomIntegerSetting").getAsBoolean());
+    assertThat(actualObject.getData().getRequestData().getTransitionName())
+            .isEqualTo(setTransitionSettingsRequest.getData().getRequestData().getTransitionName());
+    assertThat(actualObject.getData().getRequestData().getTransitionSettings().get("randomStringSetting")
+                           .getAsString()).isEqualTo(
+            setTransitionSettingsRequest.getData().getRequestData().getTransitionSettings()
+                                        .get("randomStringSetting").getAsString());
+    assertThat(actualObject.getData().getRequestData().getTransitionSettings().get("randomBooleanSetting")
+                           .getAsBoolean()).isEqualTo(
+            setTransitionSettingsRequest.getData().getRequestData().getTransitionSettings()
+                                        .get("randomBooleanSetting").getAsBoolean());
+    assertThat(actualObject.getData().getRequestData().getTransitionSettings().get("randomIntegerSetting")
+                           .getAsBoolean()).isEqualTo(
+            setTransitionSettingsRequest.getData().getRequestData().getTransitionSettings()
+                                        .get("randomIntegerSetting").getAsBoolean());
     assertThat(actualObject.getRequestId()).isEqualTo(setTransitionSettingsRequest.getRequestId());
     assertThat(actualObject.getRequestType()).isEqualTo(Request.Data.Type.SetTransitionSettings);
     assertThat(actualObject.getOperationCode()).isEqualTo(OperationCode.Request);
@@ -173,13 +175,13 @@ public class TransitionsRequestSerializationTest extends AbstractSerializationTe
   @Test
   void triggerStudioModeTransitionRequest() {
     TriggerStudioModeTransitionRequest triggerStudioModeTransitionRequest = TriggerStudioModeTransitionRequest
-        .builder().build();
+            .builder().build();
 
     String json = "{\n" +
-        "\t'requestType': 'TriggerStudioModeTransition',\n" +
-        "\t'requestId': " + triggerStudioModeTransitionRequest.getRequestId() + ",\n" +
-        "\t'op': 6\n" +
-        "}";
+            "\t'requestType': 'TriggerStudioModeTransition',\n" +
+            "\t'requestId': " + triggerStudioModeTransitionRequest.getRequestId() + ",\n" +
+            "\t'op': 6\n" +
+            "}";
 
     assertSerializationAndDeserialization(json, triggerStudioModeTransitionRequest);
   }

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -1,15 +1,15 @@
 package io.obswebsocket.community.client.example;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.message.event.general.StudioModeStateChangedEvent;
 import io.obswebsocket.community.client.message.request.general.GetStudioModeEnabledRequest;
 import io.obswebsocket.community.client.message.response.general.GetStudioModeEnabledResponse;
 import io.obswebsocket.community.client.model.Scene;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class Example {
-
   private final OBSRemoteController obsRemoteController;
   private boolean isReconnecting = false;
 
@@ -20,15 +20,15 @@ public class Example {
   private Example() {
     // Create OBSRemoteController through its builder
     this.obsRemoteController = OBSRemoteController.builder()
-        .autoConnect(false)                       // Do not connect automatically
-        .host("127.0.0.1")                        // Set the host
-        .port(4455)                               // Set the port
-        .password("53CR37")                       // Set the password
-        .lifecycle()                              // Add some lifecycle callbacks
-          .onReady(this::onReady)                 // Add onReady callback
-          .and()                                  // Build the LifecycleListenerBuilder
-        .registerEventListener(StudioModeStateChangedEvent.class, this::onStudioModeStateChanged) // Register a StudioModeStateChangedEvent
-        .build();                                 // Build the OBSRemoteController
+                                                  .autoConnect(false)                       // Do not connect automatically
+                                                  .host("127.0.0.1")                        // Set the host
+                                                  .port(4455)                               // Set the port
+                                                  .password("53CR37")                       // Set the password
+                                                  .lifecycle()                              // Add some lifecycle callbacks
+                                                  .onReady(this::onReady)                   // Add onReady callback
+                                                  .and()                                    // Build the LifecycleListenerBuilder
+                                                  .registerEventListener(StudioModeStateChangedEvent.class, this::onStudioModeStateChanged) // Register a StudioModeStateChangedEvent
+                                                  .build();                                 // Build the OBSRemoteController
 
     // Connect
     this.obsRemoteController.connect();
@@ -38,8 +38,7 @@ public class Example {
     if (!this.isReconnecting) {
       // First connection
       this.onFirstConnection();
-    }
-    else {
+    } else {
       // Second connection
       this.onSecondConnection();
     }
@@ -51,7 +50,7 @@ public class Example {
       if (getSceneListResponse.isSuccessful()) {
         // Filter by isGroup
         List<Scene> groups = getSceneListResponse.getMessageData().getResponseData().getScenes()
-            .stream().filter(Scene::getIsGroup).collect(Collectors.toList());
+                                                 .stream().filter(Scene::getIsGroup).collect(Collectors.toList());
         // Print each Scene
         groups.forEach(System.out::println);
       }
@@ -65,16 +64,16 @@ public class Example {
     this.obsRemoteController.sendRequest(GetStudioModeEnabledRequest.builder().build(), requestResponse -> {
       if (requestResponse.isSuccessful()) {
         GetStudioModeEnabledResponse getStudioModeEnabledResponse = (GetStudioModeEnabledResponse) requestResponse;
-        if (getStudioModeEnabledResponse.getResponseData().getStudioModeEnabled()) {
-          // Studio Mode is enabled
-        }
-        else {
-          // Studio Mode is not enabled
+        if (getStudioModeEnabledResponse.getMessageData().getResponseData().getStudioModeEnabled()) {
+          System.out.println("Studio mode enabled");
+        } else {
+          System.out.println("Studio mode not enabled");
         }
       }
 
       // Disconnect
       this.obsRemoteController.disconnect();
+      this.obsRemoteController.stop();
     });
   }
 
@@ -90,6 +89,6 @@ public class Example {
 
   private void onStudioModeStateChanged(StudioModeStateChangedEvent studioModeStateChangedEvent) {
     System.out.printf(
-        "Studio Mode State Changed to: %B%n", studioModeStateChangedEvent.getMessageData().getEventData().getStudioModeEnabled());
+            "Studio Mode State Changed to: %B%n", studioModeStateChangedEvent.getMessageData().getEventData().getStudioModeEnabled());
   }
 }

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.message.event.general.StudioModeStateChangedEvent;
+import io.obswebsocket.community.client.message.event.inputs.InputVolumeChangedEvent;
+import io.obswebsocket.community.client.message.event.outputs.VirtualcamStateChangedEvent;
 import io.obswebsocket.community.client.message.request.general.GetStudioModeEnabledRequest;
 import io.obswebsocket.community.client.message.response.general.GetStudioModeEnabledResponse;
 import io.obswebsocket.community.client.model.Scene;
@@ -28,10 +30,20 @@ public class Example {
                                                   .onReady(this::onReady)                   // Add onReady callback
                                                   .and()                                    // Build the LifecycleListenerBuilder
                                                   .registerEventListener(StudioModeStateChangedEvent.class, this::onStudioModeStateChanged) // Register a StudioModeStateChangedEvent
+                                                  .registerEventListener(VirtualcamStateChangedEvent.class, this::onVirtualCamStateChanged)
+                                                  .registerEventListener(InputVolumeChangedEvent.class, this::onInputVolumeChanged)
                                                   .build();                                 // Build the OBSRemoteController
 
     // Connect
     this.obsRemoteController.connect();
+  }
+
+  private void onInputVolumeChanged(InputVolumeChangedEvent t) {
+    System.out.println(t);
+  }
+
+  private void onVirtualCamStateChanged(VirtualcamStateChangedEvent t) {
+    System.out.println(t);
   }
 
   private void onReady() {

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -1,13 +1,12 @@
 package io.obswebsocket.community.client.example;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.message.event.general.StudioModeStateChangedEvent;
 import io.obswebsocket.community.client.message.request.general.GetStudioModeEnabledRequest;
 import io.obswebsocket.community.client.message.response.general.GetStudioModeEnabledResponse;
 import io.obswebsocket.community.client.model.Scene;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class Example {
   private final OBSRemoteController obsRemoteController;
@@ -50,7 +49,7 @@ public class Example {
       if (getSceneListResponse.isSuccessful()) {
         // Filter by isGroup
         List<Scene> groups = getSceneListResponse.getMessageData().getResponseData().getScenes()
-                                                 .stream().filter(Scene::getIsGroup).collect(Collectors.toList());
+            .stream().filter(Scene::isGroup).collect(Collectors.toList());
         // Print each Scene
         groups.forEach(System.out::println);
       }

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -5,8 +5,6 @@ import java.util.stream.Collectors;
 
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.message.event.general.StudioModeStateChangedEvent;
-import io.obswebsocket.community.client.message.event.inputs.InputVolumeChangedEvent;
-import io.obswebsocket.community.client.message.event.outputs.VirtualcamStateChangedEvent;
 import io.obswebsocket.community.client.message.request.general.GetStudioModeEnabledRequest;
 import io.obswebsocket.community.client.message.response.general.GetStudioModeEnabledResponse;
 import io.obswebsocket.community.client.model.Scene;
@@ -30,20 +28,10 @@ public class Example {
                                                   .onReady(this::onReady)                   // Add onReady callback
                                                   .and()                                    // Build the LifecycleListenerBuilder
                                                   .registerEventListener(StudioModeStateChangedEvent.class, this::onStudioModeStateChanged) // Register a StudioModeStateChangedEvent
-                                                  .registerEventListener(VirtualcamStateChangedEvent.class, this::onVirtualCamStateChanged)
-                                                  .registerEventListener(InputVolumeChangedEvent.class, this::onInputVolumeChanged)
                                                   .build();                                 // Build the OBSRemoteController
 
     // Connect
     this.obsRemoteController.connect();
-  }
-
-  private void onInputVolumeChanged(InputVolumeChangedEvent t) {
-    System.out.println(t);
-  }
-
-  private void onVirtualCamStateChanged(VirtualcamStateChangedEvent t) {
-    System.out.println(t);
   }
 
   private void onReady() {

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -22,7 +22,7 @@ public class Example {
     this.obsRemoteController = OBSRemoteController.builder()
         .autoConnect(false)                       // Do not connect automatically
         .host("127.0.0.1")                        // Set the host
-        .port(4444)                               // Set the port
+        .port(4455)                               // Set the port
         .password("53CR37")                       // Set the password
         .lifecycle()                              // Add some lifecycle callbacks
           .onReady(this::onReady)                 // Add onReady callback


### PR DESCRIPTION
The compatibility branch didn't use the 'd' attribute for a lot of requests and had some overlapping private fields. Those should now be fixed.

I exposed the WebSocket client in the OBSRemote ControllerBuilder because the disconnect timeout is 30s by default which made my application lag when reconnecting. There is now also an explicit stop method on the OBSRemoteController which makes the WebSocket reusable (as it should be according to the Jetty documentation).