### PR TITLE
Fix/e2e tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto eol=lf
+* text=auto eol=lf encoding=utf-8

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
@@ -84,17 +84,18 @@ public abstract class AbstractObsE2ETest {
     // Hide all visible elements in all scenes
     remote.getSceneList(sceneListResponse -> {
       sceneListResponse.getScenes().forEach(scene -> {
-        // TODO: This data isn't actually there
-//        scene.getSources().forEach(source -> {
-//          if (!source.getName().startsWith("scenename")) {
-//            remote.setSourceVisibility(scene.getName(), source.getName(), false, result -> {
-//              if (result.getError() != null && !result.getError().isEmpty()) {
-//                fail(String.format("Failed to hide source '%s' on scene '%s'", source.getName(),
-//                    scene.getName()));
-//              }
-//            });
-//          }
-//        });
+        remote.getSceneItemList(scene.getSceneName(), getSceneItemListResponse -> {
+          getSceneItemListResponse.getSceneItems().forEach(sceneItem -> {
+            if (!sceneItem.getSourceName().startsWith("scenename")) {
+              remote.setSceneItemEnabled(scene.getSceneName(), sceneItem.getSceneItemId(), false, result -> {
+                if (!result.isSuccessful()) {
+                  fail(String.format("Failed to hide sceneItem '%s' on scene '%s'", sceneItem.getSourceName(),
+                      scene.getSceneName()));
+                }
+              });
+            }
+          });
+        });
       });
     });
   }

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/AbstractObsE2ETest.java
@@ -54,12 +54,8 @@ public abstract class AbstractObsE2ETest {
   protected static void connectToObs() {
     remote = OBSRemoteController.builder()
         .lifecycle()
-        .onControllerError(((reasonThrowable) -> {
-          System.out.println("An error occurred: " + reasonThrowable.getReason());
-          reasonThrowable.getThrowable().printStackTrace();
-        }))
+        .onControllerError(((reasonThrowable) -> fail("An error occurred: " + reasonThrowable.getReason(), reasonThrowable)))
         .onCommunicatorError(e -> fail("Unable to connect", e))
-        .onControllerError(e -> fail("Error", e))
         .and()
         .build();
     remote.connect();

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eIT.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eIT.java
@@ -27,7 +27,6 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
   @BeforeEach
   public void beforeEach() {
     setupObs();
-    resultQueue.clear();
   }
 
   @AfterAll
@@ -49,14 +48,9 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
         .currentProgramSceneName(SCENE1).scenes(expectedScenes).build();
 
     // When retrieved
-    remote.getSceneList(capturingCallback);
-    waitReasonably();
-
-    // Then scenes match as expected
-    GetSceneListResponse res = getPreviousResponseAs(GetSceneListResponse.class);
+    GetSceneListResponse res = remote.getSceneList(1000);
     assertThat(res.getMessageData().getResponseData())
             .usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedResponseData);
-
   }
 
   @Disabled
@@ -80,7 +74,6 @@ public class ObsRemoteE2eIT extends AbstractObsE2ETest {
     // When retrieved
 //    remote.getSourcesList(capturingCallback);
     fail("getSourcesList not implemented");
-    waitReasonably();
 
     // Then it matches as expected
 //    GetSourcesListResponse res = getPreviousResponseAs(GetSourcesListResponse.class);

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.inputs.GetInputMuteResponse;
 import java.io.File;
 import org.junit.jupiter.api.AfterAll;
@@ -115,17 +116,18 @@ public class ObsRemoteE2eObservationIT extends AbstractObsE2ETest {
     remote.setStudioModeEnabled(false, loggingCallback());
   }
 
-//  TODO: I don't see how to change the source name
-//  @Test
-//  void setSourceSettings() {
-//    obsShould("Curse the 'scene1' text");
-//    Map<String, Object> settings = new HashMap<>();
-//    settings.put("text", "S̼͚̞̼̩̱̽̓̍̽͊́ͨ̍̀ċͭ̚҉̪̖̤̥ͅȩ͉̣̜̖̖͙͇́̀̒ͥ̓̚͠͞n̦͍͆͑ͤ̕e̶̖̝̗̻͂̑̽̔ͩ̅́͜ͅ ̢͉̬͔͙̺̖͂͂ͣ͢1̮̥͇̏̇͋̈́ͨͥ͝ͅ");
-//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback());
-//    obsShould("Change the 'scene1' text back to normal");
-//    settings.put("text", "Scene 1");
-//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback());
-//  }
+  @Test
+  void setSourceSettings() {
+    obsShould("Curse the 'scene1' text");
+
+    JsonObject setting = new JsonObject();
+    setting.addProperty("text", "S̼͚̞̼̩̱̽̓̍̽͊́ͨ̍̀ċͭ̚҉̪̖̤̥ͅȩ͉̣̜̖̖͙͇́̀̒ͥ̓̚͠͞n̦͍͆͑ͤ̕e̶̖̝̗̻͂̑̽̔ͩ̅́͜ͅ ̢͉̬͔͙̺̖͂͂ͣ͢1̮̥͇̏̇͋̈́ͨͥ͝ͅ");
+    remote.setInputSettings(SOURCE_TEXT_SCENE1, setting, false, loggingCallback());
+
+    obsShould("Change the 'scene1' text back to normal");
+    setting.addProperty("text", "Scene 1");
+    remote.setInputSettings(SOURCE_TEXT_SCENE1, setting, false, loggingCallback());
+  }
 
   @Test
   void takeSourceScreenshot() {
@@ -237,11 +239,10 @@ public class ObsRemoteE2eObservationIT extends AbstractObsE2ETest {
     obsShould("Show the browser source", 1);
     remote.setSceneItemEnabled(SCENE1, browserId, true, loggingCallback());
 
-    // TODO: How to do this?
-//    obsShould("Refresh the browser source (new random color and number)");
-//    remote.refreshBrowserSource(SOURCE_BROWSER, loggingCallback());
-//    waitReasonably(1000);
+    obsShould("Refresh the browser source (new random color and number)");
+    remote.pressInputPropertiesButton(SOURCE_BROWSER, "refreshnocache", loggingCallback());
 
+    obsShould("Hide the browser again");
     remote.setSceneItemEnabled(SCENE1, browserId, false, loggingCallback());
   }
 }

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
@@ -192,33 +192,32 @@ public class ObsRemoteE2eObservationIT extends AbstractObsE2ETest {
     remote.setInputVolume(SOURCE_MEDIA, 1.00, null, loggingCallback());
   }
 
-//  TODO: How to do this?
-//  @Test
-//  void playPauseVlcMedia() {
-//    Number vlcId = remote.getSceneItemId(SCENE1, SOURCE_VLC_MEDIA, 0, 1000).getSceneItemId();
-//    obsShould("Play video 1, by showing it (Note, VLC must be installed!)");
-//    remote.setSceneItemEnabled(SCENE1, vlcId, true, loggingCallback());
-//
-//    obsShould("Pause video 1");
-//    remote.pauseMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//
-//    // BUG: Toggle Play/Pause does not work in Palakis OBS plugin!
-//    // see https://github.com/obsproject/obs-websocket/issues/725
-//    // I've noted we can also replicate the problem
-//    obsShould("Toggle Play Video 1");
-//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//    obsShould("Toggle Pause Video 1");
-//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//
-//    obsShould("Switch to video 2");
-//    remote.nextMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//
-//    obsShould("Restart, back at video 1 (should auto play)");
-//    remote.restartMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//
-//    obsShould("Stop video 1 (going back to beginning)");
-//    remote.stopMedia(SOURCE_VLC_MEDIA, loggingCallback());
-//  }
+  @Test
+  void playPauseVlcMedia() {
+    Number vlcId = remote.getSceneItemId(SCENE1, SOURCE_VLC_MEDIA, 0, 1000).getSceneItemId();
+    obsShould("Play video 1, by showing it (Note, VLC must be installed!)");
+    remote.setSceneItemEnabled(SCENE1, vlcId, true, loggingCallback());
+
+    obsShould("Pause video 1");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PAUSE", loggingCallback());
+
+    // BUG: Toggle Play/Pause does not work in Palakis OBS plugin!
+    // see https://github.com/obsproject/obs-websocket/issues/725
+    // I've noted we can also replicate the problem
+    obsShould("Toggle Play Video 1");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PLAY", loggingCallback());
+    obsShould("Toggle Pause Video 1");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PAUSE", loggingCallback());
+
+    obsShould("Switch to video 2");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_NEXT", loggingCallback());
+
+    obsShould("Restart, back at video 1 (should auto play)");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART", loggingCallback());
+
+    obsShould("Stop video 1 (going back to beginning)");
+    remote.triggerMediaInputAction(SOURCE_VLC_MEDIA, "OBS_WEBSOCKET_MEDIA_INPUT_ACTION_STOP", loggingCallback());
+  }
 
   @Test
   void triggerHotkey() {

--- a/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
+++ b/client/src/endToEndManualTest/java/io/obswebsocket/community/client/test/ObsRemoteE2eObservationIT.java
@@ -1,223 +1,248 @@
 package io.obswebsocket.community.client.test;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.obswebsocket.community.client.message.response.inputs.GetInputMuteResponse;
+import java.io.File;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test should be run manually, following the prompts in the command-line and observing OBS for
  * the desired behavior. Authentication should be disabled. See the README in the obs-resources
  * directory for more information.
  */
-@Disabled
 public class ObsRemoteE2eObservationIT extends AbstractObsE2ETest {
 
-//  @BeforeAll
-//  static void beforeAll() {
-//    connectToObs();
-//  }
-//
-//  @BeforeEach
-//  public void beforeEach() {
-//    System.out.println("===============================");
-//    System.out.println(">> Resetting...");
-//    setupObs();
-//    System.out.println(">> ...Ready");
-//  }
-//
-//  @AfterAll
-//  static void afterAll() {
-//    remote.disconnect();
+  @BeforeAll
+  static void beforeAll() {
+    connectToObs();
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    System.out.println("===============================");
+    System.out.println(">> Resetting...");
+    setupObs();
+    System.out.println(">> ...Ready");
+  }
+
+  @AfterAll
+  static void afterAll() {
+    remote.disconnect();
 //    System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "Debug");
-//  }
-//
-//  @AfterEach
-//  public void afterEach() {
-//    try {
-//      Thread.sleep(1000);
-//    } catch (InterruptedException e) {
-//      e.printStackTrace();
-//    }
-//    System.out.println("<< Test Complete");
-//
-//  }
-//
-//  @Test
-//  void switchScene() {
-//    obsShould("Switch to scene2");
-//    remote.changeSceneWithTransition(SCENE2, TRANSITION_CUT, loggingCallback);
-//    obsShould("Switch back to scene1");
-//    remote.setCurrentScene(SCENE1, loggingCallback);
-//  }
-//
-//  @Test
-//  void showHideSceneItem() {
-//    obsShould("Show the red square");
-//    remote.setSourceVisibility(null, SOURCE_RED_SQUARE, true, loggingCallback);
-//    obsShould("Hide the red square");
-//    remote.setSourceVisibility(null, SOURCE_RED_SQUARE, false, loggingCallback);
-//  }
-//
-//  @Test
-//  void setTransition() {
-//    obsShould("Set current transition to Slide, with transition 2000ms");
-//    remote.setCurrentTransition(TRANSITION_SLIDE, loggingCallback);
-//    remote.setTransitionDuration(2000, loggingCallback);
-//    obsShould("Set current transition back to 300ms");
-//    remote.setTransitionDuration(300, loggingCallback);
-//    obsShould("Set current transition back to Cut");
-//    remote.setCurrentTransition(TRANSITION_CUT, loggingCallback);
-//  }
-//
-//  @Test
-//  void changeScenesWithTransition() {
-//    obsShould("Change to scene2, with the Slide transition");
-//    remote.changeSceneWithTransition(SCENE2, TRANSITION_SLIDE, loggingCallback);
-//  }
-//
-//  @Test
-//  void setSourceFilterVisibility() {
-//
-//    obsShould("Show a blue square (red square colored blue by a filter)");
-//    remote.setSourceVisibility(null, SOURCE_RED_SQUARE, true, loggingCallback);
-//    remote.setSourceFilterVisibility(SOURCE_RED_SQUARE, SOURCE_RED_SQUARE_FILTER, true,
-//      loggingCallback);
-//    obsShould("Return the red square to normal");
-//    remote.setSourceFilterVisibility(SOURCE_RED_SQUARE, SOURCE_RED_SQUARE_FILTER, false,
-//      loggingCallback);
-//
-//  }
-//
-//  @Test
-//  void exerciseStudioMode() {
-//    obsShould("Enable studio mode");
-//    remote.setStudioModeEnabled(true, loggingCallback);
-//    obsShould("Set preview scene to scene2");
-//    remote.setPreviewScene(SCENE2, loggingCallback);
-//    obsShould("Fade to scene2");
-//    remote.transitionToProgram(TRANSITION_FADE, 1500, loggingCallback);
-//    obsShould("Disable studio mode");
-//    remote.setStudioModeEnabled(false, loggingCallback);
-//
-//  }
-//
+  }
+
+  @AfterEach
+  public void afterEach() {
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    System.out.println("<< Test Complete");
+
+  }
+
+  @Test
+  void switchScene() {
+    obsShould("Switch to scene2");
+    remote.setCurrentProgramScene(SCENE2, loggingCallback());
+    obsShould("Switch back to scene1");
+    remote.setCurrentProgramScene(SCENE1, loggingCallback());
+  }
+
+  @Test
+  void showHideSceneItem() {
+    Number squareId = remote.getSceneItemId(SCENE1, SOURCE_RED_SQUARE, 0, 1000)
+        .getSceneItemId();
+
+    obsShould("Show the red square");
+    remote.setSceneItemEnabled(SCENE1, squareId, true, loggingCallback());
+    obsShould("Hide the red square");
+    remote.setSceneItemEnabled(SCENE1, squareId, false, loggingCallback());
+  }
+
+  @Test
+  void setTransition() {
+    obsShould("Set current transition to Slide, with transition 2000ms");
+
+    remote.setCurrentSceneTransition(TRANSITION_SLIDE, loggingCallback());
+    remote.setCurrentSceneTransitionDuration(2000, loggingCallback());
+    obsShould("Set current transition back to 300ms");
+    remote.setCurrentSceneTransitionDuration(300, loggingCallback());
+    obsShould("Set current transition back to Cut");
+    remote.setCurrentSceneTransition(TRANSITION_CUT, loggingCallback());
+  }
+
+  @Test
+  void changeScenesWithTransition() {
+    obsShould("Change to scene2, with the Slide transition");
+    remote.setCurrentSceneTransition(TRANSITION_SLIDE, 1000);
+    remote.setCurrentProgramScene(SCENE2, loggingCallback());
+  }
+
+  @Test
+  void setSourceFilterVisibility() {
+    Number squareId = remote.getSceneItemId(SCENE1, SOURCE_RED_SQUARE, 0, 1000)
+        .getSceneItemId();
+
+    obsShould("Show a blue square (red square colored blue by a filter)");
+    remote.setSceneItemEnabled(SCENE1, squareId, true, loggingCallback());
+    remote.setSourceFilterEnabled(SOURCE_RED_SQUARE, SOURCE_RED_SQUARE_FILTER, true,
+        loggingCallback());
+    obsShould("Return the red square to normal");
+    remote.setSceneItemEnabled(SCENE1, squareId, false, loggingCallback());
+  }
+
+  @Test
+  void exerciseStudioMode() {
+    obsShould("Enable studio mode");
+    remote.setStudioModeEnabled(true, loggingCallback());
+    obsShould("Set preview scene to scene2");
+    remote.setCurrentPreviewScene(SCENE2, loggingCallback());
+    remote.setCurrentSceneTransition(TRANSITION_FADE, loggingCallback());
+
+    obsShould("Fade to scene2");
+    remote.triggerStudioModeTransition(loggingCallback());
+
+    obsShould("Disable studio mode");
+    remote.setStudioModeEnabled(false, loggingCallback());
+  }
+
+//  TODO: I don't see how to change the source name
 //  @Test
 //  void setSourceSettings() {
 //    obsShould("Curse the 'scene1' text");
 //    Map<String, Object> settings = new HashMap<>();
 //    settings.put("text", "S̼͚̞̼̩̱̽̓̍̽͊́ͨ̍̀ċͭ̚҉̪̖̤̥ͅȩ͉̣̜̖̖͙͇́̀̒ͥ̓̚͠͞n̦͍͆͑ͤ̕e̶̖̝̗̻͂̑̽̔ͩ̅́͜ͅ ̢͉̬͔͙̺̖͂͂ͣ͢1̮̥͇̏̇͋̈́ͨͥ͝ͅ");
-//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback);
+//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback());
 //    obsShould("Change the 'scene1' text back to normal");
 //    settings.put("text", "Scene 1");
-//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback);
+//    remote.setSourceSettings(SOURCE_TEXT_SCENE1, settings, loggingCallback());
 //  }
-//
-//  @Test
-//  void takeSourceScreenshot() throws Exception {
-//    String path = System.getProperty("user.home");
-//    assertThat(path).isNotNull();
-//    File file = new File(path, "test.png");
-//    String screenshotPath = file.getAbsolutePath();
-//    obsShould("Take a screenshot of the current scene, and save it to " + screenshotPath, 1);
-//    remote.takeSourceScreenshot(
-//      SCENE1, "png",
-//      screenshotPath,
-//      null, 1,
-//      1080, 720,
-//      loggingCallback
-//    );
-//  }
-//
-//  @Test
-//  void startStopStreaming() {
-//    obsShould("Start Streaming");
-//    remote.startStreaming(loggingCallback);
-//    obsShould("Stop Streaming");
-//    remote.stopStreaming(loggingCallback);
-//  }
-//
-//  @Test
-//  void startStopRecordingAndReplayBuffer() {
-//    obsShould("Start Recording");
-//    remote.startRecording(loggingCallback);
-//
-//    obsShould("Start the replay buffer");
-//    remote.startReplayBuffer(loggingCallback);
-//
-//    obsShould("Save the replay buffer");
-//    remote.saveReplayBuffer(loggingCallback);
-//
-//    obsShould("Stop the replay buffer");
-//    remote.stopReplayBuffer(loggingCallback);
-//
-//    obsShould("Stop Recording");
-//    remote.stopRecording(loggingCallback);
-//  }
-//
-//  @Test
-//  void setVolumeAndMute() {
-//
-//    obsShould("Set the volume to 50% (note, appears 67% due to log scaling; check % in advanced audio properties)");
-//    remote.setSourceVisibility(null, "media", true, loggingCallback);
-//    remote.setVolume(SOURCE_MEDIA, 0.50, loggingCallback);
-//    obsShould("Mute the volume");
-//    remote.setMute(SOURCE_MEDIA, true, loggingCallback);
-//    remote.getMute(SOURCE_MEDIA, capturingCallback);
-//    waitReasonably();
-//    assertThat(getPreviousResponseAs(GetMuteResponse.class).isMuted()).isTrue();
-//
-//    obsShould("Unmute the volume");
-//    remote.setMute(SOURCE_MEDIA, false, loggingCallback);
-//    remote.getMute(SOURCE_MEDIA, capturingCallback);
-//    waitReasonably();
-//    assertThat(getPreviousResponseAs(GetMuteResponse.class).isMuted()).isFalse();
-//
-//    obsShould("Set the volume to 100%");
-//    remote.setVolume(SOURCE_MEDIA, 1.00, loggingCallback);
-//
-//  }
-//
+
+  @Test
+  void takeSourceScreenshot() {
+    String path = System.getProperty("user.home");
+    assertNotNull(path);
+    File file = new File(path, "test.png");
+    String screenshotPath = file.getAbsolutePath();
+    obsShould("Take a screenshot of the current scene, and save it to " + screenshotPath, 1);
+    remote.saveSourceScreenshot(
+        SCENE1, "png",
+        screenshotPath,
+        1080, 720,
+        1,
+        loggingCallback()
+    );
+  }
+
+  @Test
+  void startStopStreaming() {
+    obsShould("Start Streaming");
+    remote.startStream(loggingCallback());
+    obsShould("Stop Streaming");
+    remote.stopStream(loggingCallback());
+  }
+
+  @Test
+  void startStopRecordingAndReplayBuffer() {
+    obsShould("Start Recording");
+    remote.startRecord(loggingCallback());
+
+    obsShould("Start the replay buffer");
+    remote.startReplayBuffer(loggingCallback());
+
+    obsShould("Save the replay buffer");
+    remote.saveReplayBuffer(loggingCallback());
+
+    obsShould("Stop the replay buffer");
+    remote.stopReplayBuffer(loggingCallback());
+
+    obsShould("Stop Recording");
+    remote.stopRecord(loggingCallback());
+  }
+
+  @Test
+  void setVolumeAndMute() {
+    Number mediaId = remote.getSceneItemId(SCENE1, "media", 0, 1000).getSceneItemId();
+
+    obsShould(
+        "Set the volume to 50% (note, appears 67% due to log scaling; check % in advanced audio properties)");
+    remote.setSceneItemEnabled(SCENE1, mediaId, true, loggingCallback());
+    remote.setInputVolume(SOURCE_MEDIA, 0.50, null, loggingCallback());
+
+    obsShould("Mute the volume");
+    remote.setInputMute(SOURCE_MEDIA, true, loggingCallback());
+    GetInputMuteResponse muteResponse = remote.getInputMute(SOURCE_MEDIA, 1000);
+    assertTrue(muteResponse.getInputMuted());
+
+    obsShould("Unmute the volume");
+    remote.setInputMute(SOURCE_MEDIA, false, loggingCallback());
+    GetInputMuteResponse unmuteResponse = remote.getInputMute(SOURCE_MEDIA, 1000);
+    assertFalse(unmuteResponse.getInputMuted());
+
+    obsShould("Set the volume to 100%");
+    remote.setInputVolume(SOURCE_MEDIA, 1.00, null, loggingCallback());
+  }
+
+//  TODO: How to do this?
 //  @Test
 //  void playPauseVlcMedia() {
+//    Number vlcId = remote.getSceneItemId(SCENE1, SOURCE_VLC_MEDIA, 0, 1000).getSceneItemId();
 //    obsShould("Play video 1, by showing it (Note, VLC must be installed!)");
-//    remote.setSourceVisibility(null, SOURCE_VLC_MEDIA, true, loggingCallback);
+//    remote.setSceneItemEnabled(SCENE1, vlcId, true, loggingCallback());
 //
 //    obsShould("Pause video 1");
-//    remote.pauseMedia(SOURCE_VLC_MEDIA, loggingCallback);
+//    remote.pauseMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //
 //    // BUG: Toggle Play/Pause does not work in Palakis OBS plugin!
 //    // see https://github.com/obsproject/obs-websocket/issues/725
 //    // I've noted we can also replicate the problem
 //    obsShould("Toggle Play Video 1");
-//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback);
+//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //    obsShould("Toggle Pause Video 1");
-//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback);
+//    remote.toggleMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //
 //    obsShould("Switch to video 2");
-//    remote.nextMedia(SOURCE_VLC_MEDIA, loggingCallback);
+//    remote.nextMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //
 //    obsShould("Restart, back at video 1 (should auto play)");
-//    remote.restartMedia(SOURCE_VLC_MEDIA, loggingCallback);
+//    remote.restartMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //
 //    obsShould("Stop video 1 (going back to beginning)");
-//    remote.stopMedia(SOURCE_VLC_MEDIA, loggingCallback);
-//
-//  }
-//
-//  @Test
-//  void triggerHotkey() {
-//    obsShould("Show the red square via hotkey name");
-//    remote.triggerHotkeyByName("libobs.show_scene_item.red_square", loggingCallback);
-//  }
-//
-//  @Test
-//  void refreshBrowserSource() {
-//
-//    obsShould("Show the browser source", 1);
-//    remote.setSourceVisibility(null, SOURCE_BROWSER, true, loggingCallback);
-//
-//    obsShould("Refresh the browser source (new random color and number)");
-//    remote.refreshBrowserSource(SOURCE_BROWSER, loggingCallback);
-//    waitReasonably(1000);
-//
+//    remote.stopMedia(SOURCE_VLC_MEDIA, loggingCallback());
 //  }
 
+  @Test
+  void triggerHotkey() {
+    Number squareId = remote.getSceneItemId(SCENE1, SOURCE_RED_SQUARE, 0, 1000).getSceneItemId();
+
+    obsShould("Show the red square via hotkey name");
+    remote.triggerHotkeyByName("libobs.show_scene_item.red_square", loggingCallback());
+
+    obsShould("Hide the square again");
+    remote.setSceneItemEnabled(SCENE1, squareId, false, loggingCallback());
+  }
+
+  @Test
+  void refreshBrowserSource() {
+    Number browserId = remote.getSceneItemId(SCENE1, SOURCE_BROWSER, 0, 1000).getSceneItemId();
+
+    obsShould("Show the browser source", 1);
+    remote.setSceneItemEnabled(SCENE1, browserId, true, loggingCallback());
+
+    // TODO: How to do this?
+//    obsShould("Refresh the browser source (new random color and number)");
+//    remote.refreshBrowserSource(SOURCE_BROWSER, loggingCallback());
+//    waitReasonably(1000);
+
+    remote.setSceneItemEnabled(SCENE1, browserId, false, loggingCallback());
+  }
 }

--- a/client/src/integrationTest/java/io/obswebsocket/community/client/test/ObsCommunicatorEventIT.java
+++ b/client/src/integrationTest/java/io/obswebsocket/community/client/test/ObsCommunicatorEventIT.java
@@ -1194,7 +1194,7 @@ public class ObsCommunicatorEventIT {
         + "\t\t\t'scenes': [\n"
         + "\t\t\t\t{\n"
         + "\t\t\t\t'sceneName': 'sceneName',\n"
-        + "\t\t\t\t'sceneItemIndex': 5\n"
+        + "\t\t\t\t'sceneIndex': 5\n"
         + "\t\t\t\t}\n"
         + "\t\t\t]\n"
         + "\t\t}\n"
@@ -1210,7 +1210,9 @@ public class ObsCommunicatorEventIT {
     assertEquals(
         actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getSceneName(),
         "sceneName");
-    assertEquals(actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getSceneItemIndex(), 5);
+    assertEquals(
+        actualTestResult.get().getMessageData().getEventData().getScenes().get(0).getSceneIndex(),
+        5);
   }
 
   @Test

--- a/client/src/main/java/io/obswebsocket/community/client/BlockingConsumer.java
+++ b/client/src/main/java/io/obswebsocket/community/client/BlockingConsumer.java
@@ -1,0 +1,26 @@
+package io.obswebsocket.community.client;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class BlockingConsumer<T> implements Consumer<T> {
+
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private T result;
+
+  @Override
+  public void accept(T t) {
+    this.result = t;
+    latch.countDown();
+  }
+
+  public T get(long timeout) throws InterruptedException {
+    if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+      log.warn("Timeout waiting for result");
+    }
+    return result;
+  }
+}

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBase.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBase.java
@@ -309,6 +309,7 @@ public abstract class OBSRemoteControllerBase {
    * @param realm The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
    * @param slotName The name of the slot to retrieve data from
    * @param timeout long timeout in ms
+   * @return the GetPersistentDataResponse, null if the request timed out
    */
   public GetPersistentDataResponse getPersistentData(Realm realm, String slotName, long timeout) {
     BlockingConsumer<GetPersistentDataResponse> callback = new BlockingConsumer<GetPersistentDataResponse>();
@@ -336,6 +337,7 @@ public abstract class OBSRemoteControllerBase {
    * @param slotName The name of the slot to retrieve data from
    * @param slotValue The value to apply to the slot
    * @param timeout long timeout in ms
+   * @return the SetPersistentDataResponse, null if the request timed out
    */
   public SetPersistentDataResponse setPersistentData(Realm realm, String slotName,
       JsonElement slotValue, long timeout) {
@@ -357,6 +359,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets an array of all scene collections
    *
    * @param timeout long timeout in ms
+   * @return the GetSceneCollectionListResponse, null if the request timed out
    */
   public GetSceneCollectionListResponse getSceneCollectionList(long timeout) {
     BlockingConsumer<GetSceneCollectionListResponse> callback = new BlockingConsumer<GetSceneCollectionListResponse>();
@@ -384,6 +387,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneCollectionName Name of the scene collection to switch to
    * @param timeout long timeout in ms
+   * @return the SetCurrentSceneCollectionResponse, null if the request timed out
    */
   public SetCurrentSceneCollectionResponse setCurrentSceneCollection(String sceneCollectionName,
       long timeout) {
@@ -412,6 +416,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneCollectionName Name for the new scene collection
    * @param timeout long timeout in ms
+   * @return the CreateSceneCollectionResponse, null if the request timed out
    */
   public CreateSceneCollectionResponse createSceneCollection(String sceneCollectionName,
       long timeout) {
@@ -433,6 +438,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets an array of all profiles
    *
    * @param timeout long timeout in ms
+   * @return the GetProfileListResponse, null if the request timed out
    */
   public GetProfileListResponse getProfileList(long timeout) {
     BlockingConsumer<GetProfileListResponse> callback = new BlockingConsumer<GetProfileListResponse>();
@@ -455,6 +461,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param profileName Name of the profile to switch to
    * @param timeout long timeout in ms
+   * @return the SetCurrentProfileResponse, null if the request timed out
    */
   public SetCurrentProfileResponse setCurrentProfile(String profileName, long timeout) {
     BlockingConsumer<SetCurrentProfileResponse> callback = new BlockingConsumer<SetCurrentProfileResponse>();
@@ -477,6 +484,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param profileName Name for the new profile
    * @param timeout long timeout in ms
+   * @return the CreateProfileResponse, null if the request timed out
    */
   public CreateProfileResponse createProfile(String profileName, long timeout) {
     BlockingConsumer<CreateProfileResponse> callback = new BlockingConsumer<CreateProfileResponse>();
@@ -499,6 +507,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param profileName Name of the profile to remove
    * @param timeout long timeout in ms
+   * @return the RemoveProfileResponse, null if the request timed out
    */
   public RemoveProfileResponse removeProfile(String profileName, long timeout) {
     BlockingConsumer<RemoveProfileResponse> callback = new BlockingConsumer<RemoveProfileResponse>();
@@ -524,6 +533,7 @@ public abstract class OBSRemoteControllerBase {
    * @param parameterCategory Category of the parameter to get
    * @param parameterName Name of the parameter to get
    * @param timeout long timeout in ms
+   * @return the GetProfileParameterResponse, null if the request timed out
    */
   public GetProfileParameterResponse getProfileParameter(String parameterCategory,
       String parameterName, long timeout) {
@@ -552,6 +562,7 @@ public abstract class OBSRemoteControllerBase {
    * @param parameterName Name of the parameter to set
    * @param parameterValue Value of the parameter to set. Use `null` to delete
    * @param timeout long timeout in ms
+   * @return the SetProfileParameterResponse, null if the request timed out
    */
   public SetProfileParameterResponse setProfileParameter(String parameterCategory,
       String parameterName, String parameterValue, long timeout) {
@@ -577,6 +588,7 @@ public abstract class OBSRemoteControllerBase {
    * Note: To get the true FPS value, divide the FPS numerator by the FPS denominator. Example: `60000/1001`
    *
    * @param timeout long timeout in ms
+   * @return the GetVideoSettingsResponse, null if the request timed out
    */
   public GetVideoSettingsResponse getVideoSettings(long timeout) {
     BlockingConsumer<GetVideoSettingsResponse> callback = new BlockingConsumer<GetVideoSettingsResponse>();
@@ -615,6 +627,7 @@ public abstract class OBSRemoteControllerBase {
    * @param outputWidth Width of the output resolution in pixels
    * @param outputHeight Height of the output resolution in pixels
    * @param timeout long timeout in ms
+   * @return the SetVideoSettingsResponse, null if the request timed out
    */
   public SetVideoSettingsResponse setVideoSettings(Number fpsNumerator, Number fpsDenominator,
       Number baseWidth, Number baseHeight, Number outputWidth, Number outputHeight, long timeout) {
@@ -636,6 +649,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the current stream service settings (stream destination).
    *
    * @param timeout long timeout in ms
+   * @return the GetStreamServiceSettingsResponse, null if the request timed out
    */
   public GetStreamServiceSettingsResponse getStreamServiceSettings(long timeout) {
     BlockingConsumer<GetStreamServiceSettingsResponse> callback = new BlockingConsumer<GetStreamServiceSettingsResponse>();
@@ -665,6 +679,7 @@ public abstract class OBSRemoteControllerBase {
    * @param streamServiceType Type of stream service to apply. Example: `rtmp_common` or `rtmp_custom`
    * @param streamServiceSettings Settings to apply to the service
    * @param timeout long timeout in ms
+   * @return the SetStreamServiceSettingsResponse, null if the request timed out
    */
   public SetStreamServiceSettingsResponse setStreamServiceSettings(String streamServiceType,
       JsonObject streamServiceSettings, long timeout) {
@@ -686,6 +701,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the current directory that the record output is set to.
    *
    * @param timeout long timeout in ms
+   * @return the GetRecordDirectoryResponse, null if the request timed out
    */
   public GetRecordDirectoryResponse getRecordDirectory(long timeout) {
     BlockingConsumer<GetRecordDirectoryResponse> callback = new BlockingConsumer<GetRecordDirectoryResponse>();
@@ -709,6 +725,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sourceName Name of the source
    * @param timeout long timeout in ms
+   * @return the GetSourceFilterListResponse, null if the request timed out
    */
   public GetSourceFilterListResponse getSourceFilterList(String sourceName, long timeout) {
     BlockingConsumer<GetSourceFilterListResponse> callback = new BlockingConsumer<GetSourceFilterListResponse>();
@@ -732,6 +749,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param filterKind Filter kind to get the default settings for
    * @param timeout long timeout in ms
+   * @return the GetSourceFilterDefaultSettingsResponse, null if the request timed out
    */
   public GetSourceFilterDefaultSettingsResponse getSourceFilterDefaultSettings(String filterKind,
       long timeout) {
@@ -762,6 +780,7 @@ public abstract class OBSRemoteControllerBase {
    * @param filterKind The kind of filter to be created
    * @param filterSettings Settings object to initialize the filter with
    * @param timeout long timeout in ms
+   * @return the CreateSourceFilterResponse, null if the request timed out
    */
   public CreateSourceFilterResponse createSourceFilter(String sourceName, String filterName,
       String filterKind, JsonObject filterSettings, long timeout) {
@@ -788,6 +807,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sourceName Name of the source the filter is on
    * @param filterName Name of the filter to remove
    * @param timeout long timeout in ms
+   * @return the RemoveSourceFilterResponse, null if the request timed out
    */
   public RemoveSourceFilterResponse removeSourceFilter(String sourceName, String filterName,
       long timeout) {
@@ -816,6 +836,7 @@ public abstract class OBSRemoteControllerBase {
    * @param filterName Current name of the filter
    * @param newFilterName New name for the filter
    * @param timeout long timeout in ms
+   * @return the SetSourceFilterNameResponse, null if the request timed out
    */
   public SetSourceFilterNameResponse setSourceFilterName(String sourceName, String filterName,
       String newFilterName, long timeout) {
@@ -842,6 +863,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sourceName Name of the source
    * @param filterName Name of the filter
    * @param timeout long timeout in ms
+   * @return the GetSourceFilterResponse, null if the request timed out
    */
   public GetSourceFilterResponse getSourceFilter(String sourceName, String filterName,
       long timeout) {
@@ -870,6 +892,7 @@ public abstract class OBSRemoteControllerBase {
    * @param filterName Name of the filter
    * @param filterIndex New index position of the filter
    * @param timeout long timeout in ms
+   * @return the SetSourceFilterIndexResponse, null if the request timed out
    */
   public SetSourceFilterIndexResponse setSourceFilterIndex(String sourceName, String filterName,
       Number filterIndex, long timeout) {
@@ -901,6 +924,7 @@ public abstract class OBSRemoteControllerBase {
    * @param filterSettings Object of settings to apply
    * @param overlay True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.
    * @param timeout long timeout in ms
+   * @return the SetSourceFilterSettingsResponse, null if the request timed out
    */
   public SetSourceFilterSettingsResponse setSourceFilterSettings(String sourceName,
       String filterName, JsonObject filterSettings, Boolean overlay, long timeout) {
@@ -929,6 +953,7 @@ public abstract class OBSRemoteControllerBase {
    * @param filterName Name of the filter
    * @param filterEnabled New enable state of the filter
    * @param timeout long timeout in ms
+   * @return the SetSourceFilterEnabledResponse, null if the request timed out
    */
   public SetSourceFilterEnabledResponse setSourceFilterEnabled(String sourceName, String filterName,
       Boolean filterEnabled, long timeout) {
@@ -950,6 +975,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets data about the current plugin and RPC version.
    *
    * @param timeout long timeout in ms
+   * @return the GetVersionResponse, null if the request timed out
    */
   public GetVersionResponse getVersion(long timeout) {
     BlockingConsumer<GetVersionResponse> callback = new BlockingConsumer<GetVersionResponse>();
@@ -970,6 +996,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets statistics about OBS, obs-websocket, and the current session.
    *
    * @param timeout long timeout in ms
+   * @return the GetStatsResponse, null if the request timed out
    */
   public GetStatsResponse getStats(long timeout) {
     BlockingConsumer<GetStatsResponse> callback = new BlockingConsumer<GetStatsResponse>();
@@ -993,6 +1020,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param eventData Data payload to emit to all receivers
    * @param timeout long timeout in ms
+   * @return the BroadcastCustomEventResponse, null if the request timed out
    */
   public BroadcastCustomEventResponse broadcastCustomEvent(JsonObject eventData, long timeout) {
     BlockingConsumer<BroadcastCustomEventResponse> callback = new BlockingConsumer<BroadcastCustomEventResponse>();
@@ -1026,6 +1054,7 @@ public abstract class OBSRemoteControllerBase {
    * @param requestType The request type to call
    * @param requestData Object containing appropriate request data
    * @param timeout long timeout in ms
+   * @return the CallVendorRequestResponse, null if the request timed out
    */
   public CallVendorRequestResponse callVendorRequest(String vendorName, String requestType,
       JsonObject requestData, long timeout) {
@@ -1047,6 +1076,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets an array of all hotkey names in OBS
    *
    * @param timeout long timeout in ms
+   * @return the GetHotkeyListResponse, null if the request timed out
    */
   public GetHotkeyListResponse getHotkeyList(long timeout) {
     BlockingConsumer<GetHotkeyListResponse> callback = new BlockingConsumer<GetHotkeyListResponse>();
@@ -1070,6 +1100,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param hotkeyName Name of the hotkey to trigger
    * @param timeout long timeout in ms
+   * @return the TriggerHotkeyByNameResponse, null if the request timed out
    */
   public TriggerHotkeyByNameResponse triggerHotkeyByName(String hotkeyName, long timeout) {
     BlockingConsumer<TriggerHotkeyByNameResponse> callback = new BlockingConsumer<TriggerHotkeyByNameResponse>();
@@ -1095,6 +1126,7 @@ public abstract class OBSRemoteControllerBase {
    * @param keyId The OBS key ID to use. See https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h
    * @param keyModifiers Object containing key modifiers to apply
    * @param timeout long timeout in ms
+   * @return the TriggerHotkeyByKeySequenceResponse, null if the request timed out
    */
   public TriggerHotkeyByKeySequenceResponse triggerHotkeyByKeySequence(String keyId,
       KeyModifiers keyModifiers, long timeout) {
@@ -1120,6 +1152,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sleepMillis Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)
    * @param sleepFrames Number of frames to sleep for (if `SERIAL_FRAME` mode)
    * @param timeout long timeout in ms
+   * @return the SleepResponse, null if the request timed out
    */
   public SleepResponse sleep(Number sleepMillis, Number sleepFrames, long timeout) {
     BlockingConsumer<SleepResponse> callback = new BlockingConsumer<SleepResponse>();
@@ -1142,6 +1175,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputKind Restrict the array to only inputs of the specified kind
    * @param timeout long timeout in ms
+   * @return the GetInputListResponse, null if the request timed out
    */
   public GetInputListResponse getInputList(String inputKind, long timeout) {
     BlockingConsumer<GetInputListResponse> callback = new BlockingConsumer<GetInputListResponse>();
@@ -1164,6 +1198,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param unversioned True == Return all kinds as unversioned, False == Return with version suffixes (if available)
    * @param timeout long timeout in ms
+   * @return the GetInputKindListResponse, null if the request timed out
    */
   public GetInputKindListResponse getInputKindList(Boolean unversioned, long timeout) {
     BlockingConsumer<GetInputKindListResponse> callback = new BlockingConsumer<GetInputKindListResponse>();
@@ -1184,6 +1219,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the names of all special inputs.
    *
    * @param timeout long timeout in ms
+   * @return the GetSpecialInputsResponse, null if the request timed out
    */
   public GetSpecialInputsResponse getSpecialInputs(long timeout) {
     BlockingConsumer<GetSpecialInputsResponse> callback = new BlockingConsumer<GetSpecialInputsResponse>();
@@ -1215,6 +1251,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputSettings Settings object to initialize the input with
    * @param sceneItemEnabled Whether to set the created scene item to enabled or disabled
    * @param timeout long timeout in ms
+   * @return the CreateInputResponse, null if the request timed out
    */
   public CreateInputResponse createInput(String sceneName, String inputName, String inputKind,
       JsonObject inputSettings, Boolean sceneItemEnabled, long timeout) {
@@ -1242,6 +1279,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to remove
    * @param timeout long timeout in ms
+   * @return the RemoveInputResponse, null if the request timed out
    */
   public RemoveInputResponse removeInput(String inputName, long timeout) {
     BlockingConsumer<RemoveInputResponse> callback = new BlockingConsumer<RemoveInputResponse>();
@@ -1267,6 +1305,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Current input name
    * @param newInputName New name for the input
    * @param timeout long timeout in ms
+   * @return the SetInputNameResponse, null if the request timed out
    */
   public SetInputNameResponse setInputName(String inputName, String newInputName, long timeout) {
     BlockingConsumer<SetInputNameResponse> callback = new BlockingConsumer<SetInputNameResponse>();
@@ -1290,6 +1329,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputKind Input kind to get the default settings for
    * @param timeout long timeout in ms
+   * @return the GetInputDefaultSettingsResponse, null if the request timed out
    */
   public GetInputDefaultSettingsResponse getInputDefaultSettings(String inputKind, long timeout) {
     BlockingConsumer<GetInputDefaultSettingsResponse> callback = new BlockingConsumer<GetInputDefaultSettingsResponse>();
@@ -1316,6 +1356,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to get the settings of
    * @param timeout long timeout in ms
+   * @return the GetInputSettingsResponse, null if the request timed out
    */
   public GetInputSettingsResponse getInputSettings(String inputName, long timeout) {
     BlockingConsumer<GetInputSettingsResponse> callback = new BlockingConsumer<GetInputSettingsResponse>();
@@ -1343,6 +1384,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputSettings Object of settings to apply
    * @param overlay True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.
    * @param timeout long timeout in ms
+   * @return the SetInputSettingsResponse, null if the request timed out
    */
   public SetInputSettingsResponse setInputSettings(String inputName, JsonObject inputSettings,
       Boolean overlay, long timeout) {
@@ -1366,6 +1408,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of input to get the mute state of
    * @param timeout long timeout in ms
+   * @return the GetInputMuteResponse, null if the request timed out
    */
   public GetInputMuteResponse getInputMute(String inputName, long timeout) {
     BlockingConsumer<GetInputMuteResponse> callback = new BlockingConsumer<GetInputMuteResponse>();
@@ -1391,6 +1434,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input to set the mute state of
    * @param inputMuted Whether to mute the input or not
    * @param timeout long timeout in ms
+   * @return the SetInputMuteResponse, null if the request timed out
    */
   public SetInputMuteResponse setInputMute(String inputName, Boolean inputMuted, long timeout) {
     BlockingConsumer<SetInputMuteResponse> callback = new BlockingConsumer<SetInputMuteResponse>();
@@ -1413,6 +1457,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to toggle the mute state of
    * @param timeout long timeout in ms
+   * @return the ToggleInputMuteResponse, null if the request timed out
    */
   public ToggleInputMuteResponse toggleInputMute(String inputName, long timeout) {
     BlockingConsumer<ToggleInputMuteResponse> callback = new BlockingConsumer<ToggleInputMuteResponse>();
@@ -1435,6 +1480,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to get the volume of
    * @param timeout long timeout in ms
+   * @return the GetInputVolumeResponse, null if the request timed out
    */
   public GetInputVolumeResponse getInputVolume(String inputName, long timeout) {
     BlockingConsumer<GetInputVolumeResponse> callback = new BlockingConsumer<GetInputVolumeResponse>();
@@ -1462,6 +1508,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputVolumeMul Volume setting in mul
    * @param inputVolumeDb Volume setting in dB
    * @param timeout long timeout in ms
+   * @return the SetInputVolumeResponse, null if the request timed out
    */
   public SetInputVolumeResponse setInputVolume(String inputName, Number inputVolumeMul,
       Number inputVolumeDb, long timeout) {
@@ -1486,6 +1533,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to get the audio balance of
    * @param timeout long timeout in ms
+   * @return the GetInputAudioBalanceResponse, null if the request timed out
    */
   public GetInputAudioBalanceResponse getInputAudioBalance(String inputName, long timeout) {
     BlockingConsumer<GetInputAudioBalanceResponse> callback = new BlockingConsumer<GetInputAudioBalanceResponse>();
@@ -1511,6 +1559,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input to set the audio balance of
    * @param inputAudioBalance New audio balance value
    * @param timeout long timeout in ms
+   * @return the SetInputAudioBalanceResponse, null if the request timed out
    */
   public SetInputAudioBalanceResponse setInputAudioBalance(String inputName,
       Number inputAudioBalance, long timeout) {
@@ -1539,6 +1588,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to get the audio sync offset of
    * @param timeout long timeout in ms
+   * @return the GetInputAudioSyncOffsetResponse, null if the request timed out
    */
   public GetInputAudioSyncOffsetResponse getInputAudioSyncOffset(String inputName, long timeout) {
     BlockingConsumer<GetInputAudioSyncOffsetResponse> callback = new BlockingConsumer<GetInputAudioSyncOffsetResponse>();
@@ -1564,6 +1614,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input to set the audio sync offset of
    * @param inputAudioSyncOffset New audio sync offset in milliseconds
    * @param timeout long timeout in ms
+   * @return the SetInputAudioSyncOffsetResponse, null if the request timed out
    */
   public SetInputAudioSyncOffsetResponse setInputAudioSyncOffset(String inputName,
       Number inputAudioSyncOffset, long timeout) {
@@ -1600,6 +1651,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to get the audio monitor type of
    * @param timeout long timeout in ms
+   * @return the GetInputAudioMonitorTypeResponse, null if the request timed out
    */
   public GetInputAudioMonitorTypeResponse getInputAudioMonitorType(String inputName, long timeout) {
     BlockingConsumer<GetInputAudioMonitorTypeResponse> callback = new BlockingConsumer<GetInputAudioMonitorTypeResponse>();
@@ -1625,6 +1677,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input to set the audio monitor type of
    * @param monitorType Audio monitor type
    * @param timeout long timeout in ms
+   * @return the SetInputAudioMonitorTypeResponse, null if the request timed out
    */
   public SetInputAudioMonitorTypeResponse setInputAudioMonitorType(String inputName,
       Input.MonitorType monitorType, long timeout) {
@@ -1649,6 +1702,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input
    * @param timeout long timeout in ms
+   * @return the GetInputAudioTracksResponse, null if the request timed out
    */
   public GetInputAudioTracksResponse getInputAudioTracks(String inputName, long timeout) {
     BlockingConsumer<GetInputAudioTracksResponse> callback = new BlockingConsumer<GetInputAudioTracksResponse>();
@@ -1674,6 +1728,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input
    * @param inputAudioTracks Track settings to apply
    * @param timeout long timeout in ms
+   * @return the SetInputAudioTracksResponse, null if the request timed out
    */
   public SetInputAudioTracksResponse setInputAudioTracks(String inputName,
       Input.AudioTracks inputAudioTracks, long timeout) {
@@ -1704,6 +1759,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input
    * @param propertyName Name of the list property to get the items of
    * @param timeout long timeout in ms
+   * @return the GetInputPropertiesListPropertyItemsResponse, null if the request timed out
    */
   public GetInputPropertiesListPropertyItemsResponse getInputPropertiesListPropertyItems(
       String inputName, String propertyName, long timeout) {
@@ -1742,6 +1798,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the input
    * @param propertyName Name of the button property to press
    * @param timeout long timeout in ms
+   * @return the PressInputPropertiesButtonResponse, null if the request timed out
    */
   public PressInputPropertiesButtonResponse pressInputPropertiesButton(String inputName,
       String propertyName, long timeout) {
@@ -1788,6 +1845,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the media input
    * @param timeout long timeout in ms
+   * @return the GetMediaInputStatusResponse, null if the request timed out
    */
   public GetMediaInputStatusResponse getMediaInputStatus(String inputName, long timeout) {
     BlockingConsumer<GetMediaInputStatusResponse> callback = new BlockingConsumer<GetMediaInputStatusResponse>();
@@ -1817,6 +1875,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the media input
    * @param mediaCursor New cursor position to set
    * @param timeout long timeout in ms
+   * @return the SetMediaInputCursorResponse, null if the request timed out
    */
   public SetMediaInputCursorResponse setMediaInputCursor(String inputName, Number mediaCursor,
       long timeout) {
@@ -1847,6 +1906,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the media input
    * @param mediaCursorOffset Value to offset the current cursor position by
    * @param timeout long timeout in ms
+   * @return the OffsetMediaInputCursorResponse, null if the request timed out
    */
   public OffsetMediaInputCursorResponse offsetMediaInputCursor(String inputName,
       Number mediaCursorOffset, long timeout) {
@@ -1873,6 +1933,7 @@ public abstract class OBSRemoteControllerBase {
    * @param inputName Name of the media input
    * @param mediaAction Identifier of the `ObsMediaInputAction` enum
    * @param timeout long timeout in ms
+   * @return the TriggerMediaInputActionResponse, null if the request timed out
    */
   public TriggerMediaInputActionResponse triggerMediaInputAction(String inputName,
       String mediaAction, long timeout) {
@@ -1894,6 +1955,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the status of the virtualcam output.
    *
    * @param timeout long timeout in ms
+   * @return the GetVirtualCamStatusResponse, null if the request timed out
    */
   public GetVirtualCamStatusResponse getVirtualCamStatus(long timeout) {
     BlockingConsumer<GetVirtualCamStatusResponse> callback = new BlockingConsumer<GetVirtualCamStatusResponse>();
@@ -1914,6 +1976,7 @@ public abstract class OBSRemoteControllerBase {
    * Toggles the state of the virtualcam output.
    *
    * @param timeout long timeout in ms
+   * @return the ToggleVirtualCamResponse, null if the request timed out
    */
   public ToggleVirtualCamResponse toggleVirtualCam(long timeout) {
     BlockingConsumer<ToggleVirtualCamResponse> callback = new BlockingConsumer<ToggleVirtualCamResponse>();
@@ -1934,6 +1997,7 @@ public abstract class OBSRemoteControllerBase {
    * Starts the virtualcam output.
    *
    * @param timeout long timeout in ms
+   * @return the StartVirtualCamResponse, null if the request timed out
    */
   public StartVirtualCamResponse startVirtualCam(long timeout) {
     BlockingConsumer<StartVirtualCamResponse> callback = new BlockingConsumer<StartVirtualCamResponse>();
@@ -1954,6 +2018,7 @@ public abstract class OBSRemoteControllerBase {
    * Stops the virtualcam output.
    *
    * @param timeout long timeout in ms
+   * @return the StopVirtualCamResponse, null if the request timed out
    */
   public StopVirtualCamResponse stopVirtualCam(long timeout) {
     BlockingConsumer<StopVirtualCamResponse> callback = new BlockingConsumer<StopVirtualCamResponse>();
@@ -1974,6 +2039,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the status of the replay buffer output.
    *
    * @param timeout long timeout in ms
+   * @return the GetReplayBufferStatusResponse, null if the request timed out
    */
   public GetReplayBufferStatusResponse getReplayBufferStatus(long timeout) {
     BlockingConsumer<GetReplayBufferStatusResponse> callback = new BlockingConsumer<GetReplayBufferStatusResponse>();
@@ -1994,6 +2060,7 @@ public abstract class OBSRemoteControllerBase {
    * Toggles the state of the replay buffer output.
    *
    * @param timeout long timeout in ms
+   * @return the ToggleReplayBufferResponse, null if the request timed out
    */
   public ToggleReplayBufferResponse toggleReplayBuffer(long timeout) {
     BlockingConsumer<ToggleReplayBufferResponse> callback = new BlockingConsumer<ToggleReplayBufferResponse>();
@@ -2014,6 +2081,7 @@ public abstract class OBSRemoteControllerBase {
    * Starts the replay buffer output.
    *
    * @param timeout long timeout in ms
+   * @return the StartReplayBufferResponse, null if the request timed out
    */
   public StartReplayBufferResponse startReplayBuffer(long timeout) {
     BlockingConsumer<StartReplayBufferResponse> callback = new BlockingConsumer<StartReplayBufferResponse>();
@@ -2034,6 +2102,7 @@ public abstract class OBSRemoteControllerBase {
    * Stops the replay buffer output.
    *
    * @param timeout long timeout in ms
+   * @return the StopReplayBufferResponse, null if the request timed out
    */
   public StopReplayBufferResponse stopReplayBuffer(long timeout) {
     BlockingConsumer<StopReplayBufferResponse> callback = new BlockingConsumer<StopReplayBufferResponse>();
@@ -2054,6 +2123,7 @@ public abstract class OBSRemoteControllerBase {
    * Saves the contents of the replay buffer output.
    *
    * @param timeout long timeout in ms
+   * @return the SaveReplayBufferResponse, null if the request timed out
    */
   public SaveReplayBufferResponse saveReplayBuffer(long timeout) {
     BlockingConsumer<SaveReplayBufferResponse> callback = new BlockingConsumer<SaveReplayBufferResponse>();
@@ -2074,6 +2144,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the filename of the last replay buffer save file.
    *
    * @param timeout long timeout in ms
+   * @return the GetLastReplayBufferReplayResponse, null if the request timed out
    */
   public GetLastReplayBufferReplayResponse getLastReplayBufferReplay(long timeout) {
     BlockingConsumer<GetLastReplayBufferReplayResponse> callback = new BlockingConsumer<GetLastReplayBufferReplayResponse>();
@@ -2094,6 +2165,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the list of available outputs.
    *
    * @param timeout long timeout in ms
+   * @return the GetOutputListResponse, null if the request timed out
    */
   public GetOutputListResponse getOutputList(long timeout) {
     BlockingConsumer<GetOutputListResponse> callback = new BlockingConsumer<GetOutputListResponse>();
@@ -2116,6 +2188,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param outputName Output name
    * @param timeout long timeout in ms
+   * @return the GetOutputStatusResponse, null if the request timed out
    */
   public GetOutputStatusResponse getOutputStatus(String outputName, long timeout) {
     BlockingConsumer<GetOutputStatusResponse> callback = new BlockingConsumer<GetOutputStatusResponse>();
@@ -2138,6 +2211,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param outputName Output name
    * @param timeout long timeout in ms
+   * @return the ToggleOutputResponse, null if the request timed out
    */
   public ToggleOutputResponse toggleOutput(String outputName, long timeout) {
     BlockingConsumer<ToggleOutputResponse> callback = new BlockingConsumer<ToggleOutputResponse>();
@@ -2160,6 +2234,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param outputName Output name
    * @param timeout long timeout in ms
+   * @return the StartOutputResponse, null if the request timed out
    */
   public StartOutputResponse startOutput(String outputName, long timeout) {
     BlockingConsumer<StartOutputResponse> callback = new BlockingConsumer<StartOutputResponse>();
@@ -2182,6 +2257,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param outputName Output name
    * @param timeout long timeout in ms
+   * @return the StopOutputResponse, null if the request timed out
    */
   public StopOutputResponse stopOutput(String outputName, long timeout) {
     BlockingConsumer<StopOutputResponse> callback = new BlockingConsumer<StopOutputResponse>();
@@ -2204,6 +2280,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param outputName Output name
    * @param timeout long timeout in ms
+   * @return the GetOutputSettingsResponse, null if the request timed out
    */
   public GetOutputSettingsResponse getOutputSettings(String outputName, long timeout) {
     BlockingConsumer<GetOutputSettingsResponse> callback = new BlockingConsumer<GetOutputSettingsResponse>();
@@ -2229,6 +2306,7 @@ public abstract class OBSRemoteControllerBase {
    * @param outputName Output name
    * @param outputSettings Output settings
    * @param timeout long timeout in ms
+   * @return the SetOutputSettingsResponse, null if the request timed out
    */
   public SetOutputSettingsResponse setOutputSettings(String outputName, JsonObject outputSettings,
       long timeout) {
@@ -2250,6 +2328,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the status of the record output.
    *
    * @param timeout long timeout in ms
+   * @return the GetRecordStatusResponse, null if the request timed out
    */
   public GetRecordStatusResponse getRecordStatus(long timeout) {
     BlockingConsumer<GetRecordStatusResponse> callback = new BlockingConsumer<GetRecordStatusResponse>();
@@ -2270,6 +2349,7 @@ public abstract class OBSRemoteControllerBase {
    * Toggles the status of the record output.
    *
    * @param timeout long timeout in ms
+   * @return the ToggleRecordResponse, null if the request timed out
    */
   public ToggleRecordResponse toggleRecord(long timeout) {
     BlockingConsumer<ToggleRecordResponse> callback = new BlockingConsumer<ToggleRecordResponse>();
@@ -2290,6 +2370,7 @@ public abstract class OBSRemoteControllerBase {
    * Starts the record output.
    *
    * @param timeout long timeout in ms
+   * @return the StartRecordResponse, null if the request timed out
    */
   public StartRecordResponse startRecord(long timeout) {
     BlockingConsumer<StartRecordResponse> callback = new BlockingConsumer<StartRecordResponse>();
@@ -2310,6 +2391,7 @@ public abstract class OBSRemoteControllerBase {
    * Stops the record output.
    *
    * @param timeout long timeout in ms
+   * @return the StopRecordResponse, null if the request timed out
    */
   public StopRecordResponse stopRecord(long timeout) {
     BlockingConsumer<StopRecordResponse> callback = new BlockingConsumer<StopRecordResponse>();
@@ -2330,6 +2412,7 @@ public abstract class OBSRemoteControllerBase {
    * Toggles pause on the record output.
    *
    * @param timeout long timeout in ms
+   * @return the ToggleRecordPauseResponse, null if the request timed out
    */
   public ToggleRecordPauseResponse toggleRecordPause(long timeout) {
     BlockingConsumer<ToggleRecordPauseResponse> callback = new BlockingConsumer<ToggleRecordPauseResponse>();
@@ -2350,6 +2433,7 @@ public abstract class OBSRemoteControllerBase {
    * Pauses the record output.
    *
    * @param timeout long timeout in ms
+   * @return the PauseRecordResponse, null if the request timed out
    */
   public PauseRecordResponse pauseRecord(long timeout) {
     BlockingConsumer<PauseRecordResponse> callback = new BlockingConsumer<PauseRecordResponse>();
@@ -2370,6 +2454,7 @@ public abstract class OBSRemoteControllerBase {
    * Resumes the record output.
    *
    * @param timeout long timeout in ms
+   * @return the ResumeRecordResponse, null if the request timed out
    */
   public ResumeRecordResponse resumeRecord(long timeout) {
     BlockingConsumer<ResumeRecordResponse> callback = new BlockingConsumer<ResumeRecordResponse>();
@@ -2396,6 +2481,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Name of the scene to get the items of
    * @param timeout long timeout in ms
+   * @return the GetSceneItemListResponse, null if the request timed out
    */
   public GetSceneItemListResponse getSceneItemList(String sceneName, long timeout) {
     BlockingConsumer<GetSceneItemListResponse> callback = new BlockingConsumer<GetSceneItemListResponse>();
@@ -2427,6 +2513,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Name of the group to get the items of
    * @param timeout long timeout in ms
+   * @return the GetGroupSceneItemListResponse, null if the request timed out
    */
   public GetGroupSceneItemListResponse getGroupSceneItemList(String sceneName, long timeout) {
     BlockingConsumer<GetGroupSceneItemListResponse> callback = new BlockingConsumer<GetGroupSceneItemListResponse>();
@@ -2458,6 +2545,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sourceName Name of the source to find
    * @param searchOffset Number of matches to skip during search. &gt;= 0 means first forward. -1 means last (top) item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemIdResponse, null if the request timed out
    */
   public GetSceneItemIdResponse getSceneItemId(String sceneName, String sourceName,
       Number searchOffset, long timeout) {
@@ -2490,6 +2578,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sourceName Name of the source to add to the scene
    * @param sceneItemEnabled Enable state to apply to the scene item on creation
    * @param timeout long timeout in ms
+   * @return the CreateSceneItemResponse, null if the request timed out
    */
   public CreateSceneItemResponse createSceneItem(String sceneName, String sourceName,
       Boolean sceneItemEnabled, long timeout) {
@@ -2520,6 +2609,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the RemoveSceneItemResponse, null if the request timed out
    */
   public RemoveSceneItemResponse removeSceneItem(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2552,6 +2642,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param destinationSceneName Name of the scene to create the duplicated item in
    * @param timeout long timeout in ms
+   * @return the DuplicateSceneItemResponse, null if the request timed out
    */
   public DuplicateSceneItemResponse duplicateSceneItem(String sceneName, Number sceneItemId,
       String destinationSceneName, long timeout) {
@@ -2582,6 +2673,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemTransformResponse, null if the request timed out
    */
   public GetSceneItemTransformResponse getSceneItemTransform(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2610,6 +2702,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param sceneItemTransform Object containing scene item transform info to update
    * @param timeout long timeout in ms
+   * @return the SetSceneItemTransformResponse, null if the request timed out
    */
   public SetSceneItemTransformResponse setSceneItemTransform(String sceneName, Number sceneItemId,
       SceneItem.Transform sceneItemTransform, long timeout) {
@@ -2640,6 +2733,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemEnabledResponse, null if the request timed out
    */
   public GetSceneItemEnabledResponse getSceneItemEnabled(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2672,6 +2766,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param sceneItemEnabled New enable state of the scene item
    * @param timeout long timeout in ms
+   * @return the SetSceneItemEnabledResponse, null if the request timed out
    */
   public SetSceneItemEnabledResponse setSceneItemEnabled(String sceneName, Number sceneItemId,
       Boolean sceneItemEnabled, long timeout) {
@@ -2702,6 +2797,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemLockedResponse, null if the request timed out
    */
   public GetSceneItemLockedResponse getSceneItemLocked(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2734,6 +2830,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param sceneItemLocked New lock state of the scene item
    * @param timeout long timeout in ms
+   * @return the SetSceneItemLockedResponse, null if the request timed out
    */
   public SetSceneItemLockedResponse setSceneItemLocked(String sceneName, Number sceneItemId,
       Boolean sceneItemLocked, long timeout) {
@@ -2768,6 +2865,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemIndexResponse, null if the request timed out
    */
   public GetSceneItemIndexResponse getSceneItemIndex(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2800,6 +2898,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param sceneItemIndex New index position of the scene item
    * @param timeout long timeout in ms
+   * @return the SetSceneItemIndexResponse, null if the request timed out
    */
   public SetSceneItemIndexResponse setSceneItemIndex(String sceneName, Number sceneItemId,
       Number sceneItemIndex, long timeout) {
@@ -2850,6 +2949,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene the item is in
    * @param sceneItemId Numeric ID of the scene item
    * @param timeout long timeout in ms
+   * @return the GetSceneItemBlendModeResponse, null if the request timed out
    */
   public GetSceneItemBlendModeResponse getSceneItemBlendMode(String sceneName, Number sceneItemId,
       long timeout) {
@@ -2882,6 +2982,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneItemId Numeric ID of the scene item
    * @param sceneItemBlendMode New blend mode
    * @param timeout long timeout in ms
+   * @return the SetSceneItemBlendModeResponse, null if the request timed out
    */
   public SetSceneItemBlendModeResponse setSceneItemBlendMode(String sceneName, Number sceneItemId,
       SceneItem.BlendMode sceneItemBlendMode, long timeout) {
@@ -2903,6 +3004,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets an array of all scenes in OBS.
    *
    * @param timeout long timeout in ms
+   * @return the GetSceneListResponse, null if the request timed out
    */
   public GetSceneListResponse getSceneList(long timeout) {
     BlockingConsumer<GetSceneListResponse> callback = new BlockingConsumer<GetSceneListResponse>();
@@ -2927,6 +3029,7 @@ public abstract class OBSRemoteControllerBase {
    * Groups in OBS are actually scenes, but renamed and modified. In obs-websocket, we treat them as scenes where we can.
    *
    * @param timeout long timeout in ms
+   * @return the GetGroupListResponse, null if the request timed out
    */
   public GetGroupListResponse getGroupList(long timeout) {
     BlockingConsumer<GetGroupListResponse> callback = new BlockingConsumer<GetGroupListResponse>();
@@ -2947,6 +3050,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the current program scene.
    *
    * @param timeout long timeout in ms
+   * @return the GetCurrentProgramSceneResponse, null if the request timed out
    */
   public GetCurrentProgramSceneResponse getCurrentProgramScene(long timeout) {
     BlockingConsumer<GetCurrentProgramSceneResponse> callback = new BlockingConsumer<GetCurrentProgramSceneResponse>();
@@ -2970,6 +3074,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Scene to set as the current program scene
    * @param timeout long timeout in ms
+   * @return the SetCurrentProgramSceneResponse, null if the request timed out
    */
   public SetCurrentProgramSceneResponse setCurrentProgramScene(String sceneName, long timeout) {
     BlockingConsumer<SetCurrentProgramSceneResponse> callback = new BlockingConsumer<SetCurrentProgramSceneResponse>();
@@ -2994,6 +3099,7 @@ public abstract class OBSRemoteControllerBase {
    * Only available when studio mode is enabled.
    *
    * @param timeout long timeout in ms
+   * @return the GetCurrentPreviewSceneResponse, null if the request timed out
    */
   public GetCurrentPreviewSceneResponse getCurrentPreviewScene(long timeout) {
     BlockingConsumer<GetCurrentPreviewSceneResponse> callback = new BlockingConsumer<GetCurrentPreviewSceneResponse>();
@@ -3021,6 +3127,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Scene to set as the current preview scene
    * @param timeout long timeout in ms
+   * @return the SetCurrentPreviewSceneResponse, null if the request timed out
    */
   public SetCurrentPreviewSceneResponse setCurrentPreviewScene(String sceneName, long timeout) {
     BlockingConsumer<SetCurrentPreviewSceneResponse> callback = new BlockingConsumer<SetCurrentPreviewSceneResponse>();
@@ -3043,6 +3150,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Name for the new scene
    * @param timeout long timeout in ms
+   * @return the CreateSceneResponse, null if the request timed out
    */
   public CreateSceneResponse createScene(String sceneName, long timeout) {
     BlockingConsumer<CreateSceneResponse> callback = new BlockingConsumer<CreateSceneResponse>();
@@ -3065,6 +3173,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Name of the scene to remove
    * @param timeout long timeout in ms
+   * @return the RemoveSceneResponse, null if the request timed out
    */
   public RemoveSceneResponse removeScene(String sceneName, long timeout) {
     BlockingConsumer<RemoveSceneResponse> callback = new BlockingConsumer<RemoveSceneResponse>();
@@ -3090,6 +3199,7 @@ public abstract class OBSRemoteControllerBase {
    * @param sceneName Name of the scene to be renamed
    * @param newSceneName New name for the scene
    * @param timeout long timeout in ms
+   * @return the SetSceneNameResponse, null if the request timed out
    */
   public SetSceneNameResponse setSceneName(String sceneName, String newSceneName, long timeout) {
     BlockingConsumer<SetSceneNameResponse> callback = new BlockingConsumer<SetSceneNameResponse>();
@@ -3113,6 +3223,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sceneName Name of the scene
    * @param timeout long timeout in ms
+   * @return the GetSceneSceneTransitionOverrideResponse, null if the request timed out
    */
   public GetSceneSceneTransitionOverrideResponse getSceneSceneTransitionOverride(String sceneName,
       long timeout) {
@@ -3141,6 +3252,7 @@ public abstract class OBSRemoteControllerBase {
    * @param transitionName Name of the scene transition to use as override. Specify `null` to remove
    * @param transitionDuration Duration to use for any overridden transition. Specify `null` to remove
    * @param timeout long timeout in ms
+   * @return the SetSceneSceneTransitionOverrideResponse, null if the request timed out
    */
   public SetSceneSceneTransitionOverrideResponse setSceneSceneTransitionOverride(String sceneName,
       String transitionName, Number transitionDuration, long timeout) {
@@ -3168,6 +3280,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param sourceName Name of the source to get the active state of
    * @param timeout long timeout in ms
+   * @return the GetSourceActiveResponse, null if the request timed out
    */
   public GetSourceActiveResponse getSourceActive(String sourceName, long timeout) {
     BlockingConsumer<GetSourceActiveResponse> callback = new BlockingConsumer<GetSourceActiveResponse>();
@@ -3210,6 +3323,7 @@ public abstract class OBSRemoteControllerBase {
    * @param imageHeight Height to scale the screenshot to
    * @param imageCompressionQuality Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk)
    * @param timeout long timeout in ms
+   * @return the GetSourceScreenshotResponse, null if the request timed out
    */
   public GetSourceScreenshotResponse getSourceScreenshot(String sourceName, String imageFormat,
       Number imageWidth, Number imageHeight, Number imageCompressionQuality, long timeout) {
@@ -3255,6 +3369,7 @@ public abstract class OBSRemoteControllerBase {
    * @param imageHeight Height to scale the screenshot to
    * @param imageCompressionQuality Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk)
    * @param timeout long timeout in ms
+   * @return the SaveSourceScreenshotResponse, null if the request timed out
    */
   public SaveSourceScreenshotResponse saveSourceScreenshot(String sourceName, String imageFormat,
       String imageFilePath, Number imageWidth, Number imageHeight, Number imageCompressionQuality,
@@ -3277,6 +3392,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets the status of the stream output.
    *
    * @param timeout long timeout in ms
+   * @return the GetStreamStatusResponse, null if the request timed out
    */
   public GetStreamStatusResponse getStreamStatus(long timeout) {
     BlockingConsumer<GetStreamStatusResponse> callback = new BlockingConsumer<GetStreamStatusResponse>();
@@ -3297,6 +3413,7 @@ public abstract class OBSRemoteControllerBase {
    * Toggles the status of the stream output.
    *
    * @param timeout long timeout in ms
+   * @return the ToggleStreamResponse, null if the request timed out
    */
   public ToggleStreamResponse toggleStream(long timeout) {
     BlockingConsumer<ToggleStreamResponse> callback = new BlockingConsumer<ToggleStreamResponse>();
@@ -3317,6 +3434,7 @@ public abstract class OBSRemoteControllerBase {
    * Starts the stream output.
    *
    * @param timeout long timeout in ms
+   * @return the StartStreamResponse, null if the request timed out
    */
   public StartStreamResponse startStream(long timeout) {
     BlockingConsumer<StartStreamResponse> callback = new BlockingConsumer<StartStreamResponse>();
@@ -3337,6 +3455,7 @@ public abstract class OBSRemoteControllerBase {
    * Stops the stream output.
    *
    * @param timeout long timeout in ms
+   * @return the StopStreamResponse, null if the request timed out
    */
   public StopStreamResponse stopStream(long timeout) {
     BlockingConsumer<StopStreamResponse> callback = new BlockingConsumer<StopStreamResponse>();
@@ -3359,6 +3478,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param captionText Caption text
    * @param timeout long timeout in ms
+   * @return the SendStreamCaptionResponse, null if the request timed out
    */
   public SendStreamCaptionResponse sendStreamCaption(String captionText, long timeout) {
     BlockingConsumer<SendStreamCaptionResponse> callback = new BlockingConsumer<SendStreamCaptionResponse>();
@@ -3383,6 +3503,7 @@ public abstract class OBSRemoteControllerBase {
    * Similar to `GetInputKindList`
    *
    * @param timeout long timeout in ms
+   * @return the GetTransitionKindListResponse, null if the request timed out
    */
   public GetTransitionKindListResponse getTransitionKindList(long timeout) {
     BlockingConsumer<GetTransitionKindListResponse> callback = new BlockingConsumer<GetTransitionKindListResponse>();
@@ -3403,6 +3524,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets an array of all scene transitions in OBS.
    *
    * @param timeout long timeout in ms
+   * @return the GetSceneTransitionListResponse, null if the request timed out
    */
   public GetSceneTransitionListResponse getSceneTransitionList(long timeout) {
     BlockingConsumer<GetSceneTransitionListResponse> callback = new BlockingConsumer<GetSceneTransitionListResponse>();
@@ -3423,6 +3545,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets information about the current scene transition.
    *
    * @param timeout long timeout in ms
+   * @return the GetCurrentSceneTransitionResponse, null if the request timed out
    */
   public GetCurrentSceneTransitionResponse getCurrentSceneTransition(long timeout) {
     BlockingConsumer<GetCurrentSceneTransitionResponse> callback = new BlockingConsumer<GetCurrentSceneTransitionResponse>();
@@ -3450,6 +3573,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param transitionName Name of the transition to make active
    * @param timeout long timeout in ms
+   * @return the SetCurrentSceneTransitionResponse, null if the request timed out
    */
   public SetCurrentSceneTransitionResponse setCurrentSceneTransition(String transitionName,
       long timeout) {
@@ -3474,6 +3598,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param transitionDuration Duration in milliseconds
    * @param timeout long timeout in ms
+   * @return the SetCurrentSceneTransitionDurationResponse, null if the request timed out
    */
   public SetCurrentSceneTransitionDurationResponse setCurrentSceneTransitionDuration(
       Number transitionDuration, long timeout) {
@@ -3500,6 +3625,7 @@ public abstract class OBSRemoteControllerBase {
    * @param transitionSettings Settings object to apply to the transition. Can be `{}`
    * @param overlay Whether to overlay over the current settings or replace them
    * @param timeout long timeout in ms
+   * @return the SetCurrentSceneTransitionSettingsResponse, null if the request timed out
    */
   public SetCurrentSceneTransitionSettingsResponse setCurrentSceneTransitionSettings(
       JsonObject transitionSettings, Boolean overlay, long timeout) {
@@ -3526,6 +3652,7 @@ public abstract class OBSRemoteControllerBase {
    * Note: `transitionCursor` will return 1.0 when the transition is inactive.
    *
    * @param timeout long timeout in ms
+   * @return the GetCurrentSceneTransitionCursorResponse, null if the request timed out
    */
   public GetCurrentSceneTransitionCursorResponse getCurrentSceneTransitionCursor(long timeout) {
     BlockingConsumer<GetCurrentSceneTransitionCursorResponse> callback = new BlockingConsumer<GetCurrentSceneTransitionCursorResponse>();
@@ -3546,6 +3673,7 @@ public abstract class OBSRemoteControllerBase {
    * Triggers the current scene transition. Same functionality as the `Transition` button in studio mode.
    *
    * @param timeout long timeout in ms
+   * @return the TriggerStudioModeTransitionResponse, null if the request timed out
    */
   public TriggerStudioModeTransitionResponse triggerStudioModeTransition(long timeout) {
     BlockingConsumer<TriggerStudioModeTransitionResponse> callback = new BlockingConsumer<TriggerStudioModeTransitionResponse>();
@@ -3575,6 +3703,7 @@ public abstract class OBSRemoteControllerBase {
    * @param position New position
    * @param release Whether to release the TBar. Only set `false` if you know that you will be sending another position update
    * @param timeout long timeout in ms
+   * @return the SetTBarPositionResponse, null if the request timed out
    */
   public SetTBarPositionResponse setTBarPosition(Number position, Boolean release, long timeout) {
     BlockingConsumer<SetTBarPositionResponse> callback = new BlockingConsumer<SetTBarPositionResponse>();
@@ -3595,6 +3724,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets whether studio is enabled.
    *
    * @param timeout long timeout in ms
+   * @return the GetStudioModeEnabledResponse, null if the request timed out
    */
   public GetStudioModeEnabledResponse getStudioModeEnabled(long timeout) {
     BlockingConsumer<GetStudioModeEnabledResponse> callback = new BlockingConsumer<GetStudioModeEnabledResponse>();
@@ -3618,6 +3748,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param studioModeEnabled True == Enabled, False == Disabled
    * @param timeout long timeout in ms
+   * @return the SetStudioModeEnabledResponse, null if the request timed out
    */
   public SetStudioModeEnabledResponse setStudioModeEnabled(Boolean studioModeEnabled,
       long timeout) {
@@ -3642,6 +3773,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to open the dialog of
    * @param timeout long timeout in ms
+   * @return the OpenInputPropertiesDialogResponse, null if the request timed out
    */
   public OpenInputPropertiesDialogResponse openInputPropertiesDialog(String inputName,
       long timeout) {
@@ -3666,6 +3798,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to open the dialog of
    * @param timeout long timeout in ms
+   * @return the OpenInputFiltersDialogResponse, null if the request timed out
    */
   public OpenInputFiltersDialogResponse openInputFiltersDialog(String inputName, long timeout) {
     BlockingConsumer<OpenInputFiltersDialogResponse> callback = new BlockingConsumer<OpenInputFiltersDialogResponse>();
@@ -3689,6 +3822,7 @@ public abstract class OBSRemoteControllerBase {
    *
    * @param inputName Name of the input to open the dialog of
    * @param timeout long timeout in ms
+   * @return the OpenInputInteractDialogResponse, null if the request timed out
    */
   public OpenInputInteractDialogResponse openInputInteractDialog(String inputName, long timeout) {
     BlockingConsumer<OpenInputInteractDialogResponse> callback = new BlockingConsumer<OpenInputInteractDialogResponse>();
@@ -3709,6 +3843,7 @@ public abstract class OBSRemoteControllerBase {
    * Gets a list of connected monitors and information about them.
    *
    * @param timeout long timeout in ms
+   * @return the GetMonitorListResponse, null if the request timed out
    */
   public GetMonitorListResponse getMonitorList(long timeout) {
     BlockingConsumer<GetMonitorListResponse> callback = new BlockingConsumer<GetMonitorListResponse>();
@@ -3752,6 +3887,7 @@ public abstract class OBSRemoteControllerBase {
    * @param monitorIndex Monitor index, use `GetMonitorList` to obtain index
    * @param projectorGeometry Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
    * @param timeout long timeout in ms
+   * @return the OpenVideoMixProjectorResponse, null if the request timed out
    */
   public OpenVideoMixProjectorResponse openVideoMixProjector(VideoMixType videoMixType,
       Number monitorIndex, String projectorGeometry, long timeout) {
@@ -3784,6 +3920,7 @@ public abstract class OBSRemoteControllerBase {
    * @param monitorIndex Monitor index, use `GetMonitorList` to obtain index
    * @param projectorGeometry Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
    * @param timeout long timeout in ms
+   * @return the OpenSourceProjectorResponse, null if the request timed out
    */
   public OpenSourceProjectorResponse openSourceProjector(String sourceName, Number monitorIndex,
       String projectorGeometry, long timeout) {

--- a/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBase.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSRemoteControllerBase.java
@@ -304,6 +304,19 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the value of a "slot" from the selected persistent data realm.
+   *
+   * @param realm The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
+   * @param slotName The name of the slot to retrieve data from
+   * @param timeout long timeout in ms
+   */
+  public GetPersistentDataResponse getPersistentData(Realm realm, String slotName, long timeout) {
+    BlockingConsumer<GetPersistentDataResponse> callback = new BlockingConsumer<GetPersistentDataResponse>();
+    sendRequest(GetPersistentDataRequest.builder().realm(realm).slotName(slotName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the value of a "slot" from the selected persistent data realm.
    *
    * @param realm The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
@@ -317,12 +330,38 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the value of a "slot" from the selected persistent data realm.
+   *
+   * @param realm The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
+   * @param slotName The name of the slot to retrieve data from
+   * @param slotValue The value to apply to the slot
+   * @param timeout long timeout in ms
+   */
+  public SetPersistentDataResponse setPersistentData(Realm realm, String slotName,
+      JsonElement slotValue, long timeout) {
+    BlockingConsumer<SetPersistentDataResponse> callback = new BlockingConsumer<SetPersistentDataResponse>();
+    sendRequest(SetPersistentDataRequest.builder().realm(realm).slotName(slotName).slotValue(slotValue).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all scene collections
    *
    * @param callback Consumer&lt;GetSceneCollectionListResponse&gt;
    */
   public void getSceneCollectionList(Consumer<GetSceneCollectionListResponse> callback) {
     sendRequest(GetSceneCollectionListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets an array of all scene collections
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetSceneCollectionListResponse getSceneCollectionList(long timeout) {
+    BlockingConsumer<GetSceneCollectionListResponse> callback = new BlockingConsumer<GetSceneCollectionListResponse>();
+    sendRequest(GetSceneCollectionListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -339,6 +378,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Switches to a scene collection.
+   *
+   * Note: This will block until the collection has finished changing.
+   *
+   * @param sceneCollectionName Name of the scene collection to switch to
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentSceneCollectionResponse setCurrentSceneCollection(String sceneCollectionName,
+      long timeout) {
+    BlockingConsumer<SetCurrentSceneCollectionResponse> callback = new BlockingConsumer<SetCurrentSceneCollectionResponse>();
+    sendRequest(SetCurrentSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Creates a new scene collection, switching to it in the process.
    *
    * Note: This will block until the collection has finished changing.
@@ -352,12 +406,38 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Creates a new scene collection, switching to it in the process.
+   *
+   * Note: This will block until the collection has finished changing.
+   *
+   * @param sceneCollectionName Name for the new scene collection
+   * @param timeout long timeout in ms
+   */
+  public CreateSceneCollectionResponse createSceneCollection(String sceneCollectionName,
+      long timeout) {
+    BlockingConsumer<CreateSceneCollectionResponse> callback = new BlockingConsumer<CreateSceneCollectionResponse>();
+    sendRequest(CreateSceneCollectionRequest.builder().sceneCollectionName(sceneCollectionName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all profiles
    *
    * @param callback Consumer&lt;GetProfileListResponse&gt;
    */
   public void getProfileList(Consumer<GetProfileListResponse> callback) {
     sendRequest(GetProfileListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets an array of all profiles
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetProfileListResponse getProfileList(long timeout) {
+    BlockingConsumer<GetProfileListResponse> callback = new BlockingConsumer<GetProfileListResponse>();
+    sendRequest(GetProfileListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -371,6 +451,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Switches to a profile.
+   *
+   * @param profileName Name of the profile to switch to
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentProfileResponse setCurrentProfile(String profileName, long timeout) {
+    BlockingConsumer<SetCurrentProfileResponse> callback = new BlockingConsumer<SetCurrentProfileResponse>();
+    sendRequest(SetCurrentProfileRequest.builder().profileName(profileName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Creates a new profile, switching to it in the process
    *
    * @param profileName Name for the new profile
@@ -378,6 +470,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void createProfile(String profileName, Consumer<CreateProfileResponse> callback) {
     sendRequest(CreateProfileRequest.builder().profileName(profileName).build(), callback);
+  }
+
+  /**
+   * Creates a new profile, switching to it in the process
+   *
+   * @param profileName Name for the new profile
+   * @param timeout long timeout in ms
+   */
+  public CreateProfileResponse createProfile(String profileName, long timeout) {
+    BlockingConsumer<CreateProfileResponse> callback = new BlockingConsumer<CreateProfileResponse>();
+    sendRequest(CreateProfileRequest.builder().profileName(profileName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -391,6 +495,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Removes a profile. If the current profile is chosen, it will change to a different profile first.
+   *
+   * @param profileName Name of the profile to remove
+   * @param timeout long timeout in ms
+   */
+  public RemoveProfileResponse removeProfile(String profileName, long timeout) {
+    BlockingConsumer<RemoveProfileResponse> callback = new BlockingConsumer<RemoveProfileResponse>();
+    sendRequest(RemoveProfileRequest.builder().profileName(profileName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets a parameter from the current profile's configuration.
    *
    * @param parameterCategory Category of the parameter to get
@@ -400,6 +516,20 @@ public abstract class OBSRemoteControllerBase {
   public void getProfileParameter(String parameterCategory, String parameterName,
       Consumer<GetProfileParameterResponse> callback) {
     sendRequest(GetProfileParameterRequest.builder().parameterCategory(parameterCategory).parameterName(parameterName).build(), callback);
+  }
+
+  /**
+   * Gets a parameter from the current profile's configuration.
+   *
+   * @param parameterCategory Category of the parameter to get
+   * @param parameterName Name of the parameter to get
+   * @param timeout long timeout in ms
+   */
+  public GetProfileParameterResponse getProfileParameter(String parameterCategory,
+      String parameterName, long timeout) {
+    BlockingConsumer<GetProfileParameterResponse> callback = new BlockingConsumer<GetProfileParameterResponse>();
+    sendRequest(GetProfileParameterRequest.builder().parameterCategory(parameterCategory).parameterName(parameterName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -416,6 +546,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the value of a parameter in the current profile's configuration.
+   *
+   * @param parameterCategory Category of the parameter to set
+   * @param parameterName Name of the parameter to set
+   * @param parameterValue Value of the parameter to set. Use `null` to delete
+   * @param timeout long timeout in ms
+   */
+  public SetProfileParameterResponse setProfileParameter(String parameterCategory,
+      String parameterName, String parameterValue, long timeout) {
+    BlockingConsumer<SetProfileParameterResponse> callback = new BlockingConsumer<SetProfileParameterResponse>();
+    sendRequest(SetProfileParameterRequest.builder().parameterCategory(parameterCategory).parameterName(parameterName).parameterValue(parameterValue).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current video settings.
    *
    * Note: To get the true FPS value, divide the FPS numerator by the FPS denominator. Example: `60000/1001`
@@ -424,6 +569,19 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getVideoSettings(Consumer<GetVideoSettingsResponse> callback) {
     sendRequest(GetVideoSettingsRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the current video settings.
+   *
+   * Note: To get the true FPS value, divide the FPS numerator by the FPS denominator. Example: `60000/1001`
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetVideoSettingsResponse getVideoSettings(long timeout) {
+    BlockingConsumer<GetVideoSettingsResponse> callback = new BlockingConsumer<GetVideoSettingsResponse>();
+    sendRequest(GetVideoSettingsRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -446,12 +604,43 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the current video settings.
+   *
+   * Note: Fields must be specified in pairs. For example, you cannot set only `baseWidth` without needing to specify `baseHeight`.
+   *
+   * @param fpsNumerator Numerator of the fractional FPS value
+   * @param fpsDenominator Denominator of the fractional FPS value
+   * @param baseWidth Width of the base (canvas) resolution in pixels
+   * @param baseHeight Height of the base (canvas) resolution in pixels
+   * @param outputWidth Width of the output resolution in pixels
+   * @param outputHeight Height of the output resolution in pixels
+   * @param timeout long timeout in ms
+   */
+  public SetVideoSettingsResponse setVideoSettings(Number fpsNumerator, Number fpsDenominator,
+      Number baseWidth, Number baseHeight, Number outputWidth, Number outputHeight, long timeout) {
+    BlockingConsumer<SetVideoSettingsResponse> callback = new BlockingConsumer<SetVideoSettingsResponse>();
+    sendRequest(SetVideoSettingsRequest.builder().fpsNumerator(fpsNumerator).fpsDenominator(fpsDenominator).baseWidth(baseWidth).baseHeight(baseHeight).outputWidth(outputWidth).outputHeight(outputHeight).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current stream service settings (stream destination).
    *
    * @param callback Consumer&lt;GetStreamServiceSettingsResponse&gt;
    */
   public void getStreamServiceSettings(Consumer<GetStreamServiceSettingsResponse> callback) {
     sendRequest(GetStreamServiceSettingsRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the current stream service settings (stream destination).
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetStreamServiceSettingsResponse getStreamServiceSettings(long timeout) {
+    BlockingConsumer<GetStreamServiceSettingsResponse> callback = new BlockingConsumer<GetStreamServiceSettingsResponse>();
+    sendRequest(GetStreamServiceSettingsRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -469,12 +658,39 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the current stream service settings (stream destination).
+   *
+   * Note: Simple RTMP settings can be set with type `rtmp_custom` and the settings fields `server` and `key`.
+   *
+   * @param streamServiceType Type of stream service to apply. Example: `rtmp_common` or `rtmp_custom`
+   * @param streamServiceSettings Settings to apply to the service
+   * @param timeout long timeout in ms
+   */
+  public SetStreamServiceSettingsResponse setStreamServiceSettings(String streamServiceType,
+      JsonObject streamServiceSettings, long timeout) {
+    BlockingConsumer<SetStreamServiceSettingsResponse> callback = new BlockingConsumer<SetStreamServiceSettingsResponse>();
+    sendRequest(SetStreamServiceSettingsRequest.builder().streamServiceType(streamServiceType).streamServiceSettings(streamServiceSettings).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current directory that the record output is set to.
    *
    * @param callback Consumer&lt;GetRecordDirectoryResponse&gt;
    */
   public void getRecordDirectory(Consumer<GetRecordDirectoryResponse> callback) {
     sendRequest(GetRecordDirectoryRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the current directory that the record output is set to.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetRecordDirectoryResponse getRecordDirectory(long timeout) {
+    BlockingConsumer<GetRecordDirectoryResponse> callback = new BlockingConsumer<GetRecordDirectoryResponse>();
+    sendRequest(GetRecordDirectoryRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -489,6 +705,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all of a source's filters.
+   *
+   * @param sourceName Name of the source
+   * @param timeout long timeout in ms
+   */
+  public GetSourceFilterListResponse getSourceFilterList(String sourceName, long timeout) {
+    BlockingConsumer<GetSourceFilterListResponse> callback = new BlockingConsumer<GetSourceFilterListResponse>();
+    sendRequest(GetSourceFilterListRequest.builder().sourceName(sourceName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the default settings for a filter kind.
    *
    * @param filterKind Filter kind to get the default settings for
@@ -497,6 +725,19 @@ public abstract class OBSRemoteControllerBase {
   public void getSourceFilterDefaultSettings(String filterKind,
       Consumer<GetSourceFilterDefaultSettingsResponse> callback) {
     sendRequest(GetSourceFilterDefaultSettingsRequest.builder().filterKind(filterKind).build(), callback);
+  }
+
+  /**
+   * Gets the default settings for a filter kind.
+   *
+   * @param filterKind Filter kind to get the default settings for
+   * @param timeout long timeout in ms
+   */
+  public GetSourceFilterDefaultSettingsResponse getSourceFilterDefaultSettings(String filterKind,
+      long timeout) {
+    BlockingConsumer<GetSourceFilterDefaultSettingsResponse> callback = new BlockingConsumer<GetSourceFilterDefaultSettingsResponse>();
+    sendRequest(GetSourceFilterDefaultSettingsRequest.builder().filterKind(filterKind).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -514,6 +755,22 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Creates a new filter, adding it to the specified source.
+   *
+   * @param sourceName Name of the source to add the filter to
+   * @param filterName Name of the new filter to be created
+   * @param filterKind The kind of filter to be created
+   * @param filterSettings Settings object to initialize the filter with
+   * @param timeout long timeout in ms
+   */
+  public CreateSourceFilterResponse createSourceFilter(String sourceName, String filterName,
+      String filterKind, JsonObject filterSettings, long timeout) {
+    BlockingConsumer<CreateSourceFilterResponse> callback = new BlockingConsumer<CreateSourceFilterResponse>();
+    sendRequest(CreateSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).filterKind(filterKind).filterSettings(filterSettings).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Removes a filter from a source.
    *
    * @param sourceName Name of the source the filter is on
@@ -523,6 +780,20 @@ public abstract class OBSRemoteControllerBase {
   public void removeSourceFilter(String sourceName, String filterName,
       Consumer<RemoveSourceFilterResponse> callback) {
     sendRequest(RemoveSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(), callback);
+  }
+
+  /**
+   * Removes a filter from a source.
+   *
+   * @param sourceName Name of the source the filter is on
+   * @param filterName Name of the filter to remove
+   * @param timeout long timeout in ms
+   */
+  public RemoveSourceFilterResponse removeSourceFilter(String sourceName, String filterName,
+      long timeout) {
+    BlockingConsumer<RemoveSourceFilterResponse> callback = new BlockingConsumer<RemoveSourceFilterResponse>();
+    sendRequest(RemoveSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -539,6 +810,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the name of a source filter (rename).
+   *
+   * @param sourceName Name of the source the filter is on
+   * @param filterName Current name of the filter
+   * @param newFilterName New name for the filter
+   * @param timeout long timeout in ms
+   */
+  public SetSourceFilterNameResponse setSourceFilterName(String sourceName, String filterName,
+      String newFilterName, long timeout) {
+    BlockingConsumer<SetSourceFilterNameResponse> callback = new BlockingConsumer<SetSourceFilterNameResponse>();
+    sendRequest(SetSourceFilterNameRequest.builder().sourceName(sourceName).filterName(filterName).newFilterName(newFilterName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the info for a specific source filter.
    *
    * @param sourceName Name of the source
@@ -548,6 +834,20 @@ public abstract class OBSRemoteControllerBase {
   public void getSourceFilter(String sourceName, String filterName,
       Consumer<GetSourceFilterResponse> callback) {
     sendRequest(GetSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(), callback);
+  }
+
+  /**
+   * Gets the info for a specific source filter.
+   *
+   * @param sourceName Name of the source
+   * @param filterName Name of the filter
+   * @param timeout long timeout in ms
+   */
+  public GetSourceFilterResponse getSourceFilter(String sourceName, String filterName,
+      long timeout) {
+    BlockingConsumer<GetSourceFilterResponse> callback = new BlockingConsumer<GetSourceFilterResponse>();
+    sendRequest(GetSourceFilterRequest.builder().sourceName(sourceName).filterName(filterName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -561,6 +861,21 @@ public abstract class OBSRemoteControllerBase {
   public void setSourceFilterIndex(String sourceName, String filterName, Number filterIndex,
       Consumer<SetSourceFilterIndexResponse> callback) {
     sendRequest(SetSourceFilterIndexRequest.builder().sourceName(sourceName).filterName(filterName).filterIndex(filterIndex).build(), callback);
+  }
+
+  /**
+   * Sets the index position of a filter on a source.
+   *
+   * @param sourceName Name of the source the filter is on
+   * @param filterName Name of the filter
+   * @param filterIndex New index position of the filter
+   * @param timeout long timeout in ms
+   */
+  public SetSourceFilterIndexResponse setSourceFilterIndex(String sourceName, String filterName,
+      Number filterIndex, long timeout) {
+    BlockingConsumer<SetSourceFilterIndexResponse> callback = new BlockingConsumer<SetSourceFilterIndexResponse>();
+    sendRequest(SetSourceFilterIndexRequest.builder().sourceName(sourceName).filterName(filterName).filterIndex(filterIndex).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -579,6 +894,22 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the settings of a source filter.
+   *
+   * @param sourceName Name of the source the filter is on
+   * @param filterName Name of the filter to set the settings of
+   * @param filterSettings Object of settings to apply
+   * @param overlay True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.
+   * @param timeout long timeout in ms
+   */
+  public SetSourceFilterSettingsResponse setSourceFilterSettings(String sourceName,
+      String filterName, JsonObject filterSettings, Boolean overlay, long timeout) {
+    BlockingConsumer<SetSourceFilterSettingsResponse> callback = new BlockingConsumer<SetSourceFilterSettingsResponse>();
+    sendRequest(SetSourceFilterSettingsRequest.builder().sourceName(sourceName).filterName(filterName).filterSettings(filterSettings).overlay(overlay).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the enable state of a source filter.
    *
    * @param sourceName Name of the source the filter is on
@@ -592,12 +923,38 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the enable state of a source filter.
+   *
+   * @param sourceName Name of the source the filter is on
+   * @param filterName Name of the filter
+   * @param filterEnabled New enable state of the filter
+   * @param timeout long timeout in ms
+   */
+  public SetSourceFilterEnabledResponse setSourceFilterEnabled(String sourceName, String filterName,
+      Boolean filterEnabled, long timeout) {
+    BlockingConsumer<SetSourceFilterEnabledResponse> callback = new BlockingConsumer<SetSourceFilterEnabledResponse>();
+    sendRequest(SetSourceFilterEnabledRequest.builder().sourceName(sourceName).filterName(filterName).filterEnabled(filterEnabled).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets data about the current plugin and RPC version.
    *
    * @param callback Consumer&lt;GetVersionResponse&gt;
    */
   public void getVersion(Consumer<GetVersionResponse> callback) {
     sendRequest(GetVersionRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets data about the current plugin and RPC version.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetVersionResponse getVersion(long timeout) {
+    BlockingConsumer<GetVersionResponse> callback = new BlockingConsumer<GetVersionResponse>();
+    sendRequest(GetVersionRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -610,6 +967,17 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets statistics about OBS, obs-websocket, and the current session.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetStatsResponse getStats(long timeout) {
+    BlockingConsumer<GetStatsResponse> callback = new BlockingConsumer<GetStatsResponse>();
+    sendRequest(GetStatsRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.
    *
    * @param eventData Data payload to emit to all receivers
@@ -618,6 +986,18 @@ public abstract class OBSRemoteControllerBase {
   public void broadcastCustomEvent(JsonObject eventData,
       Consumer<BroadcastCustomEventResponse> callback) {
     sendRequest(BroadcastCustomEventRequest.builder().eventData(eventData).build(), callback);
+  }
+
+  /**
+   * Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.
+   *
+   * @param eventData Data payload to emit to all receivers
+   * @param timeout long timeout in ms
+   */
+  public BroadcastCustomEventResponse broadcastCustomEvent(JsonObject eventData, long timeout) {
+    BlockingConsumer<BroadcastCustomEventResponse> callback = new BlockingConsumer<BroadcastCustomEventResponse>();
+    sendRequest(BroadcastCustomEventRequest.builder().eventData(eventData).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -637,12 +1017,41 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Call a request registered to a vendor.
+   *
+   * A vendor is a unique name registered by a third-party plugin or script, which allows for custom requests and events to be added to obs-websocket.
+   * If a plugin or script implements vendor requests or events, documentation is expected to be provided with them.
+   *
+   * @param vendorName Name of the vendor to use
+   * @param requestType The request type to call
+   * @param requestData Object containing appropriate request data
+   * @param timeout long timeout in ms
+   */
+  public CallVendorRequestResponse callVendorRequest(String vendorName, String requestType,
+      JsonObject requestData, long timeout) {
+    BlockingConsumer<CallVendorRequestResponse> callback = new BlockingConsumer<CallVendorRequestResponse>();
+    sendRequest(CallVendorRequestRequest.builder().vendorName(vendorName).requestType(requestType).requestData(requestData).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all hotkey names in OBS
    *
    * @param callback Consumer&lt;GetHotkeyListResponse&gt;
    */
   public void getHotkeyList(Consumer<GetHotkeyListResponse> callback) {
     sendRequest(GetHotkeyListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets an array of all hotkey names in OBS
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetHotkeyListResponse getHotkeyList(long timeout) {
+    BlockingConsumer<GetHotkeyListResponse> callback = new BlockingConsumer<GetHotkeyListResponse>();
+    sendRequest(GetHotkeyListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -654,6 +1063,18 @@ public abstract class OBSRemoteControllerBase {
   public void triggerHotkeyByName(String hotkeyName,
       Consumer<TriggerHotkeyByNameResponse> callback) {
     sendRequest(TriggerHotkeyByNameRequest.builder().hotkeyName(hotkeyName).build(), callback);
+  }
+
+  /**
+   * Triggers a hotkey using its name. See `GetHotkeyList`
+   *
+   * @param hotkeyName Name of the hotkey to trigger
+   * @param timeout long timeout in ms
+   */
+  public TriggerHotkeyByNameResponse triggerHotkeyByName(String hotkeyName, long timeout) {
+    BlockingConsumer<TriggerHotkeyByNameResponse> callback = new BlockingConsumer<TriggerHotkeyByNameResponse>();
+    sendRequest(TriggerHotkeyByNameRequest.builder().hotkeyName(hotkeyName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -669,6 +1090,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Triggers a hotkey using a sequence of keys.
+   *
+   * @param keyId The OBS key ID to use. See https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h
+   * @param keyModifiers Object containing key modifiers to apply
+   * @param timeout long timeout in ms
+   */
+  public TriggerHotkeyByKeySequenceResponse triggerHotkeyByKeySequence(String keyId,
+      KeyModifiers keyModifiers, long timeout) {
+    BlockingConsumer<TriggerHotkeyByKeySequenceResponse> callback = new BlockingConsumer<TriggerHotkeyByKeySequenceResponse>();
+    sendRequest(TriggerHotkeyByKeySequenceRequest.builder().keyId(keyId).keyModifiers(keyModifiers).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
    *
    * @param sleepMillis Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)
@@ -677,6 +1112,19 @@ public abstract class OBSRemoteControllerBase {
    */
   public void sleep(Number sleepMillis, Number sleepFrames, Consumer<SleepResponse> callback) {
     sendRequest(SleepRequest.builder().sleepMillis(sleepMillis).sleepFrames(sleepFrames).build(), callback);
+  }
+
+  /**
+   * Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+   *
+   * @param sleepMillis Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)
+   * @param sleepFrames Number of frames to sleep for (if `SERIAL_FRAME` mode)
+   * @param timeout long timeout in ms
+   */
+  public SleepResponse sleep(Number sleepMillis, Number sleepFrames, long timeout) {
+    BlockingConsumer<SleepResponse> callback = new BlockingConsumer<SleepResponse>();
+    sendRequest(SleepRequest.builder().sleepMillis(sleepMillis).sleepFrames(sleepFrames).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -690,6 +1138,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all inputs in OBS.
+   *
+   * @param inputKind Restrict the array to only inputs of the specified kind
+   * @param timeout long timeout in ms
+   */
+  public GetInputListResponse getInputList(String inputKind, long timeout) {
+    BlockingConsumer<GetInputListResponse> callback = new BlockingConsumer<GetInputListResponse>();
+    sendRequest(GetInputListRequest.builder().inputKind(inputKind).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all available input kinds in OBS.
    *
    * @param unversioned True == Return all kinds as unversioned, False == Return with version suffixes (if available)
@@ -700,12 +1160,35 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all available input kinds in OBS.
+   *
+   * @param unversioned True == Return all kinds as unversioned, False == Return with version suffixes (if available)
+   * @param timeout long timeout in ms
+   */
+  public GetInputKindListResponse getInputKindList(Boolean unversioned, long timeout) {
+    BlockingConsumer<GetInputKindListResponse> callback = new BlockingConsumer<GetInputKindListResponse>();
+    sendRequest(GetInputKindListRequest.builder().unversioned(unversioned).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the names of all special inputs.
    *
    * @param callback Consumer&lt;GetSpecialInputsResponse&gt;
    */
   public void getSpecialInputs(Consumer<GetSpecialInputsResponse> callback) {
     sendRequest(GetSpecialInputsRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the names of all special inputs.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetSpecialInputsResponse getSpecialInputs(long timeout) {
+    BlockingConsumer<GetSpecialInputsResponse> callback = new BlockingConsumer<GetSpecialInputsResponse>();
+    sendRequest(GetSpecialInputsRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -724,6 +1207,23 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Creates a new input, adding it as a scene item to the specified scene.
+   *
+   * @param sceneName Name of the scene to add the input to as a scene item
+   * @param inputName Name of the new input to created
+   * @param inputKind The kind of input to be created
+   * @param inputSettings Settings object to initialize the input with
+   * @param sceneItemEnabled Whether to set the created scene item to enabled or disabled
+   * @param timeout long timeout in ms
+   */
+  public CreateInputResponse createInput(String sceneName, String inputName, String inputKind,
+      JsonObject inputSettings, Boolean sceneItemEnabled, long timeout) {
+    BlockingConsumer<CreateInputResponse> callback = new BlockingConsumer<CreateInputResponse>();
+    sendRequest(CreateInputRequest.builder().sceneName(sceneName).inputName(inputName).inputKind(inputKind).inputSettings(inputSettings).sceneItemEnabled(sceneItemEnabled).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Removes an existing input.
    *
    * Note: Will immediately remove all associated scene items.
@@ -733,6 +1233,20 @@ public abstract class OBSRemoteControllerBase {
    */
   public void removeInput(String inputName, Consumer<RemoveInputResponse> callback) {
     sendRequest(RemoveInputRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Removes an existing input.
+   *
+   * Note: Will immediately remove all associated scene items.
+   *
+   * @param inputName Name of the input to remove
+   * @param timeout long timeout in ms
+   */
+  public RemoveInputResponse removeInput(String inputName, long timeout) {
+    BlockingConsumer<RemoveInputResponse> callback = new BlockingConsumer<RemoveInputResponse>();
+    sendRequest(RemoveInputRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -748,6 +1262,19 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the name of an input (rename).
+   *
+   * @param inputName Current input name
+   * @param newInputName New name for the input
+   * @param timeout long timeout in ms
+   */
+  public SetInputNameResponse setInputName(String inputName, String newInputName, long timeout) {
+    BlockingConsumer<SetInputNameResponse> callback = new BlockingConsumer<SetInputNameResponse>();
+    sendRequest(SetInputNameRequest.builder().inputName(inputName).newInputName(newInputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the default settings for an input kind.
    *
    * @param inputKind Input kind to get the default settings for
@@ -756,6 +1283,18 @@ public abstract class OBSRemoteControllerBase {
   public void getInputDefaultSettings(String inputKind,
       Consumer<GetInputDefaultSettingsResponse> callback) {
     sendRequest(GetInputDefaultSettingsRequest.builder().inputKind(inputKind).build(), callback);
+  }
+
+  /**
+   * Gets the default settings for an input kind.
+   *
+   * @param inputKind Input kind to get the default settings for
+   * @param timeout long timeout in ms
+   */
+  public GetInputDefaultSettingsResponse getInputDefaultSettings(String inputKind, long timeout) {
+    BlockingConsumer<GetInputDefaultSettingsResponse> callback = new BlockingConsumer<GetInputDefaultSettingsResponse>();
+    sendRequest(GetInputDefaultSettingsRequest.builder().inputKind(inputKind).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -768,6 +1307,20 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getInputSettings(String inputName, Consumer<GetInputSettingsResponse> callback) {
     sendRequest(GetInputSettingsRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Gets the settings of an input.
+   *
+   * Note: Does not include defaults. To create the entire settings object, overlay `inputSettings` over the `defaultInputSettings` provided by `GetInputDefaultSettings`.
+   *
+   * @param inputName Name of the input to get the settings of
+   * @param timeout long timeout in ms
+   */
+  public GetInputSettingsResponse getInputSettings(String inputName, long timeout) {
+    BlockingConsumer<GetInputSettingsResponse> callback = new BlockingConsumer<GetInputSettingsResponse>();
+    sendRequest(GetInputSettingsRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -784,6 +1337,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the settings of an input.
+   *
+   * @param inputName Name of the input to set the settings of
+   * @param inputSettings Object of settings to apply
+   * @param overlay True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.
+   * @param timeout long timeout in ms
+   */
+  public SetInputSettingsResponse setInputSettings(String inputName, JsonObject inputSettings,
+      Boolean overlay, long timeout) {
+    BlockingConsumer<SetInputSettingsResponse> callback = new BlockingConsumer<SetInputSettingsResponse>();
+    sendRequest(SetInputSettingsRequest.builder().inputName(inputName).inputSettings(inputSettings).overlay(overlay).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the audio mute state of an input.
    *
    * @param inputName Name of input to get the mute state of
@@ -791,6 +1359,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getInputMute(String inputName, Consumer<GetInputMuteResponse> callback) {
     sendRequest(GetInputMuteRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Gets the audio mute state of an input.
+   *
+   * @param inputName Name of input to get the mute state of
+   * @param timeout long timeout in ms
+   */
+  public GetInputMuteResponse getInputMute(String inputName, long timeout) {
+    BlockingConsumer<GetInputMuteResponse> callback = new BlockingConsumer<GetInputMuteResponse>();
+    sendRequest(GetInputMuteRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -806,6 +1386,19 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the audio mute state of an input.
+   *
+   * @param inputName Name of the input to set the mute state of
+   * @param inputMuted Whether to mute the input or not
+   * @param timeout long timeout in ms
+   */
+  public SetInputMuteResponse setInputMute(String inputName, Boolean inputMuted, long timeout) {
+    BlockingConsumer<SetInputMuteResponse> callback = new BlockingConsumer<SetInputMuteResponse>();
+    sendRequest(SetInputMuteRequest.builder().inputName(inputName).inputMuted(inputMuted).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Toggles the audio mute state of an input.
    *
    * @param inputName Name of the input to toggle the mute state of
@@ -816,6 +1409,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Toggles the audio mute state of an input.
+   *
+   * @param inputName Name of the input to toggle the mute state of
+   * @param timeout long timeout in ms
+   */
+  public ToggleInputMuteResponse toggleInputMute(String inputName, long timeout) {
+    BlockingConsumer<ToggleInputMuteResponse> callback = new BlockingConsumer<ToggleInputMuteResponse>();
+    sendRequest(ToggleInputMuteRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current volume setting of an input.
    *
    * @param inputName Name of the input to get the volume of
@@ -823,6 +1428,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getInputVolume(String inputName, Consumer<GetInputVolumeResponse> callback) {
     sendRequest(GetInputVolumeRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Gets the current volume setting of an input.
+   *
+   * @param inputName Name of the input to get the volume of
+   * @param timeout long timeout in ms
+   */
+  public GetInputVolumeResponse getInputVolume(String inputName, long timeout) {
+    BlockingConsumer<GetInputVolumeResponse> callback = new BlockingConsumer<GetInputVolumeResponse>();
+    sendRequest(GetInputVolumeRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -839,6 +1456,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the volume setting of an input.
+   *
+   * @param inputName Name of the input to set the volume of
+   * @param inputVolumeMul Volume setting in mul
+   * @param inputVolumeDb Volume setting in dB
+   * @param timeout long timeout in ms
+   */
+  public SetInputVolumeResponse setInputVolume(String inputName, Number inputVolumeMul,
+      Number inputVolumeDb, long timeout) {
+    BlockingConsumer<SetInputVolumeResponse> callback = new BlockingConsumer<SetInputVolumeResponse>();
+    sendRequest(SetInputVolumeRequest.builder().inputName(inputName).inputVolumeMul(inputVolumeMul).inputVolumeDb(inputVolumeDb).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the audio balance of an input.
    *
    * @param inputName Name of the input to get the audio balance of
@@ -847,6 +1479,18 @@ public abstract class OBSRemoteControllerBase {
   public void getInputAudioBalance(String inputName,
       Consumer<GetInputAudioBalanceResponse> callback) {
     sendRequest(GetInputAudioBalanceRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Gets the audio balance of an input.
+   *
+   * @param inputName Name of the input to get the audio balance of
+   * @param timeout long timeout in ms
+   */
+  public GetInputAudioBalanceResponse getInputAudioBalance(String inputName, long timeout) {
+    BlockingConsumer<GetInputAudioBalanceResponse> callback = new BlockingConsumer<GetInputAudioBalanceResponse>();
+    sendRequest(GetInputAudioBalanceRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -859,6 +1503,20 @@ public abstract class OBSRemoteControllerBase {
   public void setInputAudioBalance(String inputName, Number inputAudioBalance,
       Consumer<SetInputAudioBalanceResponse> callback) {
     sendRequest(SetInputAudioBalanceRequest.builder().inputName(inputName).inputAudioBalance(inputAudioBalance).build(), callback);
+  }
+
+  /**
+   * Sets the audio balance of an input.
+   *
+   * @param inputName Name of the input to set the audio balance of
+   * @param inputAudioBalance New audio balance value
+   * @param timeout long timeout in ms
+   */
+  public SetInputAudioBalanceResponse setInputAudioBalance(String inputName,
+      Number inputAudioBalance, long timeout) {
+    BlockingConsumer<SetInputAudioBalanceResponse> callback = new BlockingConsumer<SetInputAudioBalanceResponse>();
+    sendRequest(SetInputAudioBalanceRequest.builder().inputName(inputName).inputAudioBalance(inputAudioBalance).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -875,6 +1533,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the audio sync offset of an input.
+   *
+   * Note: The audio sync offset can be negative too!
+   *
+   * @param inputName Name of the input to get the audio sync offset of
+   * @param timeout long timeout in ms
+   */
+  public GetInputAudioSyncOffsetResponse getInputAudioSyncOffset(String inputName, long timeout) {
+    BlockingConsumer<GetInputAudioSyncOffsetResponse> callback = new BlockingConsumer<GetInputAudioSyncOffsetResponse>();
+    sendRequest(GetInputAudioSyncOffsetRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the audio sync offset of an input.
    *
    * @param inputName Name of the input to set the audio sync offset of
@@ -884,6 +1556,20 @@ public abstract class OBSRemoteControllerBase {
   public void setInputAudioSyncOffset(String inputName, Number inputAudioSyncOffset,
       Consumer<SetInputAudioSyncOffsetResponse> callback) {
     sendRequest(SetInputAudioSyncOffsetRequest.builder().inputName(inputName).inputAudioSyncOffset(inputAudioSyncOffset).build(), callback);
+  }
+
+  /**
+   * Sets the audio sync offset of an input.
+   *
+   * @param inputName Name of the input to set the audio sync offset of
+   * @param inputAudioSyncOffset New audio sync offset in milliseconds
+   * @param timeout long timeout in ms
+   */
+  public SetInputAudioSyncOffsetResponse setInputAudioSyncOffset(String inputName,
+      Number inputAudioSyncOffset, long timeout) {
+    BlockingConsumer<SetInputAudioSyncOffsetResponse> callback = new BlockingConsumer<SetInputAudioSyncOffsetResponse>();
+    sendRequest(SetInputAudioSyncOffsetRequest.builder().inputName(inputName).inputAudioSyncOffset(inputAudioSyncOffset).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -904,6 +1590,24 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the audio monitor type of an input.
+   *
+   * The available audio monitor types are:
+   *
+   * - `OBS_MONITORING_TYPE_NONE`
+   * - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+   * - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+   *
+   * @param inputName Name of the input to get the audio monitor type of
+   * @param timeout long timeout in ms
+   */
+  public GetInputAudioMonitorTypeResponse getInputAudioMonitorType(String inputName, long timeout) {
+    BlockingConsumer<GetInputAudioMonitorTypeResponse> callback = new BlockingConsumer<GetInputAudioMonitorTypeResponse>();
+    sendRequest(GetInputAudioMonitorTypeRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the audio monitor type of an input.
    *
    * @param inputName Name of the input to set the audio monitor type of
@@ -916,6 +1620,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the audio monitor type of an input.
+   *
+   * @param inputName Name of the input to set the audio monitor type of
+   * @param monitorType Audio monitor type
+   * @param timeout long timeout in ms
+   */
+  public SetInputAudioMonitorTypeResponse setInputAudioMonitorType(String inputName,
+      Input.MonitorType monitorType, long timeout) {
+    BlockingConsumer<SetInputAudioMonitorTypeResponse> callback = new BlockingConsumer<SetInputAudioMonitorTypeResponse>();
+    sendRequest(SetInputAudioMonitorTypeRequest.builder().inputName(inputName).monitorType(monitorType).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the enable state of all audio tracks of an input.
    *
    * @param inputName Name of the input
@@ -924,6 +1642,18 @@ public abstract class OBSRemoteControllerBase {
   public void getInputAudioTracks(String inputName,
       Consumer<GetInputAudioTracksResponse> callback) {
     sendRequest(GetInputAudioTracksRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Gets the enable state of all audio tracks of an input.
+   *
+   * @param inputName Name of the input
+   * @param timeout long timeout in ms
+   */
+  public GetInputAudioTracksResponse getInputAudioTracks(String inputName, long timeout) {
+    BlockingConsumer<GetInputAudioTracksResponse> callback = new BlockingConsumer<GetInputAudioTracksResponse>();
+    sendRequest(GetInputAudioTracksRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -939,6 +1669,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the enable state of audio tracks of an input.
+   *
+   * @param inputName Name of the input
+   * @param inputAudioTracks Track settings to apply
+   * @param timeout long timeout in ms
+   */
+  public SetInputAudioTracksResponse setInputAudioTracks(String inputName,
+      Input.AudioTracks inputAudioTracks, long timeout) {
+    BlockingConsumer<SetInputAudioTracksResponse> callback = new BlockingConsumer<SetInputAudioTracksResponse>();
+    sendRequest(SetInputAudioTracksRequest.builder().inputName(inputName).inputAudioTracks(inputAudioTracks).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the items of a list property from an input's properties.
    *
    * Note: Use this in cases where an input provides a dynamic, selectable list of items. For example, display capture, where it provides a list of available displays.
@@ -950,6 +1694,22 @@ public abstract class OBSRemoteControllerBase {
   public void getInputPropertiesListPropertyItems(String inputName, String propertyName,
       Consumer<GetInputPropertiesListPropertyItemsResponse> callback) {
     sendRequest(GetInputPropertiesListPropertyItemsRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
+  }
+
+  /**
+   * Gets the items of a list property from an input's properties.
+   *
+   * Note: Use this in cases where an input provides a dynamic, selectable list of items. For example, display capture, where it provides a list of available displays.
+   *
+   * @param inputName Name of the input
+   * @param propertyName Name of the list property to get the items of
+   * @param timeout long timeout in ms
+   */
+  public GetInputPropertiesListPropertyItemsResponse getInputPropertiesListPropertyItems(
+      String inputName, String propertyName, long timeout) {
+    BlockingConsumer<GetInputPropertiesListPropertyItemsResponse> callback = new BlockingConsumer<GetInputPropertiesListPropertyItemsResponse>();
+    sendRequest(GetInputPropertiesListPropertyItemsRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -968,6 +1728,26 @@ public abstract class OBSRemoteControllerBase {
   public void pressInputPropertiesButton(String inputName, String propertyName,
       Consumer<PressInputPropertiesButtonResponse> callback) {
     sendRequest(PressInputPropertiesButtonRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
+  }
+
+  /**
+   * Presses a button in the properties of an input.
+   *
+   * Some known `propertyName` values are:
+   *
+   * - `refreshnocache` - Browser source reload button
+   *
+   * Note: Use this in cases where there is a button in the properties of an input that cannot be accessed in any other way. For example, browser sources, where there is a refresh button.
+   *
+   * @param inputName Name of the input
+   * @param propertyName Name of the button property to press
+   * @param timeout long timeout in ms
+   */
+  public PressInputPropertiesButtonResponse pressInputPropertiesButton(String inputName,
+      String propertyName, long timeout) {
+    BlockingConsumer<PressInputPropertiesButtonResponse> callback = new BlockingConsumer<PressInputPropertiesButtonResponse>();
+    sendRequest(PressInputPropertiesButtonRequest.builder().inputName(inputName).propertyName(propertyName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -993,6 +1773,29 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the status of a media input.
+   *
+   * Media States:
+   *
+   * - `OBS_MEDIA_STATE_NONE`
+   * - `OBS_MEDIA_STATE_PLAYING`
+   * - `OBS_MEDIA_STATE_OPENING`
+   * - `OBS_MEDIA_STATE_BUFFERING`
+   * - `OBS_MEDIA_STATE_PAUSED`
+   * - `OBS_MEDIA_STATE_STOPPED`
+   * - `OBS_MEDIA_STATE_ENDED`
+   * - `OBS_MEDIA_STATE_ERROR`
+   *
+   * @param inputName Name of the media input
+   * @param timeout long timeout in ms
+   */
+  public GetMediaInputStatusResponse getMediaInputStatus(String inputName, long timeout) {
+    BlockingConsumer<GetMediaInputStatusResponse> callback = new BlockingConsumer<GetMediaInputStatusResponse>();
+    sendRequest(GetMediaInputStatusRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the cursor position of a media input.
    *
    * This request does not perform bounds checking of the cursor position.
@@ -1004,6 +1807,22 @@ public abstract class OBSRemoteControllerBase {
   public void setMediaInputCursor(String inputName, Number mediaCursor,
       Consumer<SetMediaInputCursorResponse> callback) {
     sendRequest(SetMediaInputCursorRequest.builder().inputName(inputName).mediaCursor(mediaCursor).build(), callback);
+  }
+
+  /**
+   * Sets the cursor position of a media input.
+   *
+   * This request does not perform bounds checking of the cursor position.
+   *
+   * @param inputName Name of the media input
+   * @param mediaCursor New cursor position to set
+   * @param timeout long timeout in ms
+   */
+  public SetMediaInputCursorResponse setMediaInputCursor(String inputName, Number mediaCursor,
+      long timeout) {
+    BlockingConsumer<SetMediaInputCursorResponse> callback = new BlockingConsumer<SetMediaInputCursorResponse>();
+    sendRequest(SetMediaInputCursorRequest.builder().inputName(inputName).mediaCursor(mediaCursor).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1021,6 +1840,22 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Offsets the current cursor position of a media input by the specified value.
+   *
+   * This request does not perform bounds checking of the cursor position.
+   *
+   * @param inputName Name of the media input
+   * @param mediaCursorOffset Value to offset the current cursor position by
+   * @param timeout long timeout in ms
+   */
+  public OffsetMediaInputCursorResponse offsetMediaInputCursor(String inputName,
+      Number mediaCursorOffset, long timeout) {
+    BlockingConsumer<OffsetMediaInputCursorResponse> callback = new BlockingConsumer<OffsetMediaInputCursorResponse>();
+    sendRequest(OffsetMediaInputCursorRequest.builder().inputName(inputName).mediaCursorOffset(mediaCursorOffset).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Triggers an action on a media input.
    *
    * @param inputName Name of the media input
@@ -1033,12 +1868,37 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Triggers an action on a media input.
+   *
+   * @param inputName Name of the media input
+   * @param mediaAction Identifier of the `ObsMediaInputAction` enum
+   * @param timeout long timeout in ms
+   */
+  public TriggerMediaInputActionResponse triggerMediaInputAction(String inputName,
+      String mediaAction, long timeout) {
+    BlockingConsumer<TriggerMediaInputActionResponse> callback = new BlockingConsumer<TriggerMediaInputActionResponse>();
+    sendRequest(TriggerMediaInputActionRequest.builder().inputName(inputName).mediaAction(mediaAction).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the status of the virtualcam output.
    *
    * @param callback Consumer&lt;GetVirtualCamStatusResponse&gt;
    */
   public void getVirtualCamStatus(Consumer<GetVirtualCamStatusResponse> callback) {
     sendRequest(GetVirtualCamStatusRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the status of the virtualcam output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetVirtualCamStatusResponse getVirtualCamStatus(long timeout) {
+    BlockingConsumer<GetVirtualCamStatusResponse> callback = new BlockingConsumer<GetVirtualCamStatusResponse>();
+    sendRequest(GetVirtualCamStatusRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1051,12 +1911,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Toggles the state of the virtualcam output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ToggleVirtualCamResponse toggleVirtualCam(long timeout) {
+    BlockingConsumer<ToggleVirtualCamResponse> callback = new BlockingConsumer<ToggleVirtualCamResponse>();
+    sendRequest(ToggleVirtualCamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Starts the virtualcam output.
    *
    * @param callback Consumer&lt;StartVirtualCamResponse&gt;
    */
   public void startVirtualCam(Consumer<StartVirtualCamResponse> callback) {
     sendRequest(StartVirtualCamRequest.builder().build(), callback);
+  }
+
+  /**
+   * Starts the virtualcam output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StartVirtualCamResponse startVirtualCam(long timeout) {
+    BlockingConsumer<StartVirtualCamResponse> callback = new BlockingConsumer<StartVirtualCamResponse>();
+    sendRequest(StartVirtualCamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1069,12 +1951,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Stops the virtualcam output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StopVirtualCamResponse stopVirtualCam(long timeout) {
+    BlockingConsumer<StopVirtualCamResponse> callback = new BlockingConsumer<StopVirtualCamResponse>();
+    sendRequest(StopVirtualCamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the status of the replay buffer output.
    *
    * @param callback Consumer&lt;GetReplayBufferStatusResponse&gt;
    */
   public void getReplayBufferStatus(Consumer<GetReplayBufferStatusResponse> callback) {
     sendRequest(GetReplayBufferStatusRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the status of the replay buffer output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetReplayBufferStatusResponse getReplayBufferStatus(long timeout) {
+    BlockingConsumer<GetReplayBufferStatusResponse> callback = new BlockingConsumer<GetReplayBufferStatusResponse>();
+    sendRequest(GetReplayBufferStatusRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1087,12 +1991,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Toggles the state of the replay buffer output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ToggleReplayBufferResponse toggleReplayBuffer(long timeout) {
+    BlockingConsumer<ToggleReplayBufferResponse> callback = new BlockingConsumer<ToggleReplayBufferResponse>();
+    sendRequest(ToggleReplayBufferRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Starts the replay buffer output.
    *
    * @param callback Consumer&lt;StartReplayBufferResponse&gt;
    */
   public void startReplayBuffer(Consumer<StartReplayBufferResponse> callback) {
     sendRequest(StartReplayBufferRequest.builder().build(), callback);
+  }
+
+  /**
+   * Starts the replay buffer output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StartReplayBufferResponse startReplayBuffer(long timeout) {
+    BlockingConsumer<StartReplayBufferResponse> callback = new BlockingConsumer<StartReplayBufferResponse>();
+    sendRequest(StartReplayBufferRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1105,12 +2031,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Stops the replay buffer output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StopReplayBufferResponse stopReplayBuffer(long timeout) {
+    BlockingConsumer<StopReplayBufferResponse> callback = new BlockingConsumer<StopReplayBufferResponse>();
+    sendRequest(StopReplayBufferRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Saves the contents of the replay buffer output.
    *
    * @param callback Consumer&lt;SaveReplayBufferResponse&gt;
    */
   public void saveReplayBuffer(Consumer<SaveReplayBufferResponse> callback) {
     sendRequest(SaveReplayBufferRequest.builder().build(), callback);
+  }
+
+  /**
+   * Saves the contents of the replay buffer output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public SaveReplayBufferResponse saveReplayBuffer(long timeout) {
+    BlockingConsumer<SaveReplayBufferResponse> callback = new BlockingConsumer<SaveReplayBufferResponse>();
+    sendRequest(SaveReplayBufferRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1123,12 +2071,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the filename of the last replay buffer save file.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetLastReplayBufferReplayResponse getLastReplayBufferReplay(long timeout) {
+    BlockingConsumer<GetLastReplayBufferReplayResponse> callback = new BlockingConsumer<GetLastReplayBufferReplayResponse>();
+    sendRequest(GetLastReplayBufferReplayRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the list of available outputs.
    *
    * @param callback Consumer&lt;GetOutputListResponse&gt;
    */
   public void getOutputList(Consumer<GetOutputListResponse> callback) {
     sendRequest(GetOutputListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the list of available outputs.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetOutputListResponse getOutputList(long timeout) {
+    BlockingConsumer<GetOutputListResponse> callback = new BlockingConsumer<GetOutputListResponse>();
+    sendRequest(GetOutputListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1142,6 +2112,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the status of an output.
+   *
+   * @param outputName Output name
+   * @param timeout long timeout in ms
+   */
+  public GetOutputStatusResponse getOutputStatus(String outputName, long timeout) {
+    BlockingConsumer<GetOutputStatusResponse> callback = new BlockingConsumer<GetOutputStatusResponse>();
+    sendRequest(GetOutputStatusRequest.builder().outputName(outputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Toggles the status of an output.
    *
    * @param outputName Output name
@@ -1149,6 +2131,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void toggleOutput(String outputName, Consumer<ToggleOutputResponse> callback) {
     sendRequest(ToggleOutputRequest.builder().outputName(outputName).build(), callback);
+  }
+
+  /**
+   * Toggles the status of an output.
+   *
+   * @param outputName Output name
+   * @param timeout long timeout in ms
+   */
+  public ToggleOutputResponse toggleOutput(String outputName, long timeout) {
+    BlockingConsumer<ToggleOutputResponse> callback = new BlockingConsumer<ToggleOutputResponse>();
+    sendRequest(ToggleOutputRequest.builder().outputName(outputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1162,6 +2156,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Starts an output.
+   *
+   * @param outputName Output name
+   * @param timeout long timeout in ms
+   */
+  public StartOutputResponse startOutput(String outputName, long timeout) {
+    BlockingConsumer<StartOutputResponse> callback = new BlockingConsumer<StartOutputResponse>();
+    sendRequest(StartOutputRequest.builder().outputName(outputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Stops an output.
    *
    * @param outputName Output name
@@ -1172,6 +2178,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Stops an output.
+   *
+   * @param outputName Output name
+   * @param timeout long timeout in ms
+   */
+  public StopOutputResponse stopOutput(String outputName, long timeout) {
+    BlockingConsumer<StopOutputResponse> callback = new BlockingConsumer<StopOutputResponse>();
+    sendRequest(StopOutputRequest.builder().outputName(outputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the settings of an output.
    *
    * @param outputName Output name
@@ -1179,6 +2197,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getOutputSettings(String outputName, Consumer<GetOutputSettingsResponse> callback) {
     sendRequest(GetOutputSettingsRequest.builder().outputName(outputName).build(), callback);
+  }
+
+  /**
+   * Gets the settings of an output.
+   *
+   * @param outputName Output name
+   * @param timeout long timeout in ms
+   */
+  public GetOutputSettingsResponse getOutputSettings(String outputName, long timeout) {
+    BlockingConsumer<GetOutputSettingsResponse> callback = new BlockingConsumer<GetOutputSettingsResponse>();
+    sendRequest(GetOutputSettingsRequest.builder().outputName(outputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1194,12 +2224,37 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the settings of an output.
+   *
+   * @param outputName Output name
+   * @param outputSettings Output settings
+   * @param timeout long timeout in ms
+   */
+  public SetOutputSettingsResponse setOutputSettings(String outputName, JsonObject outputSettings,
+      long timeout) {
+    BlockingConsumer<SetOutputSettingsResponse> callback = new BlockingConsumer<SetOutputSettingsResponse>();
+    sendRequest(SetOutputSettingsRequest.builder().outputName(outputName).outputSettings(outputSettings).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the status of the record output.
    *
    * @param callback Consumer&lt;GetRecordStatusResponse&gt;
    */
   public void getRecordStatus(Consumer<GetRecordStatusResponse> callback) {
     sendRequest(GetRecordStatusRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the status of the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetRecordStatusResponse getRecordStatus(long timeout) {
+    BlockingConsumer<GetRecordStatusResponse> callback = new BlockingConsumer<GetRecordStatusResponse>();
+    sendRequest(GetRecordStatusRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1212,12 +2267,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Toggles the status of the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ToggleRecordResponse toggleRecord(long timeout) {
+    BlockingConsumer<ToggleRecordResponse> callback = new BlockingConsumer<ToggleRecordResponse>();
+    sendRequest(ToggleRecordRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Starts the record output.
    *
    * @param callback Consumer&lt;StartRecordResponse&gt;
    */
   public void startRecord(Consumer<StartRecordResponse> callback) {
     sendRequest(StartRecordRequest.builder().build(), callback);
+  }
+
+  /**
+   * Starts the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StartRecordResponse startRecord(long timeout) {
+    BlockingConsumer<StartRecordResponse> callback = new BlockingConsumer<StartRecordResponse>();
+    sendRequest(StartRecordRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1230,12 +2307,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Stops the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StopRecordResponse stopRecord(long timeout) {
+    BlockingConsumer<StopRecordResponse> callback = new BlockingConsumer<StopRecordResponse>();
+    sendRequest(StopRecordRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Toggles pause on the record output.
    *
    * @param callback Consumer&lt;ToggleRecordPauseResponse&gt;
    */
   public void toggleRecordPause(Consumer<ToggleRecordPauseResponse> callback) {
     sendRequest(ToggleRecordPauseRequest.builder().build(), callback);
+  }
+
+  /**
+   * Toggles pause on the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ToggleRecordPauseResponse toggleRecordPause(long timeout) {
+    BlockingConsumer<ToggleRecordPauseResponse> callback = new BlockingConsumer<ToggleRecordPauseResponse>();
+    sendRequest(ToggleRecordPauseRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1248,12 +2347,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Pauses the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public PauseRecordResponse pauseRecord(long timeout) {
+    BlockingConsumer<PauseRecordResponse> callback = new BlockingConsumer<PauseRecordResponse>();
+    sendRequest(PauseRecordRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Resumes the record output.
    *
    * @param callback Consumer&lt;ResumeRecordResponse&gt;
    */
   public void resumeRecord(Consumer<ResumeRecordResponse> callback) {
     sendRequest(ResumeRecordRequest.builder().build(), callback);
+  }
+
+  /**
+   * Resumes the record output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ResumeRecordResponse resumeRecord(long timeout) {
+    BlockingConsumer<ResumeRecordResponse> callback = new BlockingConsumer<ResumeRecordResponse>();
+    sendRequest(ResumeRecordRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1266,6 +2387,20 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getSceneItemList(String sceneName, Consumer<GetSceneItemListResponse> callback) {
     sendRequest(GetSceneItemListRequest.builder().sceneName(sceneName).build(), callback);
+  }
+
+  /**
+   * Gets a list of all scene items in a scene.
+   *
+   * Scenes only
+   *
+   * @param sceneName Name of the scene to get the items of
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemListResponse getSceneItemList(String sceneName, long timeout) {
+    BlockingConsumer<GetSceneItemListResponse> callback = new BlockingConsumer<GetSceneItemListResponse>();
+    sendRequest(GetSceneItemListRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1284,6 +2419,22 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Basically GetSceneItemList, but for groups.
+   *
+   * Using groups at all in OBS is discouraged, as they are very broken under the hood. Please use nested scenes instead.
+   *
+   * Groups only
+   *
+   * @param sceneName Name of the group to get the items of
+   * @param timeout long timeout in ms
+   */
+  public GetGroupSceneItemListResponse getGroupSceneItemList(String sceneName, long timeout) {
+    BlockingConsumer<GetGroupSceneItemListResponse> callback = new BlockingConsumer<GetGroupSceneItemListResponse>();
+    sendRequest(GetGroupSceneItemListRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Searches a scene for a source, and returns its id.
    *
    * Scenes and Groups
@@ -1296,6 +2447,23 @@ public abstract class OBSRemoteControllerBase {
   public void getSceneItemId(String sceneName, String sourceName, Number searchOffset,
       Consumer<GetSceneItemIdResponse> callback) {
     sendRequest(GetSceneItemIdRequest.builder().sceneName(sceneName).sourceName(sourceName).searchOffset(searchOffset).build(), callback);
+  }
+
+  /**
+   * Searches a scene for a source, and returns its id.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene or group to search in
+   * @param sourceName Name of the source to find
+   * @param searchOffset Number of matches to skip during search. &gt;= 0 means first forward. -1 means last (top) item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemIdResponse getSceneItemId(String sceneName, String sourceName,
+      Number searchOffset, long timeout) {
+    BlockingConsumer<GetSceneItemIdResponse> callback = new BlockingConsumer<GetSceneItemIdResponse>();
+    sendRequest(GetSceneItemIdRequest.builder().sceneName(sceneName).sourceName(sourceName).searchOffset(searchOffset).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1314,6 +2482,23 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Creates a new scene item using a source.
+   *
+   * Scenes only
+   *
+   * @param sceneName Name of the scene to create the new item in
+   * @param sourceName Name of the source to add to the scene
+   * @param sceneItemEnabled Enable state to apply to the scene item on creation
+   * @param timeout long timeout in ms
+   */
+  public CreateSceneItemResponse createSceneItem(String sceneName, String sourceName,
+      Boolean sceneItemEnabled, long timeout) {
+    BlockingConsumer<CreateSceneItemResponse> callback = new BlockingConsumer<CreateSceneItemResponse>();
+    sendRequest(CreateSceneItemRequest.builder().sceneName(sceneName).sourceName(sourceName).sceneItemEnabled(sceneItemEnabled).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Removes a scene item from a scene.
    *
    * Scenes only
@@ -1325,6 +2510,22 @@ public abstract class OBSRemoteControllerBase {
   public void removeSceneItem(String sceneName, Number sceneItemId,
       Consumer<RemoveSceneItemResponse> callback) {
     sendRequest(RemoveSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+  }
+
+  /**
+   * Removes a scene item from a scene.
+   *
+   * Scenes only
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public RemoveSceneItemResponse removeSceneItem(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<RemoveSceneItemResponse> callback = new BlockingConsumer<RemoveSceneItemResponse>();
+    sendRequest(RemoveSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1343,6 +2544,23 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Duplicates a scene item, copying all transform and crop info.
+   *
+   * Scenes only
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param destinationSceneName Name of the scene to create the duplicated item in
+   * @param timeout long timeout in ms
+   */
+  public DuplicateSceneItemResponse duplicateSceneItem(String sceneName, Number sceneItemId,
+      String destinationSceneName, long timeout) {
+    BlockingConsumer<DuplicateSceneItemResponse> callback = new BlockingConsumer<DuplicateSceneItemResponse>();
+    sendRequest(DuplicateSceneItemRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).destinationSceneName(destinationSceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the transform and crop info of a scene item.
    *
    * Scenes and Groups
@@ -1354,6 +2572,22 @@ public abstract class OBSRemoteControllerBase {
   public void getSceneItemTransform(String sceneName, Number sceneItemId,
       Consumer<GetSceneItemTransformResponse> callback) {
     sendRequest(GetSceneItemTransformRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+  }
+
+  /**
+   * Gets the transform and crop info of a scene item.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemTransformResponse getSceneItemTransform(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<GetSceneItemTransformResponse> callback = new BlockingConsumer<GetSceneItemTransformResponse>();
+    sendRequest(GetSceneItemTransformRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1370,6 +2604,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the transform and crop info of a scene item.
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param sceneItemTransform Object containing scene item transform info to update
+   * @param timeout long timeout in ms
+   */
+  public SetSceneItemTransformResponse setSceneItemTransform(String sceneName, Number sceneItemId,
+      SceneItem.Transform sceneItemTransform, long timeout) {
+    BlockingConsumer<SetSceneItemTransformResponse> callback = new BlockingConsumer<SetSceneItemTransformResponse>();
+    sendRequest(SetSceneItemTransformRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemTransform(sceneItemTransform).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the enable state of a scene item.
    *
    * Scenes and Groups
@@ -1381,6 +2630,22 @@ public abstract class OBSRemoteControllerBase {
   public void getSceneItemEnabled(String sceneName, Number sceneItemId,
       Consumer<GetSceneItemEnabledResponse> callback) {
     sendRequest(GetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+  }
+
+  /**
+   * Gets the enable state of a scene item.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemEnabledResponse getSceneItemEnabled(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<GetSceneItemEnabledResponse> callback = new BlockingConsumer<GetSceneItemEnabledResponse>();
+    sendRequest(GetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1399,6 +2664,23 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the enable state of a scene item.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param sceneItemEnabled New enable state of the scene item
+   * @param timeout long timeout in ms
+   */
+  public SetSceneItemEnabledResponse setSceneItemEnabled(String sceneName, Number sceneItemId,
+      Boolean sceneItemEnabled, long timeout) {
+    BlockingConsumer<SetSceneItemEnabledResponse> callback = new BlockingConsumer<SetSceneItemEnabledResponse>();
+    sendRequest(SetSceneItemEnabledRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemEnabled(sceneItemEnabled).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the lock state of a scene item.
    *
    * Scenes and Groups
@@ -1410,6 +2692,22 @@ public abstract class OBSRemoteControllerBase {
   public void getSceneItemLocked(String sceneName, Number sceneItemId,
       Consumer<GetSceneItemLockedResponse> callback) {
     sendRequest(GetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+  }
+
+  /**
+   * Gets the lock state of a scene item.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemLockedResponse getSceneItemLocked(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<GetSceneItemLockedResponse> callback = new BlockingConsumer<GetSceneItemLockedResponse>();
+    sendRequest(GetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1425,6 +2723,23 @@ public abstract class OBSRemoteControllerBase {
   public void setSceneItemLocked(String sceneName, Number sceneItemId, Boolean sceneItemLocked,
       Consumer<SetSceneItemLockedResponse> callback) {
     sendRequest(SetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemLocked(sceneItemLocked).build(), callback);
+  }
+
+  /**
+   * Sets the lock state of a scene item.
+   *
+   * Scenes and Group
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param sceneItemLocked New lock state of the scene item
+   * @param timeout long timeout in ms
+   */
+  public SetSceneItemLockedResponse setSceneItemLocked(String sceneName, Number sceneItemId,
+      Boolean sceneItemLocked, long timeout) {
+    BlockingConsumer<SetSceneItemLockedResponse> callback = new BlockingConsumer<SetSceneItemLockedResponse>();
+    sendRequest(SetSceneItemLockedRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemLocked(sceneItemLocked).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1444,6 +2759,24 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the index position of a scene item in a scene.
+   *
+   * An index of 0 is at the bottom of the source list in the UI.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemIndexResponse getSceneItemIndex(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<GetSceneItemIndexResponse> callback = new BlockingConsumer<GetSceneItemIndexResponse>();
+    sendRequest(GetSceneItemIndexRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the index position of a scene item in a scene.
    *
    * Scenes and Groups
@@ -1456,6 +2789,23 @@ public abstract class OBSRemoteControllerBase {
   public void setSceneItemIndex(String sceneName, Number sceneItemId, Number sceneItemIndex,
       Consumer<SetSceneItemIndexResponse> callback) {
     sendRequest(SetSceneItemIndexRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemIndex(sceneItemIndex).build(), callback);
+  }
+
+  /**
+   * Sets the index position of a scene item in a scene.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param sceneItemIndex New index position of the scene item
+   * @param timeout long timeout in ms
+   */
+  public SetSceneItemIndexResponse setSceneItemIndex(String sceneName, Number sceneItemId,
+      Number sceneItemIndex, long timeout) {
+    BlockingConsumer<SetSceneItemIndexResponse> callback = new BlockingConsumer<SetSceneItemIndexResponse>();
+    sendRequest(SetSceneItemIndexRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemIndex(sceneItemIndex).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1483,6 +2833,32 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the blend mode of a scene item.
+   *
+   * Blend modes:
+   *
+   * - `OBS_BLEND_NORMAL`
+   * - `OBS_BLEND_ADDITIVE`
+   * - `OBS_BLEND_SUBTRACT`
+   * - `OBS_BLEND_SCREEN`
+   * - `OBS_BLEND_MULTIPLY`
+   * - `OBS_BLEND_LIGHTEN`
+   * - `OBS_BLEND_DARKEN`
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param timeout long timeout in ms
+   */
+  public GetSceneItemBlendModeResponse getSceneItemBlendMode(String sceneName, Number sceneItemId,
+      long timeout) {
+    BlockingConsumer<GetSceneItemBlendModeResponse> callback = new BlockingConsumer<GetSceneItemBlendModeResponse>();
+    sendRequest(GetSceneItemBlendModeRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the blend mode of a scene item.
    *
    * Scenes and Groups
@@ -1498,12 +2874,40 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the blend mode of a scene item.
+   *
+   * Scenes and Groups
+   *
+   * @param sceneName Name of the scene the item is in
+   * @param sceneItemId Numeric ID of the scene item
+   * @param sceneItemBlendMode New blend mode
+   * @param timeout long timeout in ms
+   */
+  public SetSceneItemBlendModeResponse setSceneItemBlendMode(String sceneName, Number sceneItemId,
+      SceneItem.BlendMode sceneItemBlendMode, long timeout) {
+    BlockingConsumer<SetSceneItemBlendModeResponse> callback = new BlockingConsumer<SetSceneItemBlendModeResponse>();
+    sendRequest(SetSceneItemBlendModeRequest.builder().sceneName(sceneName).sceneItemId(sceneItemId).sceneItemBlendMode(sceneItemBlendMode).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all scenes in OBS.
    *
    * @param callback Consumer&lt;GetSceneListResponse&gt;
    */
   public void getSceneList(Consumer<GetSceneListResponse> callback) {
     sendRequest(GetSceneListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets an array of all scenes in OBS.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetSceneListResponse getSceneList(long timeout) {
+    BlockingConsumer<GetSceneListResponse> callback = new BlockingConsumer<GetSceneListResponse>();
+    sendRequest(GetSceneListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1518,12 +2922,36 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all groups in OBS.
+   *
+   * Groups in OBS are actually scenes, but renamed and modified. In obs-websocket, we treat them as scenes where we can.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetGroupListResponse getGroupList(long timeout) {
+    BlockingConsumer<GetGroupListResponse> callback = new BlockingConsumer<GetGroupListResponse>();
+    sendRequest(GetGroupListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current program scene.
    *
    * @param callback Consumer&lt;GetCurrentProgramSceneResponse&gt;
    */
   public void getCurrentProgramScene(Consumer<GetCurrentProgramSceneResponse> callback) {
     sendRequest(GetCurrentProgramSceneRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the current program scene.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetCurrentProgramSceneResponse getCurrentProgramScene(long timeout) {
+    BlockingConsumer<GetCurrentProgramSceneResponse> callback = new BlockingConsumer<GetCurrentProgramSceneResponse>();
+    sendRequest(GetCurrentProgramSceneRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1538,6 +2966,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the current program scene.
+   *
+   * @param sceneName Scene to set as the current program scene
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentProgramSceneResponse setCurrentProgramScene(String sceneName, long timeout) {
+    BlockingConsumer<SetCurrentProgramSceneResponse> callback = new BlockingConsumer<SetCurrentProgramSceneResponse>();
+    sendRequest(SetCurrentProgramSceneRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the current preview scene.
    *
    * Only available when studio mode is enabled.
@@ -1546,6 +2986,19 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getCurrentPreviewScene(Consumer<GetCurrentPreviewSceneResponse> callback) {
     sendRequest(GetCurrentPreviewSceneRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the current preview scene.
+   *
+   * Only available when studio mode is enabled.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetCurrentPreviewSceneResponse getCurrentPreviewScene(long timeout) {
+    BlockingConsumer<GetCurrentPreviewSceneResponse> callback = new BlockingConsumer<GetCurrentPreviewSceneResponse>();
+    sendRequest(GetCurrentPreviewSceneRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1562,6 +3015,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the current preview scene.
+   *
+   * Only available when studio mode is enabled.
+   *
+   * @param sceneName Scene to set as the current preview scene
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentPreviewSceneResponse setCurrentPreviewScene(String sceneName, long timeout) {
+    BlockingConsumer<SetCurrentPreviewSceneResponse> callback = new BlockingConsumer<SetCurrentPreviewSceneResponse>();
+    sendRequest(SetCurrentPreviewSceneRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Creates a new scene in OBS.
    *
    * @param sceneName Name for the new scene
@@ -1569,6 +3036,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void createScene(String sceneName, Consumer<CreateSceneResponse> callback) {
     sendRequest(CreateSceneRequest.builder().sceneName(sceneName).build(), callback);
+  }
+
+  /**
+   * Creates a new scene in OBS.
+   *
+   * @param sceneName Name for the new scene
+   * @param timeout long timeout in ms
+   */
+  public CreateSceneResponse createScene(String sceneName, long timeout) {
+    BlockingConsumer<CreateSceneResponse> callback = new BlockingConsumer<CreateSceneResponse>();
+    sendRequest(CreateSceneRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1582,6 +3061,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Removes a scene from OBS.
+   *
+   * @param sceneName Name of the scene to remove
+   * @param timeout long timeout in ms
+   */
+  public RemoveSceneResponse removeScene(String sceneName, long timeout) {
+    BlockingConsumer<RemoveSceneResponse> callback = new BlockingConsumer<RemoveSceneResponse>();
+    sendRequest(RemoveSceneRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the name of a scene (rename).
    *
    * @param sceneName Name of the scene to be renamed
@@ -1591,6 +3082,19 @@ public abstract class OBSRemoteControllerBase {
   public void setSceneName(String sceneName, String newSceneName,
       Consumer<SetSceneNameResponse> callback) {
     sendRequest(SetSceneNameRequest.builder().sceneName(sceneName).newSceneName(newSceneName).build(), callback);
+  }
+
+  /**
+   * Sets the name of a scene (rename).
+   *
+   * @param sceneName Name of the scene to be renamed
+   * @param newSceneName New name for the scene
+   * @param timeout long timeout in ms
+   */
+  public SetSceneNameResponse setSceneName(String sceneName, String newSceneName, long timeout) {
+    BlockingConsumer<SetSceneNameResponse> callback = new BlockingConsumer<SetSceneNameResponse>();
+    sendRequest(SetSceneNameRequest.builder().sceneName(sceneName).newSceneName(newSceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1608,6 +3112,19 @@ public abstract class OBSRemoteControllerBase {
    * Gets the scene transition overridden for a scene.
    *
    * @param sceneName Name of the scene
+   * @param timeout long timeout in ms
+   */
+  public GetSceneSceneTransitionOverrideResponse getSceneSceneTransitionOverride(String sceneName,
+      long timeout) {
+    BlockingConsumer<GetSceneSceneTransitionOverrideResponse> callback = new BlockingConsumer<GetSceneSceneTransitionOverrideResponse>();
+    sendRequest(GetSceneSceneTransitionOverrideRequest.builder().sceneName(sceneName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
+   * Gets the scene transition overridden for a scene.
+   *
+   * @param sceneName Name of the scene
    * @param transitionName Name of the scene transition to use as override. Specify `null` to remove
    * @param transitionDuration Duration to use for any overridden transition. Specify `null` to remove
    * @param callback Consumer&lt;SetSceneSceneTransitionOverrideResponse&gt;
@@ -1615,6 +3132,21 @@ public abstract class OBSRemoteControllerBase {
   public void setSceneSceneTransitionOverride(String sceneName, String transitionName,
       Number transitionDuration, Consumer<SetSceneSceneTransitionOverrideResponse> callback) {
     sendRequest(SetSceneSceneTransitionOverrideRequest.builder().sceneName(sceneName).transitionName(transitionName).transitionDuration(transitionDuration).build(), callback);
+  }
+
+  /**
+   * Gets the scene transition overridden for a scene.
+   *
+   * @param sceneName Name of the scene
+   * @param transitionName Name of the scene transition to use as override. Specify `null` to remove
+   * @param transitionDuration Duration to use for any overridden transition. Specify `null` to remove
+   * @param timeout long timeout in ms
+   */
+  public SetSceneSceneTransitionOverrideResponse setSceneSceneTransitionOverride(String sceneName,
+      String transitionName, Number transitionDuration, long timeout) {
+    BlockingConsumer<SetSceneSceneTransitionOverrideResponse> callback = new BlockingConsumer<SetSceneSceneTransitionOverrideResponse>();
+    sendRequest(SetSceneSceneTransitionOverrideRequest.builder().sceneName(sceneName).transitionName(transitionName).transitionDuration(transitionDuration).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1627,6 +3159,20 @@ public abstract class OBSRemoteControllerBase {
    */
   public void getSourceActive(String sourceName, Consumer<GetSourceActiveResponse> callback) {
     sendRequest(GetSourceActiveRequest.builder().sourceName(sourceName).build(), callback);
+  }
+
+  /**
+   * Gets the active and show state of a source.
+   *
+   * **Compatible with inputs and scenes.**
+   *
+   * @param sourceName Name of the source to get the active state of
+   * @param timeout long timeout in ms
+   */
+  public GetSourceActiveResponse getSourceActive(String sourceName, long timeout) {
+    BlockingConsumer<GetSourceActiveResponse> callback = new BlockingConsumer<GetSourceActiveResponse>();
+    sendRequest(GetSourceActiveRequest.builder().sourceName(sourceName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1648,6 +3194,28 @@ public abstract class OBSRemoteControllerBase {
       Number imageHeight, Number imageCompressionQuality,
       Consumer<GetSourceScreenshotResponse> callback) {
     sendRequest(GetSourceScreenshotRequest.builder().sourceName(sourceName).imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight).imageCompressionQuality(imageCompressionQuality).build(), callback);
+  }
+
+  /**
+   * Gets a Base64-encoded screenshot of a source.
+   *
+   * The `imageWidth` and `imageHeight` parameters are treated as "scale to inner", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+   * If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+   *
+   * **Compatible with inputs and scenes.**
+   *
+   * @param sourceName Name of the source to take a screenshot of
+   * @param imageFormat Image compression format to use. Use `GetVersion` to get compatible image formats
+   * @param imageWidth Width to scale the screenshot to
+   * @param imageHeight Height to scale the screenshot to
+   * @param imageCompressionQuality Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk)
+   * @param timeout long timeout in ms
+   */
+  public GetSourceScreenshotResponse getSourceScreenshot(String sourceName, String imageFormat,
+      Number imageWidth, Number imageHeight, Number imageCompressionQuality, long timeout) {
+    BlockingConsumer<GetSourceScreenshotResponse> callback = new BlockingConsumer<GetSourceScreenshotResponse>();
+    sendRequest(GetSourceScreenshotRequest.builder().sourceName(sourceName).imageFormat(imageFormat).imageWidth(imageWidth).imageHeight(imageHeight).imageCompressionQuality(imageCompressionQuality).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1673,12 +3241,47 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Saves a screenshot of a source to the filesystem.
+   *
+   * The `imageWidth` and `imageHeight` parameters are treated as "scale to inner", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+   * If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+   *
+   * **Compatible with inputs and scenes.**
+   *
+   * @param sourceName Name of the source to take a screenshot of
+   * @param imageFormat Image compression format to use. Use `GetVersion` to get compatible image formats
+   * @param imageFilePath Path to save the screenshot file to. Eg. `C:\Users\\user\Desktop\screenshot.png`
+   * @param imageWidth Width to scale the screenshot to
+   * @param imageHeight Height to scale the screenshot to
+   * @param imageCompressionQuality Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk)
+   * @param timeout long timeout in ms
+   */
+  public SaveSourceScreenshotResponse saveSourceScreenshot(String sourceName, String imageFormat,
+      String imageFilePath, Number imageWidth, Number imageHeight, Number imageCompressionQuality,
+      long timeout) {
+    BlockingConsumer<SaveSourceScreenshotResponse> callback = new BlockingConsumer<SaveSourceScreenshotResponse>();
+    sendRequest(SaveSourceScreenshotRequest.builder().sourceName(sourceName).imageFormat(imageFormat).imageFilePath(imageFilePath).imageWidth(imageWidth).imageHeight(imageHeight).imageCompressionQuality(imageCompressionQuality).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the status of the stream output.
    *
    * @param callback Consumer&lt;GetStreamStatusResponse&gt;
    */
   public void getStreamStatus(Consumer<GetStreamStatusResponse> callback) {
     sendRequest(GetStreamStatusRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets the status of the stream output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetStreamStatusResponse getStreamStatus(long timeout) {
+    BlockingConsumer<GetStreamStatusResponse> callback = new BlockingConsumer<GetStreamStatusResponse>();
+    sendRequest(GetStreamStatusRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1691,12 +3294,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Toggles the status of the stream output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public ToggleStreamResponse toggleStream(long timeout) {
+    BlockingConsumer<ToggleStreamResponse> callback = new BlockingConsumer<ToggleStreamResponse>();
+    sendRequest(ToggleStreamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Starts the stream output.
    *
    * @param callback Consumer&lt;StartStreamResponse&gt;
    */
   public void startStream(Consumer<StartStreamResponse> callback) {
     sendRequest(StartStreamRequest.builder().build(), callback);
+  }
+
+  /**
+   * Starts the stream output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StartStreamResponse startStream(long timeout) {
+    BlockingConsumer<StartStreamResponse> callback = new BlockingConsumer<StartStreamResponse>();
+    sendRequest(StartStreamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1709,6 +3334,17 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Stops the stream output.
+   *
+   * @param timeout long timeout in ms
+   */
+  public StopStreamResponse stopStream(long timeout) {
+    BlockingConsumer<StopStreamResponse> callback = new BlockingConsumer<StopStreamResponse>();
+    sendRequest(StopStreamRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sends CEA-608 caption text over the stream output.
    *
    * @param captionText Caption text
@@ -1716,6 +3352,18 @@ public abstract class OBSRemoteControllerBase {
    */
   public void sendStreamCaption(String captionText, Consumer<SendStreamCaptionResponse> callback) {
     sendRequest(SendStreamCaptionRequest.builder().captionText(captionText).build(), callback);
+  }
+
+  /**
+   * Sends CEA-608 caption text over the stream output.
+   *
+   * @param captionText Caption text
+   * @param timeout long timeout in ms
+   */
+  public SendStreamCaptionResponse sendStreamCaption(String captionText, long timeout) {
+    BlockingConsumer<SendStreamCaptionResponse> callback = new BlockingConsumer<SendStreamCaptionResponse>();
+    sendRequest(SendStreamCaptionRequest.builder().captionText(captionText).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1730,6 +3378,19 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all available transition kinds.
+   *
+   * Similar to `GetInputKindList`
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetTransitionKindListResponse getTransitionKindList(long timeout) {
+    BlockingConsumer<GetTransitionKindListResponse> callback = new BlockingConsumer<GetTransitionKindListResponse>();
+    sendRequest(GetTransitionKindListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets an array of all scene transitions in OBS.
    *
    * @param callback Consumer&lt;GetSceneTransitionListResponse&gt;
@@ -1739,12 +3400,34 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets an array of all scene transitions in OBS.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetSceneTransitionListResponse getSceneTransitionList(long timeout) {
+    BlockingConsumer<GetSceneTransitionListResponse> callback = new BlockingConsumer<GetSceneTransitionListResponse>();
+    sendRequest(GetSceneTransitionListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets information about the current scene transition.
    *
    * @param callback Consumer&lt;GetCurrentSceneTransitionResponse&gt;
    */
   public void getCurrentSceneTransition(Consumer<GetCurrentSceneTransitionResponse> callback) {
     sendRequest(GetCurrentSceneTransitionRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets information about the current scene transition.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetCurrentSceneTransitionResponse getCurrentSceneTransition(long timeout) {
+    BlockingConsumer<GetCurrentSceneTransitionResponse> callback = new BlockingConsumer<GetCurrentSceneTransitionResponse>();
+    sendRequest(GetCurrentSceneTransitionRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1761,6 +3444,21 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the current scene transition.
+   *
+   * Small note: While the namespace of scene transitions is generally unique, that uniqueness is not a guarantee as it is with other resources like inputs.
+   *
+   * @param transitionName Name of the transition to make active
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentSceneTransitionResponse setCurrentSceneTransition(String transitionName,
+      long timeout) {
+    BlockingConsumer<SetCurrentSceneTransitionResponse> callback = new BlockingConsumer<SetCurrentSceneTransitionResponse>();
+    sendRequest(SetCurrentSceneTransitionRequest.builder().transitionName(transitionName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Sets the duration of the current scene transition, if it is not fixed.
    *
    * @param transitionDuration Duration in milliseconds
@@ -1769,6 +3467,19 @@ public abstract class OBSRemoteControllerBase {
   public void setCurrentSceneTransitionDuration(Number transitionDuration,
       Consumer<SetCurrentSceneTransitionDurationResponse> callback) {
     sendRequest(SetCurrentSceneTransitionDurationRequest.builder().transitionDuration(transitionDuration).build(), callback);
+  }
+
+  /**
+   * Sets the duration of the current scene transition, if it is not fixed.
+   *
+   * @param transitionDuration Duration in milliseconds
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentSceneTransitionDurationResponse setCurrentSceneTransitionDuration(
+      Number transitionDuration, long timeout) {
+    BlockingConsumer<SetCurrentSceneTransitionDurationResponse> callback = new BlockingConsumer<SetCurrentSceneTransitionDurationResponse>();
+    sendRequest(SetCurrentSceneTransitionDurationRequest.builder().transitionDuration(transitionDuration).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1784,6 +3495,20 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the settings of the current scene transition.
+   *
+   * @param transitionSettings Settings object to apply to the transition. Can be `{}`
+   * @param overlay Whether to overlay over the current settings or replace them
+   * @param timeout long timeout in ms
+   */
+  public SetCurrentSceneTransitionSettingsResponse setCurrentSceneTransitionSettings(
+      JsonObject transitionSettings, Boolean overlay, long timeout) {
+    BlockingConsumer<SetCurrentSceneTransitionSettingsResponse> callback = new BlockingConsumer<SetCurrentSceneTransitionSettingsResponse>();
+    sendRequest(SetCurrentSceneTransitionSettingsRequest.builder().transitionSettings(transitionSettings).overlay(overlay).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets the cursor position of the current scene transition.
    *
    * Note: `transitionCursor` will return 1.0 when the transition is inactive.
@@ -1796,12 +3521,36 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Gets the cursor position of the current scene transition.
+   *
+   * Note: `transitionCursor` will return 1.0 when the transition is inactive.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetCurrentSceneTransitionCursorResponse getCurrentSceneTransitionCursor(long timeout) {
+    BlockingConsumer<GetCurrentSceneTransitionCursorResponse> callback = new BlockingConsumer<GetCurrentSceneTransitionCursorResponse>();
+    sendRequest(GetCurrentSceneTransitionCursorRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Triggers the current scene transition. Same functionality as the `Transition` button in studio mode.
    *
    * @param callback Consumer&lt;TriggerStudioModeTransitionResponse&gt;
    */
   public void triggerStudioModeTransition(Consumer<TriggerStudioModeTransitionResponse> callback) {
     sendRequest(TriggerStudioModeTransitionRequest.builder().build(), callback);
+  }
+
+  /**
+   * Triggers the current scene transition. Same functionality as the `Transition` button in studio mode.
+   *
+   * @param timeout long timeout in ms
+   */
+  public TriggerStudioModeTransitionResponse triggerStudioModeTransition(long timeout) {
+    BlockingConsumer<TriggerStudioModeTransitionResponse> callback = new BlockingConsumer<TriggerStudioModeTransitionResponse>();
+    sendRequest(TriggerStudioModeTransitionRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1819,12 +3568,38 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Sets the position of the TBar.
+   *
+   * **Very important note**: This will be deprecated and replaced in a future version of obs-websocket.
+   *
+   * @param position New position
+   * @param release Whether to release the TBar. Only set `false` if you know that you will be sending another position update
+   * @param timeout long timeout in ms
+   */
+  public SetTBarPositionResponse setTBarPosition(Number position, Boolean release, long timeout) {
+    BlockingConsumer<SetTBarPositionResponse> callback = new BlockingConsumer<SetTBarPositionResponse>();
+    sendRequest(SetTBarPositionRequest.builder().position(position).release(release).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets whether studio is enabled.
    *
    * @param callback Consumer&lt;GetStudioModeEnabledResponse&gt;
    */
   public void getStudioModeEnabled(Consumer<GetStudioModeEnabledResponse> callback) {
     sendRequest(GetStudioModeEnabledRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets whether studio is enabled.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetStudioModeEnabledResponse getStudioModeEnabled(long timeout) {
+    BlockingConsumer<GetStudioModeEnabledResponse> callback = new BlockingConsumer<GetStudioModeEnabledResponse>();
+    sendRequest(GetStudioModeEnabledRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1839,6 +3614,19 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Enables or disables studio mode
+   *
+   * @param studioModeEnabled True == Enabled, False == Disabled
+   * @param timeout long timeout in ms
+   */
+  public SetStudioModeEnabledResponse setStudioModeEnabled(Boolean studioModeEnabled,
+      long timeout) {
+    BlockingConsumer<SetStudioModeEnabledResponse> callback = new BlockingConsumer<SetStudioModeEnabledResponse>();
+    sendRequest(SetStudioModeEnabledRequest.builder().studioModeEnabled(studioModeEnabled).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Opens the properties dialog of an input.
    *
    * @param inputName Name of the input to open the dialog of
@@ -1847,6 +3635,19 @@ public abstract class OBSRemoteControllerBase {
   public void openInputPropertiesDialog(String inputName,
       Consumer<OpenInputPropertiesDialogResponse> callback) {
     sendRequest(OpenInputPropertiesDialogRequest.builder().inputName(inputName).build(), callback);
+  }
+
+  /**
+   * Opens the properties dialog of an input.
+   *
+   * @param inputName Name of the input to open the dialog of
+   * @param timeout long timeout in ms
+   */
+  public OpenInputPropertiesDialogResponse openInputPropertiesDialog(String inputName,
+      long timeout) {
+    BlockingConsumer<OpenInputPropertiesDialogResponse> callback = new BlockingConsumer<OpenInputPropertiesDialogResponse>();
+    sendRequest(OpenInputPropertiesDialogRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1861,6 +3662,18 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Opens the filters dialog of an input.
+   *
+   * @param inputName Name of the input to open the dialog of
+   * @param timeout long timeout in ms
+   */
+  public OpenInputFiltersDialogResponse openInputFiltersDialog(String inputName, long timeout) {
+    BlockingConsumer<OpenInputFiltersDialogResponse> callback = new BlockingConsumer<OpenInputFiltersDialogResponse>();
+    sendRequest(OpenInputFiltersDialogRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Opens the interact dialog of an input.
    *
    * @param inputName Name of the input to open the dialog of
@@ -1872,12 +3685,35 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Opens the interact dialog of an input.
+   *
+   * @param inputName Name of the input to open the dialog of
+   * @param timeout long timeout in ms
+   */
+  public OpenInputInteractDialogResponse openInputInteractDialog(String inputName, long timeout) {
+    BlockingConsumer<OpenInputInteractDialogResponse> callback = new BlockingConsumer<OpenInputInteractDialogResponse>();
+    sendRequest(OpenInputInteractDialogRequest.builder().inputName(inputName).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Gets a list of connected monitors and information about them.
    *
    * @param callback Consumer&lt;GetMonitorListResponse&gt;
    */
   public void getMonitorList(Consumer<GetMonitorListResponse> callback) {
     sendRequest(GetMonitorListRequest.builder().build(), callback);
+  }
+
+  /**
+   * Gets a list of connected monitors and information about them.
+   *
+   * @param timeout long timeout in ms
+   */
+  public GetMonitorListResponse getMonitorList(long timeout) {
+    BlockingConsumer<GetMonitorListResponse> callback = new BlockingConsumer<GetMonitorListResponse>();
+    sendRequest(GetMonitorListRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 
   /**
@@ -1902,6 +3738,29 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Opens a projector for a specific output video mix.
+   *
+   * Mix types:
+   *
+   * - `OBS_WEBSOCKET_VIDEO_MIX_TYPE_PREVIEW`
+   * - `OBS_WEBSOCKET_VIDEO_MIX_TYPE_PROGRAM`
+   * - `OBS_WEBSOCKET_VIDEO_MIX_TYPE_MULTIVIEW`
+   *
+   * Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
+   *
+   * @param videoMixType Type of mix to open
+   * @param monitorIndex Monitor index, use `GetMonitorList` to obtain index
+   * @param projectorGeometry Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
+   * @param timeout long timeout in ms
+   */
+  public OpenVideoMixProjectorResponse openVideoMixProjector(VideoMixType videoMixType,
+      Number monitorIndex, String projectorGeometry, long timeout) {
+    BlockingConsumer<OpenVideoMixProjectorResponse> callback = new BlockingConsumer<OpenVideoMixProjectorResponse>();
+    sendRequest(OpenVideoMixProjectorRequest.builder().videoMixType(videoMixType).monitorIndex(monitorIndex).projectorGeometry(projectorGeometry).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Opens a projector for a source.
    *
    * Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
@@ -1914,5 +3773,22 @@ public abstract class OBSRemoteControllerBase {
   public void openSourceProjector(String sourceName, Number monitorIndex, String projectorGeometry,
       Consumer<OpenSourceProjectorResponse> callback) {
     sendRequest(OpenSourceProjectorRequest.builder().sourceName(sourceName).monitorIndex(monitorIndex).projectorGeometry(projectorGeometry).build(), callback);
+  }
+
+  /**
+   * Opens a projector for a source.
+   *
+   * Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
+   *
+   * @param sourceName Name of the source to open a projector for
+   * @param monitorIndex Monitor index, use `GetMonitorList` to obtain index
+   * @param projectorGeometry Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex`
+   * @param timeout long timeout in ms
+   */
+  public OpenSourceProjectorResponse openSourceProjector(String sourceName, Number monitorIndex,
+      String projectorGeometry, long timeout) {
+    BlockingConsumer<OpenSourceProjectorResponse> callback = new BlockingConsumer<OpenSourceProjectorResponse>();
+    sendRequest(OpenSourceProjectorRequest.builder().sourceName(sourceName).monitorIndex(monitorIndex).projectorGeometry(projectorGeometry).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.config;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class CurrentProfileChangedEvent extends Event<CurrentProfileChangedEvent
     super(Intent.Config, data);
   }
 
+  /**
+   * Name of the new profile
+   *
+   * @return the profileName
+   */
+  public String getProfileName() {
+    return getMessageData().getEventData().getProfileName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class CurrentProfileChangedEvent extends Event<CurrentProfileChangedEvent
     /**
      * Name of the new profile
      */
-    @NonNull
     private String profileName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangingEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentProfileChangingEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.config;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class CurrentProfileChangingEvent extends Event<CurrentProfileChangingEve
     super(Intent.Config, data);
   }
 
+  /**
+   * Name of the current profile
+   *
+   * @return the profileName
+   */
+  public String getProfileName() {
+    return getMessageData().getEventData().getProfileName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class CurrentProfileChangingEvent extends Event<CurrentProfileChangingEve
     /**
      * Name of the current profile
      */
-    @NonNull
     private String profileName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.config;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -27,6 +26,15 @@ public class CurrentSceneCollectionChangedEvent extends Event<CurrentSceneCollec
     super(Intent.Config, data);
   }
 
+  /**
+   * Name of the new scene collection
+   *
+   * @return the sceneCollectionName
+   */
+  public String getSceneCollectionName() {
+    return getMessageData().getEventData().getSceneCollectionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -34,7 +42,6 @@ public class CurrentSceneCollectionChangedEvent extends Event<CurrentSceneCollec
     /**
      * Name of the new scene collection
      */
-    @NonNull
     private String sceneCollectionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangingEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/CurrentSceneCollectionChangingEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.config;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -28,6 +27,15 @@ public class CurrentSceneCollectionChangingEvent extends Event<CurrentSceneColle
     super(Intent.Config, data);
   }
 
+  /**
+   * Name of the current scene collection
+   *
+   * @return the sceneCollectionName
+   */
+  public String getSceneCollectionName() {
+    return getMessageData().getEventData().getSceneCollectionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -35,7 +43,6 @@ public class CurrentSceneCollectionChangingEvent extends Event<CurrentSceneColle
     /**
      * Name of the current scene collection
      */
-    @NonNull
     private String sceneCollectionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/ProfileListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/ProfileListChangedEvent.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.event.Event;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -26,6 +25,15 @@ public class ProfileListChangedEvent extends Event<ProfileListChangedEvent.Speci
     super(Intent.Config, data);
   }
 
+  /**
+   * Updated list of profiles
+   *
+   * @return the profiles
+   */
+  public List<String> getProfiles() {
+    return getMessageData().getEventData().getProfiles();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,7 +41,6 @@ public class ProfileListChangedEvent extends Event<ProfileListChangedEvent.Speci
     /**
      * Updated list of profiles
      */
-    @NonNull
     @Singular
     private List<String> profiles;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/config/SceneCollectionListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/config/SceneCollectionListChangedEvent.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.event.Event;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -26,6 +25,15 @@ public class SceneCollectionListChangedEvent extends Event<SceneCollectionListCh
     super(Intent.Config, data);
   }
 
+  /**
+   * Updated list of scene collections
+   *
+   * @return the sceneCollections
+   */
+  public List<String> getSceneCollections() {
+    return getMessageData().getEventData().getSceneCollections();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,7 +41,6 @@ public class SceneCollectionListChangedEvent extends Event<SceneCollectionListCh
     /**
      * Updated list of scene collections
      */
-    @NonNull
     @Singular
     private List<String> sceneCollections;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterCreatedEvent.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,60 @@ public class SourceFilterCreatedEvent extends Event<SourceFilterCreatedEvent.Spe
     super(Intent.Filters, data);
   }
 
+  /**
+   * Name of the source the filter was added to
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Name of the filter
+   *
+   * @return the filterName
+   */
+  public String getFilterName() {
+    return getMessageData().getEventData().getFilterName();
+  }
+
+  /**
+   * The kind of the filter
+   *
+   * @return the filterKind
+   */
+  public String getFilterKind() {
+    return getMessageData().getEventData().getFilterKind();
+  }
+
+  /**
+   * Index position of the filter
+   *
+   * @return the filterIndex
+   */
+  public Number getFilterIndex() {
+    return getMessageData().getEventData().getFilterIndex();
+  }
+
+  /**
+   * The settings configured to the filter when it was created
+   *
+   * @return the filterSettings
+   */
+  public JsonObject getFilterSettings() {
+    return getMessageData().getEventData().getFilterSettings();
+  }
+
+  /**
+   * The default settings for the filter
+   *
+   * @return the defaultFilterSettings
+   */
+  public JsonObject getDefaultFilterSettings() {
+    return getMessageData().getEventData().getDefaultFilterSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,37 +85,31 @@ public class SourceFilterCreatedEvent extends Event<SourceFilterCreatedEvent.Spe
     /**
      * Name of the source the filter was added to
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Name of the filter
      */
-    @NonNull
     private String filterName;
 
     /**
      * The kind of the filter
      */
-    @NonNull
     private String filterKind;
 
     /**
      * Index position of the filter
      */
-    @NonNull
     private Number filterIndex;
 
     /**
      * The settings configured to the filter when it was created
      */
-    @NonNull
     private JsonObject filterSettings;
 
     /**
      * The default settings for the filter
      */
-    @NonNull
     private JsonObject defaultFilterSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterEnableStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterEnableStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.filters;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,33 @@ public class SourceFilterEnableStateChangedEvent extends Event<SourceFilterEnabl
     super(Intent.Filters, data);
   }
 
+  /**
+   * Name of the source the filter is on
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Name of the filter
+   *
+   * @return the filterName
+   */
+  public String getFilterName() {
+    return getMessageData().getEventData().getFilterName();
+  }
+
+  /**
+   * Whether the filter is enabled
+   *
+   * @return the filterEnabled
+   */
+  public Boolean getFilterEnabled() {
+    return getMessageData().getEventData().getFilterEnabled();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,19 +58,16 @@ public class SourceFilterEnableStateChangedEvent extends Event<SourceFilterEnabl
     /**
      * Name of the source the filter is on
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Name of the filter
      */
-    @NonNull
     private String filterName;
 
     /**
      * Whether the filter is enabled
      */
-    @NonNull
     private Boolean filterEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterListReindexedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterListReindexedEvent.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Filter;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -27,6 +26,24 @@ public class SourceFilterListReindexedEvent extends Event<SourceFilterListReinde
     super(Intent.Filters, data);
   }
 
+  /**
+   * Name of the source
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Array of filter objects
+   *
+   * @return the filters
+   */
+  public List<Filter> getFilters() {
+    return getMessageData().getEventData().getFilters();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -34,13 +51,11 @@ public class SourceFilterListReindexedEvent extends Event<SourceFilterListReinde
     /**
      * Name of the source
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Array of filter objects
      */
-    @NonNull
     @Singular
     private List<Filter> filters;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterNameChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.filters;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,33 @@ public class SourceFilterNameChangedEvent extends Event<SourceFilterNameChangedE
     super(Intent.Filters, data);
   }
 
+  /**
+   * The source the filter is on
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Old name of the filter
+   *
+   * @return the oldFilterName
+   */
+  public String getOldFilterName() {
+    return getMessageData().getEventData().getOldFilterName();
+  }
+
+  /**
+   * New name of the filter
+   *
+   * @return the filterName
+   */
+  public String getFilterName() {
+    return getMessageData().getEventData().getFilterName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,19 +57,16 @@ public class SourceFilterNameChangedEvent extends Event<SourceFilterNameChangedE
     /**
      * The source the filter is on
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Old name of the filter
      */
-    @NonNull
     private String oldFilterName;
 
     /**
      * New name of the filter
      */
-    @NonNull
     private String filterName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/filters/SourceFilterRemovedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.filters;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class SourceFilterRemovedEvent extends Event<SourceFilterRemovedEvent.Spe
     super(Intent.Filters, data);
   }
 
+  /**
+   * Name of the source the filter was on
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Name of the filter
+   *
+   * @return the filterName
+   */
+  public String getFilterName() {
+    return getMessageData().getEventData().getFilterName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class SourceFilterRemovedEvent extends Event<SourceFilterRemovedEvent.Spe
     /**
      * Name of the source the filter was on
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Name of the filter
      */
-    @NonNull
     private String filterName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/general/VendorEventEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/general/VendorEventEvent.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -28,6 +27,33 @@ public class VendorEventEvent extends Event<VendorEventEvent.SpecificData> {
     super(Intent.Vendors, data);
   }
 
+  /**
+   * Name of the vendor emitting the event
+   *
+   * @return the vendorName
+   */
+  public String getVendorName() {
+    return getMessageData().getEventData().getVendorName();
+  }
+
+  /**
+   * Vendor-provided event typedef
+   *
+   * @return the eventType
+   */
+  public String getEventType() {
+    return getMessageData().getEventData().getEventType();
+  }
+
+  /**
+   * Vendor-provided event data. {} if event does not provide any data
+   *
+   * @return the eventData
+   */
+  public JsonObject getEventData() {
+    return getMessageData().getEventData().getEventData();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -35,19 +61,16 @@ public class VendorEventEvent extends Event<VendorEventEvent.SpecificData> {
     /**
      * Name of the vendor emitting the event
      */
-    @NonNull
     private String vendorName;
 
     /**
      * Vendor-provided event typedef
      */
-    @NonNull
     private String eventType;
 
     /**
      * Vendor-provided event data. {} if event does not provide any data
      */
-    @NonNull
     private JsonObject eventData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputActiveStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputActiveStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -26,6 +25,24 @@ public class InputActiveStateChangedEvent extends Event<InputActiveStateChangedE
     super(Intent.InputActiveStateChanged, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * Whether the input is active
+   *
+   * @return the videoActive
+   */
+  public Boolean getVideoActive() {
+    return getMessageData().getEventData().getVideoActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,13 +50,11 @@ public class InputActiveStateChangedEvent extends Event<InputActiveStateChangedE
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * Whether the input is active
      */
-    @NonNull
     private Boolean videoActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioBalanceChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioBalanceChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class InputAudioBalanceChangedEvent extends Event<InputAudioBalanceChange
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the affected input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * New audio balance value of the input
+   *
+   * @return the inputAudioBalance
+   */
+  public Number getInputAudioBalance() {
+    return getMessageData().getEventData().getInputAudioBalance();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class InputAudioBalanceChangedEvent extends Event<InputAudioBalanceChange
     /**
      * Name of the affected input
      */
-    @NonNull
     private String inputName;
 
     /**
      * New audio balance value of the input
      */
-    @NonNull
     private Number inputAudioBalance;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioMonitorTypeChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioMonitorTypeChangedEvent.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.Input;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -31,6 +30,24 @@ public class InputAudioMonitorTypeChangedEvent extends Event<InputAudioMonitorTy
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * New monitor type of the input
+   *
+   * @return the monitorType
+   */
+  public Input.MonitorType getMonitorType() {
+    return getMessageData().getEventData().getMonitorType();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -38,13 +55,11 @@ public class InputAudioMonitorTypeChangedEvent extends Event<InputAudioMonitorTy
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * New monitor type of the input
      */
-    @NonNull
     private Input.MonitorType monitorType;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioSyncOffsetChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioSyncOffsetChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class InputAudioSyncOffsetChangedEvent extends Event<InputAudioSyncOffset
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * New sync offset in milliseconds
+   *
+   * @return the inputAudioSyncOffset
+   */
+  public Number getInputAudioSyncOffset() {
+    return getMessageData().getEventData().getInputAudioSyncOffset();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class InputAudioSyncOffsetChangedEvent extends Event<InputAudioSyncOffset
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * New sync offset in milliseconds
      */
-    @NonNull
     private Number inputAudioSyncOffset;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioTracksChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputAudioTracksChangedEvent.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.Input;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,24 @@ public class InputAudioTracksChangedEvent extends Event<InputAudioTracksChangedE
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * Object of audio tracks along with their associated enable states
+   *
+   * @return the inputAudioTracks
+   */
+  public Input.AudioTracks getInputAudioTracks() {
+    return getMessageData().getEventData().getInputAudioTracks();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,13 +49,11 @@ public class InputAudioTracksChangedEvent extends Event<InputAudioTracksChangedE
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * Object of audio tracks along with their associated enable states
      */
-    @NonNull
     private Input.AudioTracks inputAudioTracks;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputCreatedEvent.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,51 @@ public class InputCreatedEvent extends Event<InputCreatedEvent.SpecificData> {
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * The kind of the input
+   *
+   * @return the inputKind
+   */
+  public String getInputKind() {
+    return getMessageData().getEventData().getInputKind();
+  }
+
+  /**
+   * The unversioned kind of input (aka no `_v2` stuff)
+   *
+   * @return the unversionedInputKind
+   */
+  public String getUnversionedInputKind() {
+    return getMessageData().getEventData().getUnversionedInputKind();
+  }
+
+  /**
+   * The settings configured to the input when it was created
+   *
+   * @return the inputSettings
+   */
+  public JsonObject getInputSettings() {
+    return getMessageData().getEventData().getInputSettings();
+  }
+
+  /**
+   * The default settings for the input
+   *
+   * @return the defaultInputSettings
+   */
+  public JsonObject getDefaultInputSettings() {
+    return getMessageData().getEventData().getDefaultInputSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,31 +76,26 @@ public class InputCreatedEvent extends Event<InputCreatedEvent.SpecificData> {
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * The kind of the input
      */
-    @NonNull
     private String inputKind;
 
     /**
      * The unversioned kind of input (aka no `_v2` stuff)
      */
-    @NonNull
     private String unversionedInputKind;
 
     /**
      * The settings configured to the input when it was created
      */
-    @NonNull
     private JsonObject inputSettings;
 
     /**
      * The default settings for the input
      */
-    @NonNull
     private JsonObject defaultInputSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputMuteStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputMuteStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class InputMuteStateChangedEvent extends Event<InputMuteStateChangedEvent
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * Whether the input is muted
+   *
+   * @return the inputMuted
+   */
+  public Boolean getInputMuted() {
+    return getMessageData().getEventData().getInputMuted();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class InputMuteStateChangedEvent extends Event<InputMuteStateChangedEvent
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * Whether the input is muted
      */
-    @NonNull
     private Boolean inputMuted;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputNameChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class InputNameChangedEvent extends Event<InputNameChangedEvent.SpecificD
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Old name of the input
+   *
+   * @return the oldInputName
+   */
+  public String getOldInputName() {
+    return getMessageData().getEventData().getOldInputName();
+  }
+
+  /**
+   * New name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class InputNameChangedEvent extends Event<InputNameChangedEvent.SpecificD
     /**
      * Old name of the input
      */
-    @NonNull
     private String oldInputName;
 
     /**
      * New name of the input
      */
-    @NonNull
     private String inputName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputRemovedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class InputRemovedEvent extends Event<InputRemovedEvent.SpecificData> {
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class InputRemovedEvent extends Event<InputRemovedEvent.SpecificData> {
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputShowStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputShowStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -26,6 +25,24 @@ public class InputShowStateChangedEvent extends Event<InputShowStateChangedEvent
     super(Intent.InputShowStateChanged, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * Whether the input is showing
+   *
+   * @return the videoShowing
+   */
+  public Boolean getVideoShowing() {
+    return getMessageData().getEventData().getVideoShowing();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,13 +50,11 @@ public class InputShowStateChangedEvent extends Event<InputShowStateChangedEvent
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * Whether the input is showing
      */
-    @NonNull
     private Boolean videoShowing;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.inputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,33 @@ public class InputVolumeChangedEvent extends Event<InputVolumeChangedEvent.Speci
     super(Intent.Inputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * New volume level in multimap
+   *
+   * @return the inputVolumeMul
+   */
+  public Number getInputVolumeMul() {
+    return getMessageData().getEventData().getInputVolumeMul();
+  }
+
+  /**
+   * New volume level in dB
+   *
+   * @return the inputVolumeDb
+   */
+  public Number getInputVolumeDb() {
+    return getMessageData().getEventData().getInputVolumeDb();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,19 +57,16 @@ public class InputVolumeChangedEvent extends Event<InputVolumeChangedEvent.Speci
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * New volume level in multimap
      */
-    @NonNull
     private Number inputVolumeMul;
 
     /**
      * New volume level in dB
      */
-    @NonNull
     private Number inputVolumeDb;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeMetersEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/inputs/InputVolumeMetersEvent.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.InputLevels;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -27,6 +26,15 @@ public class InputVolumeMetersEvent extends Event<InputVolumeMetersEvent.Specifi
     super(Intent.InputVolumeMeters, data);
   }
 
+  /**
+   * Array of active inputs with their associated volume levels
+   *
+   * @return the inputs
+   */
+  public List<InputLevels> getInputs() {
+    return getMessageData().getEventData().getInputs();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -34,7 +42,6 @@ public class InputVolumeMetersEvent extends Event<InputVolumeMetersEvent.Specifi
     /**
      * Array of active inputs with their associated volume levels
      */
-    @NonNull
     @Singular
     private List<InputLevels> inputs;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputActionTriggeredEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputActionTriggeredEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.mediainputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class MediaInputActionTriggeredEvent extends Event<MediaInputActionTrigge
     super(Intent.MediaInputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
+  /**
+   * Action performed on the input. See `ObsMediaInputAction` enum
+   *
+   * @return the mediaAction
+   */
+  public String getMediaAction() {
+    return getMessageData().getEventData().getMediaAction();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class MediaInputActionTriggeredEvent extends Event<MediaInputActionTrigge
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
 
     /**
      * Action performed on the input. See `ObsMediaInputAction` enum
      */
-    @NonNull
     private String mediaAction;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackEndedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackEndedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.mediainputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class MediaInputPlaybackEndedEvent extends Event<MediaInputPlaybackEndedE
     super(Intent.MediaInputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class MediaInputPlaybackEndedEvent extends Event<MediaInputPlaybackEndedE
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/mediainputs/MediaInputPlaybackStartedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.mediainputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class MediaInputPlaybackStartedEvent extends Event<MediaInputPlaybackStar
     super(Intent.MediaInputs, data);
   }
 
+  /**
+   * Name of the input
+   *
+   * @return the inputName
+   */
+  public String getInputName() {
+    return getMessageData().getEventData().getInputName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class MediaInputPlaybackStartedEvent extends Event<MediaInputPlaybackStar
     /**
      * Name of the input
      */
-    @NonNull
     private String inputName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/RecordStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/RecordStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,33 @@ public class RecordStateChangedEvent extends Event<RecordStateChangedEvent.Speci
     super(Intent.Outputs, data);
   }
 
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getEventData().getOutputActive();
+  }
+
+  /**
+   * The specific state of the output
+   *
+   * @return the outputState
+   */
+  public String getOutputState() {
+    return getMessageData().getEventData().getOutputState();
+  }
+
+  /**
+   * File name for the saved recording, if record stopped. `null` otherwise
+   *
+   * @return the outputPath
+   */
+  public String getOutputPath() {
+    return getMessageData().getEventData().getOutputPath();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,19 +57,16 @@ public class RecordStateChangedEvent extends Event<RecordStateChangedEvent.Speci
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * The specific state of the output
      */
-    @NonNull
     private String outputState;
 
     /**
      * File name for the saved recording, if record stopped. `null` otherwise
      */
-    @NonNull
     private String outputPath;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferSavedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferSavedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class ReplayBufferSavedEvent extends Event<ReplayBufferSavedEvent.Specifi
     super(Intent.Outputs, data);
   }
 
+  /**
+   * Path of the saved replay file
+   *
+   * @return the savedReplayPath
+   */
+  public String getSavedReplayPath() {
+    return getMessageData().getEventData().getSavedReplayPath();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class ReplayBufferSavedEvent extends Event<ReplayBufferSavedEvent.Specifi
     /**
      * Path of the saved replay file
      */
-    @NonNull
     private String savedReplayPath;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/ReplayBufferStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class ReplayBufferStateChangedEvent extends Event<ReplayBufferStateChange
     super(Intent.Outputs, data);
   }
 
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getEventData().getOutputActive();
+  }
+
+  /**
+   * The specific state of the output
+   *
+   * @return the outputState
+   */
+  public String getOutputState() {
+    return getMessageData().getEventData().getOutputState();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class ReplayBufferStateChangedEvent extends Event<ReplayBufferStateChange
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * The specific state of the output
      */
-    @NonNull
     private String outputState;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/StreamStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/StreamStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class StreamStateChangedEvent extends Event<StreamStateChangedEvent.Speci
     super(Intent.Outputs, data);
   }
 
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getEventData().getOutputActive();
+  }
+
+  /**
+   * The specific state of the output
+   *
+   * @return the outputState
+   */
+  public String getOutputState() {
+    return getMessageData().getEventData().getOutputState();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class StreamStateChangedEvent extends Event<StreamStateChangedEvent.Speci
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * The specific state of the output
      */
-    @NonNull
     private String outputState;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/VirtualcamStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/outputs/VirtualcamStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.outputs;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class VirtualcamStateChangedEvent extends Event<VirtualcamStateChangedEve
     super(Intent.Outputs, data);
   }
 
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getEventData().getOutputActive();
+  }
+
+  /**
+   * The specific state of the output
+   *
+   * @return the outputState
+   */
+  public String getOutputState() {
+    return getMessageData().getEventData().getOutputState();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class VirtualcamStateChangedEvent extends Event<VirtualcamStateChangedEve
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * The specific state of the output
      */
-    @NonNull
     private String outputState;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemCreatedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,42 @@ public class SceneItemCreatedEvent extends Event<SceneItemCreatedEvent.SpecificD
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene the item was added to
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Name of the underlying source (input/scene)
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
+  /**
+   * Index position of the item
+   *
+   * @return the sceneItemIndex
+   */
+  public Number getSceneItemIndex() {
+    return getMessageData().getEventData().getSceneItemIndex();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,25 +66,21 @@ public class SceneItemCreatedEvent extends Event<SceneItemCreatedEvent.SpecificD
     /**
      * Name of the scene the item was added to
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Name of the underlying source (input/scene)
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
 
     /**
      * Index position of the item
      */
-    @NonNull
     private Number sceneItemIndex;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEnableStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemEnableStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,33 @@ public class SceneItemEnableStateChangedEvent extends Event<SceneItemEnableState
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene the item is in
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
+  /**
+   * Whether the scene item is enabled (visible)
+   *
+   * @return the sceneItemEnabled
+   */
+  public Boolean getSceneItemEnabled() {
+    return getMessageData().getEventData().getSceneItemEnabled();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,19 +57,16 @@ public class SceneItemEnableStateChangedEvent extends Event<SceneItemEnableState
     /**
      * Name of the scene the item is in
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
 
     /**
      * Whether the scene item is enabled (visible)
      */
-    @NonNull
     private Boolean sceneItemEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemListReindexedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemListReindexedEvent.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.SceneItemIdAndIndex;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -27,6 +26,24 @@ public class SceneItemListReindexedEvent extends Event<SceneItemListReindexedEve
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Array of scene item objects
+   *
+   * @return the sceneItems
+   */
+  public List<SceneItemIdAndIndex> getSceneItems() {
+    return getMessageData().getEventData().getSceneItems();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -34,13 +51,11 @@ public class SceneItemListReindexedEvent extends Event<SceneItemListReindexedEve
     /**
      * Name of the scene
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Array of scene item objects
      */
-    @NonNull
     @Singular
     private List<SceneItemIdAndIndex> sceneItems;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemLockStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemLockStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,33 @@ public class SceneItemLockStateChangedEvent extends Event<SceneItemLockStateChan
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene the item is in
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
+  /**
+   * Whether the scene item is locked
+   *
+   * @return the sceneItemLocked
+   */
+  public Boolean getSceneItemLocked() {
+    return getMessageData().getEventData().getSceneItemLocked();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,19 +57,16 @@ public class SceneItemLockStateChangedEvent extends Event<SceneItemLockStateChan
     /**
      * Name of the scene the item is in
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
 
     /**
      * Whether the scene item is locked
      */
-    @NonNull
     private Boolean sceneItemLocked;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemRemovedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -26,6 +25,33 @@ public class SceneItemRemovedEvent extends Event<SceneItemRemovedEvent.SpecificD
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene the item was removed from
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Name of the underlying source (input/scene)
+   *
+   * @return the sourceName
+   */
+  public String getSourceName() {
+    return getMessageData().getEventData().getSourceName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,19 +59,16 @@ public class SceneItemRemovedEvent extends Event<SceneItemRemovedEvent.SpecificD
     /**
      * Name of the scene the item was removed from
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Name of the underlying source (input/scene)
      */
-    @NonNull
     private String sourceName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemSelectedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemSelectedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.sceneitems;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class SceneItemSelectedEvent extends Event<SceneItemSelectedEvent.Specifi
     super(Intent.SceneItems, data);
   }
 
+  /**
+   * Name of the scene the item is in
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class SceneItemSelectedEvent extends Event<SceneItemSelectedEvent.Specifi
     /**
      * Name of the scene the item is in
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemTransformChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/sceneitems/SceneItemTransformChangedEvent.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.event.Event;
 import io.obswebsocket.community.client.model.SceneItem;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,33 @@ public class SceneItemTransformChangedEvent extends Event<SceneItemTransformChan
     super(Intent.SceneItemTransformChanged, data);
   }
 
+  /**
+   * The name of the scene the item is in
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getEventData().getSceneItemId();
+  }
+
+  /**
+   * New transform/crop info of the scene item
+   *
+   * @return the sceneItemTransform
+   */
+  public SceneItem.Transform getSceneItemTransform() {
+    return getMessageData().getEventData().getSceneItemTransform();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,19 +58,16 @@ public class SceneItemTransformChangedEvent extends Event<SceneItemTransformChan
     /**
      * The name of the scene the item is in
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
 
     /**
      * New transform/crop info of the scene item
      */
-    @NonNull
     private SceneItem.Transform sceneItemTransform;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentPreviewSceneChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentPreviewSceneChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class CurrentPreviewSceneChangedEvent extends Event<CurrentPreviewSceneCh
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Name of the scene that was switched to
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class CurrentPreviewSceneChangedEvent extends Event<CurrentPreviewSceneCh
     /**
      * Name of the scene that was switched to
      */
-    @NonNull
     private String sceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentProgramSceneChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/CurrentProgramSceneChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class CurrentProgramSceneChangedEvent extends Event<CurrentProgramSceneCh
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Name of the scene that was switched to
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class CurrentProgramSceneChangedEvent extends Event<CurrentProgramSceneCh
     /**
      * Name of the scene that was switched to
      */
-    @NonNull
     private String sceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneCreatedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneCreatedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class SceneCreatedEvent extends Event<SceneCreatedEvent.SpecificData> {
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Name of the new scene
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Whether the new scene is a group
+   *
+   * @return the isGroup
+   */
+  public Boolean getIsGroup() {
+    return getMessageData().getEventData().getIsGroup();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class SceneCreatedEvent extends Event<SceneCreatedEvent.SpecificData> {
     /**
      * Name of the new scene
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Whether the new scene is a group
      */
-    @NonNull
     private Boolean isGroup;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneListChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneListChangedEvent.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Scene;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -29,6 +28,15 @@ public class SceneListChangedEvent extends Event<SceneListChangedEvent.SpecificD
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Updated array of scenes
+   *
+   * @return the scenes
+   */
+  public List<Scene> getScenes() {
+    return getMessageData().getEventData().getScenes();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -36,7 +44,6 @@ public class SceneListChangedEvent extends Event<SceneListChangedEvent.SpecificD
     /**
      * Updated array of scenes
      */
-    @NonNull
     @Singular
     private List<Scene> scenes;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneNameChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneNameChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class SceneNameChangedEvent extends Event<SceneNameChangedEvent.SpecificD
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Old name of the scene
+   *
+   * @return the oldSceneName
+   */
+  public String getOldSceneName() {
+    return getMessageData().getEventData().getOldSceneName();
+  }
+
+  /**
+   * New name of the scene
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class SceneNameChangedEvent extends Event<SceneNameChangedEvent.SpecificD
     /**
      * Old name of the scene
      */
-    @NonNull
     private String oldSceneName;
 
     /**
      * New name of the scene
      */
-    @NonNull
     private String sceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneRemovedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/scenes/SceneRemovedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.scenes;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,24 @@ public class SceneRemovedEvent extends Event<SceneRemovedEvent.SpecificData> {
     super(Intent.Scenes, data);
   }
 
+  /**
+   * Name of the removed scene
+   *
+   * @return the sceneName
+   */
+  public String getSceneName() {
+    return getMessageData().getEventData().getSceneName();
+  }
+
+  /**
+   * Whether the scene was a group
+   *
+   * @return the isGroup
+   */
+  public Boolean getIsGroup() {
+    return getMessageData().getEventData().getIsGroup();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,13 +48,11 @@ public class SceneRemovedEvent extends Event<SceneRemovedEvent.SpecificData> {
     /**
      * Name of the removed scene
      */
-    @NonNull
     private String sceneName;
 
     /**
      * Whether the scene was a group
      */
-    @NonNull
     private Boolean isGroup;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentSceneTransitionChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentSceneTransitionChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.transitions;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,15 @@ public class CurrentSceneTransitionChangedEvent extends Event<CurrentSceneTransi
     super(Intent.Transitions, data);
   }
 
+  /**
+   * Name of the new transition
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getEventData().getTransitionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,7 +40,6 @@ public class CurrentSceneTransitionChangedEvent extends Event<CurrentSceneTransi
     /**
      * Name of the new transition
      */
-    @NonNull
     private String transitionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentSceneTransitionDurationChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/CurrentSceneTransitionDurationChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.transitions;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -25,6 +24,15 @@ public class CurrentSceneTransitionDurationChangedEvent extends Event<CurrentSce
     super(Intent.Transitions, data);
   }
 
+  /**
+   * Transition duration in milliseconds
+   *
+   * @return the transitionDuration
+   */
+  public Number getTransitionDuration() {
+    return getMessageData().getEventData().getTransitionDuration();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -32,7 +40,6 @@ public class CurrentSceneTransitionDurationChangedEvent extends Event<CurrentSce
     /**
      * Transition duration in milliseconds
      */
-    @NonNull
     private Number transitionDuration;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionEndedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionEndedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.transitions;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -26,6 +25,15 @@ public class SceneTransitionEndedEvent extends Event<SceneTransitionEndedEvent.S
     super(Intent.Transitions, data);
   }
 
+  /**
+   * Scene transition name
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getEventData().getTransitionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -33,7 +41,6 @@ public class SceneTransitionEndedEvent extends Event<SceneTransitionEndedEvent.S
     /**
      * Scene transition name
      */
-    @NonNull
     private String transitionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionStartedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionStartedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.transitions;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class SceneTransitionStartedEvent extends Event<SceneTransitionStartedEve
     super(Intent.Transitions, data);
   }
 
+  /**
+   * Scene transition name
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getEventData().getTransitionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class SceneTransitionStartedEvent extends Event<SceneTransitionStartedEve
     /**
      * Scene transition name
      */
-    @NonNull
     private String transitionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionVideoEndedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/transitions/SceneTransitionVideoEndedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.transitions;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -29,6 +28,15 @@ public class SceneTransitionVideoEndedEvent extends Event<SceneTransitionVideoEn
     super(Intent.Transitions, data);
   }
 
+  /**
+   * Scene transition name
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getEventData().getTransitionName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -36,7 +44,6 @@ public class SceneTransitionVideoEndedEvent extends Event<SceneTransitionVideoEn
     /**
      * Scene transition name
      */
-    @NonNull
     private String transitionName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/event/ui/StudioModeStateChangedEvent.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/event/ui/StudioModeStateChangedEvent.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.event.ui;
 import io.obswebsocket.community.client.message.event.Event;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -24,6 +23,15 @@ public class StudioModeStateChangedEvent extends Event<StudioModeStateChangedEve
     super(Intent.Ui, data);
   }
 
+  /**
+   * True == Enabled, False == Disabled
+   *
+   * @return the studioModeEnabled
+   */
+  public Boolean getStudioModeEnabled() {
+    return getMessageData().getEventData().getStudioModeEnabled();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -31,7 +39,6 @@ public class StudioModeStateChangedEvent extends Event<StudioModeStateChangedEve
     /**
      * True == Enabled, False == Disabled
      */
-    @NonNull
     private Boolean studioModeEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/RequestResponse.java
@@ -22,18 +22,21 @@ public abstract class RequestResponse<T> extends Message {
   @ToString(callSuper = true)
   @Getter
   public static class Data<T> extends Request.Data {
+
     protected Status requestStatus;
     private T responseData;
   }
 
   public boolean isSuccessful() {
-    return this.messageData.requestStatus != null && this.messageData.requestStatus.result;
+    return this.messageData.requestStatus != null &&
+        Boolean.TRUE.equals(this.messageData.requestStatus.result);
   }
 
   @Getter
   @ToString
   @Builder
   public static class Status {
+
     protected Boolean result;
     protected Integer code;
     protected String comment;

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetPersistentDataResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetPersistentDataResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetPersistentDataResponse extends RequestResponse<GetPersistentDataResponse.SpecificData> {
+  /**
+   * Value associated with the slot. `null` if not set
+   *
+   * @return the slotValue
+   */
+  public JsonObject getSlotValue() {
+    return getMessageData().getResponseData().getSlotValue();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetPersistentDataResponse extends RequestResponse<GetPersistentData
     /**
      * Value associated with the slot. `null` if not set
      */
-    @NonNull
     private JsonObject slotValue;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetProfileListResponse extends RequestResponse<GetProfileListResponse.SpecificData> {
+  /**
+   * The name of the current profile
+   *
+   * @return the currentProfileName
+   */
+  public String getCurrentProfileName() {
+    return getMessageData().getResponseData().getCurrentProfileName();
+  }
+
+  /**
+   * Array of all available profiles
+   *
+   * @return the profiles
+   */
+  public List<String> getProfiles() {
+    return getMessageData().getResponseData().getProfiles();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,13 +39,11 @@ public class GetProfileListResponse extends RequestResponse<GetProfileListRespon
     /**
      * The name of the current profile
      */
-    @NonNull
     private String currentProfileName;
 
     /**
      * Array of all available profiles
      */
-    @NonNull
     @Singular
     private List<String> profiles;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileParameterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetProfileParameterResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.config;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetProfileParameterResponse extends RequestResponse<GetProfileParameterResponse.SpecificData> {
+  /**
+   * Value associated with the parameter. `null` if not set and no default
+   *
+   * @return the parameterValue
+   */
+  public String getParameterValue() {
+    return getMessageData().getResponseData().getParameterValue();
+  }
+
+  /**
+   * Default value associated with the parameter. `null` if no default
+   *
+   * @return the defaultParameterValue
+   */
+  public String getDefaultParameterValue() {
+    return getMessageData().getResponseData().getDefaultParameterValue();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,13 +37,11 @@ public class GetProfileParameterResponse extends RequestResponse<GetProfileParam
     /**
      * Value associated with the parameter. `null` if not set and no default
      */
-    @NonNull
     private String parameterValue;
 
     /**
      * Default value associated with the parameter. `null` if no default
      */
-    @NonNull
     private String defaultParameterValue;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetRecordDirectoryResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetRecordDirectoryResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.config;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetRecordDirectoryResponse extends RequestResponse<GetRecordDirectoryResponse.SpecificData> {
+  /**
+   * Output directory
+   *
+   * @return the recordDirectory
+   */
+  public String getRecordDirectory() {
+    return getMessageData().getResponseData().getRecordDirectory();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetRecordDirectoryResponse extends RequestResponse<GetRecordDirecto
     /**
      * Output directory
      */
-    @NonNull
     private String recordDirectory;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetSceneCollectionListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetSceneCollectionListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneCollectionListResponse extends RequestResponse<GetSceneCollectionListResponse.SpecificData> {
+  /**
+   * The name of the current scene collection
+   *
+   * @return the currentSceneCollectionName
+   */
+  public String getCurrentSceneCollectionName() {
+    return getMessageData().getResponseData().getCurrentSceneCollectionName();
+  }
+
+  /**
+   * Array of all available scene collections
+   *
+   * @return the sceneCollections
+   */
+  public List<String> getSceneCollections() {
+    return getMessageData().getResponseData().getSceneCollections();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,13 +39,11 @@ public class GetSceneCollectionListResponse extends RequestResponse<GetSceneColl
     /**
      * The name of the current scene collection
      */
-    @NonNull
     private String currentSceneCollectionName;
 
     /**
      * Array of all available scene collections
      */
-    @NonNull
     @Singular
     private List<String> sceneCollections;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetStreamServiceSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetStreamServiceSettingsResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetStreamServiceSettingsResponse extends RequestResponse<GetStreamServiceSettingsResponse.SpecificData> {
+  /**
+   * Stream service type, like `rtmp_custom` or `rtmp_common`
+   *
+   * @return the streamServiceType
+   */
+  public String getStreamServiceType() {
+    return getMessageData().getResponseData().getStreamServiceType();
+  }
+
+  /**
+   * Stream service settings
+   *
+   * @return the streamServiceSettings
+   */
+  public JsonObject getStreamServiceSettings() {
+    return getMessageData().getResponseData().getStreamServiceSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,13 +38,11 @@ public class GetStreamServiceSettingsResponse extends RequestResponse<GetStreamS
     /**
      * Stream service type, like `rtmp_custom` or `rtmp_common`
      */
-    @NonNull
     private String streamServiceType;
 
     /**
      * Stream service settings
      */
-    @NonNull
     private JsonObject streamServiceSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetVideoSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/config/GetVideoSettingsResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.config;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,60 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetVideoSettingsResponse extends RequestResponse<GetVideoSettingsResponse.SpecificData> {
+  /**
+   * Numerator of the fractional FPS value
+   *
+   * @return the fpsNumerator
+   */
+  public Number getFpsNumerator() {
+    return getMessageData().getResponseData().getFpsNumerator();
+  }
+
+  /**
+   * Denominator of the fractional FPS value
+   *
+   * @return the fpsDenominator
+   */
+  public Number getFpsDenominator() {
+    return getMessageData().getResponseData().getFpsDenominator();
+  }
+
+  /**
+   * Width of the base (canvas) resolution in pixels
+   *
+   * @return the baseWidth
+   */
+  public Number getBaseWidth() {
+    return getMessageData().getResponseData().getBaseWidth();
+  }
+
+  /**
+   * Height of the base (canvas) resolution in pixels
+   *
+   * @return the baseHeight
+   */
+  public Number getBaseHeight() {
+    return getMessageData().getResponseData().getBaseHeight();
+  }
+
+  /**
+   * Width of the output resolution in pixels
+   *
+   * @return the outputWidth
+   */
+  public Number getOutputWidth() {
+    return getMessageData().getResponseData().getOutputWidth();
+  }
+
+  /**
+   * Height of the output resolution in pixels
+   *
+   * @return the outputHeight
+   */
+  public Number getOutputHeight() {
+    return getMessageData().getResponseData().getOutputHeight();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,37 +73,31 @@ public class GetVideoSettingsResponse extends RequestResponse<GetVideoSettingsRe
     /**
      * Numerator of the fractional FPS value
      */
-    @NonNull
     private Number fpsNumerator;
 
     /**
      * Denominator of the fractional FPS value
      */
-    @NonNull
     private Number fpsDenominator;
 
     /**
      * Width of the base (canvas) resolution in pixels
      */
-    @NonNull
     private Number baseWidth;
 
     /**
      * Height of the base (canvas) resolution in pixels
      */
-    @NonNull
     private Number baseHeight;
 
     /**
      * Width of the output resolution in pixels
      */
-    @NonNull
     private Number outputWidth;
 
     /**
      * Height of the output resolution in pixels
      */
-    @NonNull
     private Number outputHeight;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterDefaultSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterDefaultSettingsResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSourceFilterDefaultSettingsResponse extends RequestResponse<GetSourceFilterDefaultSettingsResponse.SpecificData> {
+  /**
+   * Object of default settings for the filter kind
+   *
+   * @return the defaultFilterSettings
+   */
+  public JsonObject getDefaultFilterSettings() {
+    return getMessageData().getResponseData().getDefaultFilterSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetSourceFilterDefaultSettingsResponse extends RequestResponse<GetS
     /**
      * Object of default settings for the filter kind
      */
-    @NonNull
     private JsonObject defaultFilterSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Filter;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSourceFilterListResponse extends RequestResponse<GetSourceFilterListResponse.SpecificData> {
+  /**
+   * Array of filters
+   *
+   * @return the filters
+   */
+  public List<Filter> getFilters() {
+    return getMessageData().getResponseData().getFilters();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetSourceFilterListResponse extends RequestResponse<GetSourceFilter
     /**
      * Array of filters
      */
-    @NonNull
     @Singular
     private List<Filter> filters;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/filters/GetSourceFilterResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,42 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSourceFilterResponse extends RequestResponse<GetSourceFilterResponse.SpecificData> {
+  /**
+   * Whether the filter is enabled
+   *
+   * @return the filterEnabled
+   */
+  public Boolean getFilterEnabled() {
+    return getMessageData().getResponseData().getFilterEnabled();
+  }
+
+  /**
+   * Index of the filter in the list, beginning at 0
+   *
+   * @return the filterIndex
+   */
+  public Number getFilterIndex() {
+    return getMessageData().getResponseData().getFilterIndex();
+  }
+
+  /**
+   * The kind of filter
+   *
+   * @return the filterKind
+   */
+  public String getFilterKind() {
+    return getMessageData().getResponseData().getFilterKind();
+  }
+
+  /**
+   * Settings object associated with the filter
+   *
+   * @return the filterSettings
+   */
+  public JsonObject getFilterSettings() {
+    return getMessageData().getResponseData().getFilterSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,25 +56,21 @@ public class GetSourceFilterResponse extends RequestResponse<GetSourceFilterResp
     /**
      * Whether the filter is enabled
      */
-    @NonNull
     private Boolean filterEnabled;
 
     /**
      * Index of the filter in the list, beginning at 0
      */
-    @NonNull
     private Number filterIndex;
 
     /**
      * The kind of filter
      */
-    @NonNull
     private String filterKind;
 
     /**
      * Settings object associated with the filter
      */
-    @NonNull
     private JsonObject filterSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/CallVendorRequestResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/CallVendorRequestResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,33 @@ import lombok.ToString;
     callSuper = true
 )
 public class CallVendorRequestResponse extends RequestResponse<CallVendorRequestResponse.SpecificData> {
+  /**
+   * Echoed of `vendorName`
+   *
+   * @return the vendorName
+   */
+  public String getVendorName() {
+    return getMessageData().getResponseData().getVendorName();
+  }
+
+  /**
+   * Echoed of `requestType`
+   *
+   * @return the requestType
+   */
+  public String getRequestType() {
+    return getMessageData().getResponseData().getRequestType();
+  }
+
+  /**
+   * Object containing appropriate response data. {} if request does not provide any response data
+   *
+   * @return the responseData
+   */
+  public JsonObject getResponseData() {
+    return getMessageData().getResponseData().getResponseData();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,19 +47,16 @@ public class CallVendorRequestResponse extends RequestResponse<CallVendorRequest
     /**
      * Echoed of `vendorName`
      */
-    @NonNull
     private String vendorName;
 
     /**
      * Echoed of `requestType`
      */
-    @NonNull
     private String requestType;
 
     /**
      * Object containing appropriate response data. {} if request does not provide any response data
      */
-    @NonNull
     private JsonObject responseData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetHotkeyListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetHotkeyListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetHotkeyListResponse extends RequestResponse<GetHotkeyListResponse.SpecificData> {
+  /**
+   * Array of hotkey names
+   *
+   * @return the hotkeys
+   */
+  public List<String> getHotkeys() {
+    return getMessageData().getResponseData().getHotkeys();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,7 +30,6 @@ public class GetHotkeyListResponse extends RequestResponse<GetHotkeyListResponse
     /**
      * Array of hotkey names
      */
-    @NonNull
     @Singular
     private List<String> hotkeys;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStatsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetStatsResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.general;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,105 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetStatsResponse extends RequestResponse<GetStatsResponse.SpecificData> {
+  /**
+   * Current CPU usage in percent
+   *
+   * @return the cpuUsage
+   */
+  public Number getCpuUsage() {
+    return getMessageData().getResponseData().getCpuUsage();
+  }
+
+  /**
+   * Amount of memory in MB currently being used by OBS
+   *
+   * @return the memoryUsage
+   */
+  public Number getMemoryUsage() {
+    return getMessageData().getResponseData().getMemoryUsage();
+  }
+
+  /**
+   * Available disk space on the device being used for recording storage
+   *
+   * @return the availableDiskSpace
+   */
+  public Number getAvailableDiskSpace() {
+    return getMessageData().getResponseData().getAvailableDiskSpace();
+  }
+
+  /**
+   * Current FPS being rendered
+   *
+   * @return the activeFps
+   */
+  public Number getActiveFps() {
+    return getMessageData().getResponseData().getActiveFps();
+  }
+
+  /**
+   * Average time in milliseconds that OBS is taking to render a frame
+   *
+   * @return the averageFrameRenderTime
+   */
+  public Number getAverageFrameRenderTime() {
+    return getMessageData().getResponseData().getAverageFrameRenderTime();
+  }
+
+  /**
+   * Number of frames skipped by OBS in the render thread
+   *
+   * @return the renderSkippedFrames
+   */
+  public Number getRenderSkippedFrames() {
+    return getMessageData().getResponseData().getRenderSkippedFrames();
+  }
+
+  /**
+   * Total number of frames outputted by the render thread
+   *
+   * @return the renderTotalFrames
+   */
+  public Number getRenderTotalFrames() {
+    return getMessageData().getResponseData().getRenderTotalFrames();
+  }
+
+  /**
+   * Number of frames skipped by OBS in the output thread
+   *
+   * @return the outputSkippedFrames
+   */
+  public Number getOutputSkippedFrames() {
+    return getMessageData().getResponseData().getOutputSkippedFrames();
+  }
+
+  /**
+   * Total number of frames outputted by the output thread
+   *
+   * @return the outputTotalFrames
+   */
+  public Number getOutputTotalFrames() {
+    return getMessageData().getResponseData().getOutputTotalFrames();
+  }
+
+  /**
+   * Total number of messages received by obs-websocket from the client
+   *
+   * @return the webSocketSessionIncomingMessages
+   */
+  public Number getWebSocketSessionIncomingMessages() {
+    return getMessageData().getResponseData().getWebSocketSessionIncomingMessages();
+  }
+
+  /**
+   * Total number of messages sent by obs-websocket to the client
+   *
+   * @return the webSocketSessionOutgoingMessages
+   */
+  public Number getWebSocketSessionOutgoingMessages() {
+    return getMessageData().getResponseData().getWebSocketSessionOutgoingMessages();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,67 +118,56 @@ public class GetStatsResponse extends RequestResponse<GetStatsResponse.SpecificD
     /**
      * Current CPU usage in percent
      */
-    @NonNull
     private Number cpuUsage;
 
     /**
      * Amount of memory in MB currently being used by OBS
      */
-    @NonNull
     private Number memoryUsage;
 
     /**
      * Available disk space on the device being used for recording storage
      */
-    @NonNull
     private Number availableDiskSpace;
 
     /**
      * Current FPS being rendered
      */
-    @NonNull
     private Number activeFps;
 
     /**
      * Average time in milliseconds that OBS is taking to render a frame
      */
-    @NonNull
     private Number averageFrameRenderTime;
 
     /**
      * Number of frames skipped by OBS in the render thread
      */
-    @NonNull
     private Number renderSkippedFrames;
 
     /**
      * Total number of frames outputted by the render thread
      */
-    @NonNull
     private Number renderTotalFrames;
 
     /**
      * Number of frames skipped by OBS in the output thread
      */
-    @NonNull
     private Number outputSkippedFrames;
 
     /**
      * Total number of frames outputted by the output thread
      */
-    @NonNull
     private Number outputTotalFrames;
 
     /**
      * Total number of messages received by obs-websocket from the client
      */
-    @NonNull
     private Number webSocketSessionIncomingMessages;
 
     /**
      * Total number of messages sent by obs-websocket to the client
      */
-    @NonNull
     private Number webSocketSessionOutgoingMessages;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetVersionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/general/GetVersionResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,69 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetVersionResponse extends RequestResponse<GetVersionResponse.SpecificData> {
+  /**
+   * Current OBS Studio version
+   *
+   * @return the obsVersion
+   */
+  public String getObsVersion() {
+    return getMessageData().getResponseData().getObsVersion();
+  }
+
+  /**
+   * Current obs-websocket version
+   *
+   * @return the obsWebSocketVersion
+   */
+  public String getObsWebSocketVersion() {
+    return getMessageData().getResponseData().getObsWebSocketVersion();
+  }
+
+  /**
+   * Current latest obs-websocket RPC version
+   *
+   * @return the rpcVersion
+   */
+  public Number getRpcVersion() {
+    return getMessageData().getResponseData().getRpcVersion();
+  }
+
+  /**
+   * Array of available RPC requests for the currently negotiated RPC version
+   *
+   * @return the availableRequests
+   */
+  public List<String> getAvailableRequests() {
+    return getMessageData().getResponseData().getAvailableRequests();
+  }
+
+  /**
+   * Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
+   *
+   * @return the supportedImageFormats
+   */
+  public List<String> getSupportedImageFormats() {
+    return getMessageData().getResponseData().getSupportedImageFormats();
+  }
+
+  /**
+   * Name of the platform. Usually `windows`, `macos`, or `ubuntu` (linux flavor). Not guaranteed to be any of those
+   *
+   * @return the platform
+   */
+  public String getPlatform() {
+    return getMessageData().getResponseData().getPlatform();
+  }
+
+  /**
+   * Description of the platform, like `Windows 10 (10.0)`
+   *
+   * @return the platformDescription
+   */
+  public String getPlatformDescription() {
+    return getMessageData().getResponseData().getPlatformDescription();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,45 +84,38 @@ public class GetVersionResponse extends RequestResponse<GetVersionResponse.Speci
     /**
      * Current OBS Studio version
      */
-    @NonNull
     private String obsVersion;
 
     /**
      * Current obs-websocket version
      */
-    @NonNull
     private String obsWebSocketVersion;
 
     /**
      * Current latest obs-websocket RPC version
      */
-    @NonNull
     private Number rpcVersion;
 
     /**
      * Array of available RPC requests for the currently negotiated RPC version
      */
-    @NonNull
     @Singular
     private List<String> availableRequests;
 
     /**
      * Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
      */
-    @NonNull
     @Singular
     private List<String> supportedImageFormats;
 
     /**
      * Name of the platform. Usually `windows`, `macos`, or `ubuntu` (linux flavor). Not guaranteed to be any of those
      */
-    @NonNull
     private String platform;
 
     /**
      * Description of the platform, like `Windows 10 (10.0)`
      */
-    @NonNull
     private String platformDescription;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/CreateInputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/CreateInputResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class CreateInputResponse extends RequestResponse<CreateInputResponse.SpecificData> {
+  /**
+   * ID of the newly created scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getResponseData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class CreateInputResponse extends RequestResponse<CreateInputResponse.Spe
     /**
      * ID of the newly created scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioBalanceResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioBalanceResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputAudioBalanceResponse extends RequestResponse<GetInputAudioBalanceResponse.SpecificData> {
+  /**
+   * Audio balance value from 0.0-1.0
+   *
+   * @return the inputAudioBalance
+   */
+  public Number getInputAudioBalance() {
+    return getMessageData().getResponseData().getInputAudioBalance();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetInputAudioBalanceResponse extends RequestResponse<GetInputAudioB
     /**
      * Audio balance value from 0.0-1.0
      */
-    @NonNull
     private Number inputAudioBalance;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioMonitorTypeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioMonitorTypeResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Input;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputAudioMonitorTypeResponse extends RequestResponse<GetInputAudioMonitorTypeResponse.SpecificData> {
+  /**
+   * Audio monitor type
+   *
+   * @return the monitorType
+   */
+  public Input.MonitorType getMonitorType() {
+    return getMessageData().getResponseData().getMonitorType();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetInputAudioMonitorTypeResponse extends RequestResponse<GetInputAu
     /**
      * Audio monitor type
      */
-    @NonNull
     private Input.MonitorType monitorType;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioSyncOffsetResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioSyncOffsetResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputAudioSyncOffsetResponse extends RequestResponse<GetInputAudioSyncOffsetResponse.SpecificData> {
+  /**
+   * Audio sync offset in milliseconds
+   *
+   * @return the inputAudioSyncOffset
+   */
+  public Number getInputAudioSyncOffset() {
+    return getMessageData().getResponseData().getInputAudioSyncOffset();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetInputAudioSyncOffsetResponse extends RequestResponse<GetInputAud
     /**
      * Audio sync offset in milliseconds
      */
-    @NonNull
     private Number inputAudioSyncOffset;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioTracksResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputAudioTracksResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.Input;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputAudioTracksResponse extends RequestResponse<GetInputAudioTracksResponse.SpecificData> {
+  /**
+   * Object of audio tracks and associated enable states
+   *
+   * @return the inputAudioTracks
+   */
+  public Input.AudioTracks getInputAudioTracks() {
+    return getMessageData().getResponseData().getInputAudioTracks();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetInputAudioTracksResponse extends RequestResponse<GetInputAudioTr
     /**
      * Object of audio tracks and associated enable states
      */
-    @NonNull
     private Input.AudioTracks inputAudioTracks;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputDefaultSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputDefaultSettingsResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputDefaultSettingsResponse extends RequestResponse<GetInputDefaultSettingsResponse.SpecificData> {
+  /**
+   * Object of default settings for the input kind
+   *
+   * @return the defaultInputSettings
+   */
+  public JsonObject getDefaultInputSettings() {
+    return getMessageData().getResponseData().getDefaultInputSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetInputDefaultSettingsResponse extends RequestResponse<GetInputDef
     /**
      * Object of default settings for the input kind
      */
-    @NonNull
     private JsonObject defaultInputSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputKindListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputKindListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputKindListResponse extends RequestResponse<GetInputKindListResponse.SpecificData> {
+  /**
+   * Array of input kinds
+   *
+   * @return the inputKinds
+   */
+  public List<String> getInputKinds() {
+    return getMessageData().getResponseData().getInputKinds();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,7 +30,6 @@ public class GetInputKindListResponse extends RequestResponse<GetInputKindListRe
     /**
      * Array of input kinds
      */
-    @NonNull
     @Singular
     private List<String> inputKinds;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Input;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputListResponse extends RequestResponse<GetInputListResponse.SpecificData> {
+  /**
+   * Array of inputs
+   *
+   * @return the inputs
+   */
+  public List<Input> getInputs() {
+    return getMessageData().getResponseData().getInputs();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetInputListResponse extends RequestResponse<GetInputListResponse.S
     /**
      * Array of inputs
      */
-    @NonNull
     @Singular
     private List<Input> inputs;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputMuteResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputMuteResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputMuteResponse extends RequestResponse<GetInputMuteResponse.SpecificData> {
+  /**
+   * Whether the input is muted
+   *
+   * @return the inputMuted
+   */
+  public Boolean getInputMuted() {
+    return getMessageData().getResponseData().getInputMuted();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetInputMuteResponse extends RequestResponse<GetInputMuteResponse.S
     /**
      * Whether the input is muted
      */
-    @NonNull
     private Boolean inputMuted;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputPropertiesListPropertyItemsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputPropertiesListPropertyItemsResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Input;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputPropertiesListPropertyItemsResponse extends RequestResponse<GetInputPropertiesListPropertyItemsResponse.SpecificData> {
+  /**
+   * Array of items in the list property
+   *
+   * @return the propertyItems
+   */
+  public List<Input.PropertyItem> getPropertyItems() {
+    return getMessageData().getResponseData().getPropertyItems();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetInputPropertiesListPropertyItemsResponse extends RequestResponse
     /**
      * Array of items in the list property
      */
-    @NonNull
     @Singular
     private List<Input.PropertyItem> propertyItems;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputSettingsResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputSettingsResponse extends RequestResponse<GetInputSettingsResponse.SpecificData> {
+  /**
+   * Object of settings for the input
+   *
+   * @return the inputSettings
+   */
+  public JsonObject getInputSettings() {
+    return getMessageData().getResponseData().getInputSettings();
+  }
+
+  /**
+   * The kind of the input
+   *
+   * @return the inputKind
+   */
+  public String getInputKind() {
+    return getMessageData().getResponseData().getInputKind();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,13 +38,11 @@ public class GetInputSettingsResponse extends RequestResponse<GetInputSettingsRe
     /**
      * Object of settings for the input
      */
-    @NonNull
     private JsonObject inputSettings;
 
     /**
      * The kind of the input
      */
-    @NonNull
     private String inputKind;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputVolumeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetInputVolumeResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetInputVolumeResponse extends RequestResponse<GetInputVolumeResponse.SpecificData> {
+  /**
+   * Volume setting in mul
+   *
+   * @return the inputVolumeMul
+   */
+  public Number getInputVolumeMul() {
+    return getMessageData().getResponseData().getInputVolumeMul();
+  }
+
+  /**
+   * Volume setting in dB
+   *
+   * @return the inputVolumeDb
+   */
+  public Number getInputVolumeDb() {
+    return getMessageData().getResponseData().getInputVolumeDb();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,13 +37,11 @@ public class GetInputVolumeResponse extends RequestResponse<GetInputVolumeRespon
     /**
      * Volume setting in mul
      */
-    @NonNull
     private Number inputVolumeMul;
 
     /**
      * Volume setting in dB
      */
-    @NonNull
     private Number inputVolumeDb;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetSpecialInputsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/GetSpecialInputsResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,60 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSpecialInputsResponse extends RequestResponse<GetSpecialInputsResponse.SpecificData> {
+  /**
+   * Name of the Desktop Audio input
+   *
+   * @return the desktop1
+   */
+  public String getDesktop1() {
+    return getMessageData().getResponseData().getDesktop1();
+  }
+
+  /**
+   * Name of the Desktop Audio 2 input
+   *
+   * @return the desktop2
+   */
+  public String getDesktop2() {
+    return getMessageData().getResponseData().getDesktop2();
+  }
+
+  /**
+   * Name of the Mic/Auxiliary Audio input
+   *
+   * @return the mic1
+   */
+  public String getMic1() {
+    return getMessageData().getResponseData().getMic1();
+  }
+
+  /**
+   * Name of the Mic/Auxiliary Audio 2 input
+   *
+   * @return the mic2
+   */
+  public String getMic2() {
+    return getMessageData().getResponseData().getMic2();
+  }
+
+  /**
+   * Name of the Mic/Auxiliary Audio 3 input
+   *
+   * @return the mic3
+   */
+  public String getMic3() {
+    return getMessageData().getResponseData().getMic3();
+  }
+
+  /**
+   * Name of the Mic/Auxiliary Audio 4 input
+   *
+   * @return the mic4
+   */
+  public String getMic4() {
+    return getMessageData().getResponseData().getMic4();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,37 +73,31 @@ public class GetSpecialInputsResponse extends RequestResponse<GetSpecialInputsRe
     /**
      * Name of the Desktop Audio input
      */
-    @NonNull
     private String desktop1;
 
     /**
      * Name of the Desktop Audio 2 input
      */
-    @NonNull
     private String desktop2;
 
     /**
      * Name of the Mic/Auxiliary Audio input
      */
-    @NonNull
     private String mic1;
 
     /**
      * Name of the Mic/Auxiliary Audio 2 input
      */
-    @NonNull
     private String mic2;
 
     /**
      * Name of the Mic/Auxiliary Audio 3 input
      */
-    @NonNull
     private String mic3;
 
     /**
      * Name of the Mic/Auxiliary Audio 4 input
      */
-    @NonNull
     private String mic4;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/ToggleInputMuteResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/inputs/ToggleInputMuteResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.inputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class ToggleInputMuteResponse extends RequestResponse<ToggleInputMuteResponse.SpecificData> {
+  /**
+   * Whether the input has been muted or unmuted
+   *
+   * @return the inputMuted
+   */
+  public Boolean getInputMuted() {
+    return getMessageData().getResponseData().getInputMuted();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class ToggleInputMuteResponse extends RequestResponse<ToggleInputMuteResp
     /**
      * Whether the input has been muted or unmuted
      */
-    @NonNull
     private Boolean inputMuted;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/GetMediaInputStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/mediainputs/GetMediaInputStatusResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.MediaState;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,33 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetMediaInputStatusResponse extends RequestResponse<GetMediaInputStatusResponse.SpecificData> {
+  /**
+   * State of the media input
+   *
+   * @return the mediaState
+   */
+  public MediaState getMediaState() {
+    return getMessageData().getResponseData().getMediaState();
+  }
+
+  /**
+   * Total duration of the playing media in milliseconds. `null` if not playing
+   *
+   * @return the mediaDuration
+   */
+  public Number getMediaDuration() {
+    return getMessageData().getResponseData().getMediaDuration();
+  }
+
+  /**
+   * Position of the cursor in milliseconds. `null` if not playing
+   *
+   * @return the mediaCursor
+   */
+  public Number getMediaCursor() {
+    return getMessageData().getResponseData().getMediaCursor();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,19 +47,16 @@ public class GetMediaInputStatusResponse extends RequestResponse<GetMediaInputSt
     /**
      * State of the media input
      */
-    @NonNull
     private MediaState mediaState;
 
     /**
      * Total duration of the playing media in milliseconds. `null` if not playing
      */
-    @NonNull
     private Number mediaDuration;
 
     /**
      * Position of the cursor in milliseconds. `null` if not playing
      */
-    @NonNull
     private Number mediaCursor;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetLastReplayBufferReplayResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetLastReplayBufferReplayResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetLastReplayBufferReplayResponse extends RequestResponse<GetLastReplayBufferReplayResponse.SpecificData> {
+  /**
+   * File path
+   *
+   * @return the savedReplayPath
+   */
+  public String getSavedReplayPath() {
+    return getMessageData().getResponseData().getSavedReplayPath();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetLastReplayBufferReplayResponse extends RequestResponse<GetLastRe
     /**
      * File path
      */
-    @NonNull
     private String savedReplayPath;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Output;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetOutputListResponse extends RequestResponse<GetOutputListResponse.SpecificData> {
+  /**
+   * The outputs
+   *
+   * @return the outputs
+   */
+  public List<Output> getOutputs() {
+    return getMessageData().getResponseData().getOutputs();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetOutputListResponse extends RequestResponse<GetOutputListResponse
     /**
      * The outputs
      */
-    @NonNull
     @Singular
     private List<Output> outputs;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputSettingsResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputSettingsResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetOutputSettingsResponse extends RequestResponse<GetOutputSettingsResponse.SpecificData> {
+  /**
+   * Output settings
+   *
+   * @return the outputSettings
+   */
+  public JsonObject getOutputSettings() {
+    return getMessageData().getResponseData().getOutputSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetOutputSettingsResponse extends RequestResponse<GetOutputSettings
     /**
      * Output settings
      */
-    @NonNull
     private JsonObject outputSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetOutputStatusResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,78 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetOutputStatusResponse extends RequestResponse<GetOutputStatusResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
+  /**
+   * Whether the output is reconnecting
+   *
+   * @return the outputReconnecting
+   */
+  public Boolean getOutputReconnecting() {
+    return getMessageData().getResponseData().getOutputReconnecting();
+  }
+
+  /**
+   * Current formatted timecode string for the output
+   *
+   * @return the outputTimecode
+   */
+  public String getOutputTimecode() {
+    return getMessageData().getResponseData().getOutputTimecode();
+  }
+
+  /**
+   * Current duration in milliseconds for the output
+   *
+   * @return the outputDuration
+   */
+  public Number getOutputDuration() {
+    return getMessageData().getResponseData().getOutputDuration();
+  }
+
+  /**
+   * Congestion of the output
+   *
+   * @return the outputCongestion
+   */
+  public Number getOutputCongestion() {
+    return getMessageData().getResponseData().getOutputCongestion();
+  }
+
+  /**
+   * Number of bytes sent by the output
+   *
+   * @return the outputBytes
+   */
+  public Number getOutputBytes() {
+    return getMessageData().getResponseData().getOutputBytes();
+  }
+
+  /**
+   * Number of frames skipped by the output's process
+   *
+   * @return the outputSkippedFrames
+   */
+  public Number getOutputSkippedFrames() {
+    return getMessageData().getResponseData().getOutputSkippedFrames();
+  }
+
+  /**
+   * Total number of frames delivered by the output's process
+   *
+   * @return the outputTotalFrames
+   */
+  public Number getOutputTotalFrames() {
+    return getMessageData().getResponseData().getOutputTotalFrames();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,49 +91,41 @@ public class GetOutputStatusResponse extends RequestResponse<GetOutputStatusResp
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * Whether the output is reconnecting
      */
-    @NonNull
     private Boolean outputReconnecting;
 
     /**
      * Current formatted timecode string for the output
      */
-    @NonNull
     private String outputTimecode;
 
     /**
      * Current duration in milliseconds for the output
      */
-    @NonNull
     private Number outputDuration;
 
     /**
      * Congestion of the output
      */
-    @NonNull
     private Number outputCongestion;
 
     /**
      * Number of bytes sent by the output
      */
-    @NonNull
     private Number outputBytes;
 
     /**
      * Number of frames skipped by the output's process
      */
-    @NonNull
     private Number outputSkippedFrames;
 
     /**
      * Total number of frames delivered by the output's process
      */
-    @NonNull
     private Number outputTotalFrames;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetReplayBufferStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetReplayBufferStatusResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetReplayBufferStatusResponse extends RequestResponse<GetReplayBufferStatusResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetReplayBufferStatusResponse extends RequestResponse<GetReplayBuff
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetVirtualCamStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/GetVirtualCamStatusResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetVirtualCamStatusResponse extends RequestResponse<GetVirtualCamStatusResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetVirtualCamStatusResponse extends RequestResponse<GetVirtualCamSt
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleOutputResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleOutputResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class ToggleOutputResponse extends RequestResponse<ToggleOutputResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class ToggleOutputResponse extends RequestResponse<ToggleOutputResponse.S
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleReplayBufferResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleReplayBufferResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class ToggleReplayBufferResponse extends RequestResponse<ToggleReplayBufferResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class ToggleReplayBufferResponse extends RequestResponse<ToggleReplayBuff
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleVirtualCamResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/outputs/ToggleVirtualCamResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.outputs;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class ToggleVirtualCamResponse extends RequestResponse<ToggleVirtualCamResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class ToggleVirtualCamResponse extends RequestResponse<ToggleVirtualCamRe
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/GetRecordStatusResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.record;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,51 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetRecordStatusResponse extends RequestResponse<GetRecordStatusResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
+  /**
+   * Whether the output is paused
+   *
+   * @return the outputPaused
+   */
+  public Boolean getOutputPaused() {
+    return getMessageData().getResponseData().getOutputPaused();
+  }
+
+  /**
+   * Current formatted timecode string for the output
+   *
+   * @return the outputTimecode
+   */
+  public String getOutputTimecode() {
+    return getMessageData().getResponseData().getOutputTimecode();
+  }
+
+  /**
+   * Current duration in milliseconds for the output
+   *
+   * @return the outputDuration
+   */
+  public Number getOutputDuration() {
+    return getMessageData().getResponseData().getOutputDuration();
+  }
+
+  /**
+   * Number of bytes sent by the output
+   *
+   * @return the outputBytes
+   */
+  public Number getOutputBytes() {
+    return getMessageData().getResponseData().getOutputBytes();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,31 +64,26 @@ public class GetRecordStatusResponse extends RequestResponse<GetRecordStatusResp
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * Whether the output is paused
      */
-    @NonNull
     private Boolean outputPaused;
 
     /**
      * Current formatted timecode string for the output
      */
-    @NonNull
     private String outputTimecode;
 
     /**
      * Current duration in milliseconds for the output
      */
-    @NonNull
     private Number outputDuration;
 
     /**
      * Number of bytes sent by the output
      */
-    @NonNull
     private Number outputBytes;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/record/StopRecordResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/record/StopRecordResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.record;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class StopRecordResponse extends RequestResponse<StopRecordResponse.SpecificData> {
+  /**
+   * File name for the saved recording
+   *
+   * @return the outputPath
+   */
+  public String getOutputPath() {
+    return getMessageData().getResponseData().getOutputPath();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class StopRecordResponse extends RequestResponse<StopRecordResponse.Speci
     /**
      * File name for the saved recording
      */
-    @NonNull
     private String outputPath;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/CreateSceneItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/CreateSceneItemResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class CreateSceneItemResponse extends RequestResponse<CreateSceneItemResponse.SpecificData> {
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getResponseData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class CreateSceneItemResponse extends RequestResponse<CreateSceneItemResp
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/DuplicateSceneItemResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/DuplicateSceneItemResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class DuplicateSceneItemResponse extends RequestResponse<DuplicateSceneItemResponse.SpecificData> {
+  /**
+   * Numeric ID of the duplicated scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getResponseData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class DuplicateSceneItemResponse extends RequestResponse<DuplicateSceneIt
     /**
      * Numeric ID of the duplicated scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetGroupSceneItemListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetGroupSceneItemListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.SceneItem;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetGroupSceneItemListResponse extends RequestResponse<GetGroupSceneItemListResponse.SpecificData> {
+  /**
+   * Array of scene items in the group
+   *
+   * @return the sceneItems
+   */
+  public List<SceneItem> getSceneItems() {
+    return getMessageData().getResponseData().getSceneItems();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetGroupSceneItemListResponse extends RequestResponse<GetGroupScene
     /**
      * Array of scene items in the group
      */
-    @NonNull
     @Singular
     private List<SceneItem> sceneItems;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemBlendModeResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemBlendModeResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemBlendModeResponse extends RequestResponse<GetSceneItemBlendModeResponse.SpecificData> {
+  /**
+   * Current blend mode
+   *
+   * @return the sceneItemBlendMode
+   */
+  public String getSceneItemBlendMode() {
+    return getMessageData().getResponseData().getSceneItemBlendMode();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSceneItemBlendModeResponse extends RequestResponse<GetSceneItemB
     /**
      * Current blend mode
      */
-    @NonNull
     private String sceneItemBlendMode;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemEnabledResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemEnabledResponse extends RequestResponse<GetSceneItemEnabledResponse.SpecificData> {
+  /**
+   * Whether the scene item is enabled. `true` for enabled, `false` for disabled
+   *
+   * @return the sceneItemEnabled
+   */
+  public Boolean getSceneItemEnabled() {
+    return getMessageData().getResponseData().getSceneItemEnabled();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSceneItemEnabledResponse extends RequestResponse<GetSceneItemEna
     /**
      * Whether the scene item is enabled. `true` for enabled, `false` for disabled
      */
-    @NonNull
     private Boolean sceneItemEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemIdResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemIdResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemIdResponse extends RequestResponse<GetSceneItemIdResponse.SpecificData> {
+  /**
+   * Numeric ID of the scene item
+   *
+   * @return the sceneItemId
+   */
+  public Number getSceneItemId() {
+    return getMessageData().getResponseData().getSceneItemId();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSceneItemIdResponse extends RequestResponse<GetSceneItemIdRespon
     /**
      * Numeric ID of the scene item
      */
-    @NonNull
     private Number sceneItemId;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemIndexResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemIndexResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemIndexResponse extends RequestResponse<GetSceneItemIndexResponse.SpecificData> {
+  /**
+   * Index position of the scene item
+   *
+   * @return the sceneItemIndex
+   */
+  public Number getSceneItemIndex() {
+    return getMessageData().getResponseData().getSceneItemIndex();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSceneItemIndexResponse extends RequestResponse<GetSceneItemIndex
     /**
      * Index position of the scene item
      */
-    @NonNull
     private Number sceneItemIndex;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.SceneItem;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemListResponse extends RequestResponse<GetSceneItemListResponse.SpecificData> {
+  /**
+   * Array of scene items in the scene
+   *
+   * @return the sceneItems
+   */
+  public List<SceneItem> getSceneItems() {
+    return getMessageData().getResponseData().getSceneItems();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetSceneItemListResponse extends RequestResponse<GetSceneItemListRe
     /**
      * Array of scene items in the scene
      */
-    @NonNull
     @Singular
     private List<SceneItem> sceneItems;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemLockedResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemLockedResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sceneitems;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemLockedResponse extends RequestResponse<GetSceneItemLockedResponse.SpecificData> {
+  /**
+   * Whether the scene item is locked. `true` for locked, `false` for unlocked
+   *
+   * @return the sceneItemLocked
+   */
+  public Boolean getSceneItemLocked() {
+    return getMessageData().getResponseData().getSceneItemLocked();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSceneItemLockedResponse extends RequestResponse<GetSceneItemLock
     /**
      * Whether the scene item is locked. `true` for locked, `false` for unlocked
      */
-    @NonNull
     private Boolean sceneItemLocked;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemTransformResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sceneitems/GetSceneItemTransformResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import io.obswebsocket.community.client.model.SceneItem;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneItemTransformResponse extends RequestResponse<GetSceneItemTransformResponse.SpecificData> {
+  /**
+   * Object containing scene item transform info
+   *
+   * @return the sceneItemTransform
+   */
+  public SceneItem.Transform getSceneItemTransform() {
+    return getMessageData().getResponseData().getSceneItemTransform();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,7 +29,6 @@ public class GetSceneItemTransformResponse extends RequestResponse<GetSceneItemT
     /**
      * Object containing scene item transform info
      */
-    @NonNull
     private SceneItem.Transform sceneItemTransform;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentPreviewSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentPreviewSceneResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.scenes;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetCurrentPreviewSceneResponse extends RequestResponse<GetCurrentPreviewSceneResponse.SpecificData> {
+  /**
+   * Current preview scene
+   *
+   * @return the currentPreviewSceneName
+   */
+  public String getCurrentPreviewSceneName() {
+    return getMessageData().getResponseData().getCurrentPreviewSceneName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetCurrentPreviewSceneResponse extends RequestResponse<GetCurrentPr
     /**
      * Current preview scene
      */
-    @NonNull
     private String currentPreviewSceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentProgramSceneResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetCurrentProgramSceneResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.scenes;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetCurrentProgramSceneResponse extends RequestResponse<GetCurrentProgramSceneResponse.SpecificData> {
+  /**
+   * Current program scene
+   *
+   * @return the currentProgramSceneName
+   */
+  public String getCurrentProgramSceneName() {
+    return getMessageData().getResponseData().getCurrentProgramSceneName();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetCurrentProgramSceneResponse extends RequestResponse<GetCurrentPr
     /**
      * Current program scene
      */
-    @NonNull
     private String currentProgramSceneName;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetGroupListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetGroupListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetGroupListResponse extends RequestResponse<GetGroupListResponse.SpecificData> {
+  /**
+   * Array of group names
+   *
+   * @return the groups
+   */
+  public List<String> getGroups() {
+    return getMessageData().getResponseData().getGroups();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,7 +30,6 @@ public class GetGroupListResponse extends RequestResponse<GetGroupListResponse.S
     /**
      * Array of group names
      */
-    @NonNull
     @Singular
     private List<String> groups;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Scene;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,33 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneListResponse extends RequestResponse<GetSceneListResponse.SpecificData> {
+  /**
+   * Current program scene
+   *
+   * @return the currentProgramSceneName
+   */
+  public String getCurrentProgramSceneName() {
+    return getMessageData().getResponseData().getCurrentProgramSceneName();
+  }
+
+  /**
+   * Current preview scene. `null` if not in studio mode
+   *
+   * @return the currentPreviewSceneName
+   */
+  public String getCurrentPreviewSceneName() {
+    return getMessageData().getResponseData().getCurrentPreviewSceneName();
+  }
+
+  /**
+   * Array of scenes
+   *
+   * @return the scenes
+   */
+  public List<Scene> getScenes() {
+    return getMessageData().getResponseData().getScenes();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,19 +49,16 @@ public class GetSceneListResponse extends RequestResponse<GetSceneListResponse.S
     /**
      * Current program scene
      */
-    @NonNull
     private String currentProgramSceneName;
 
     /**
      * Current preview scene. `null` if not in studio mode
      */
-    @NonNull
     private String currentPreviewSceneName;
 
     /**
      * Array of scenes
      */
-    @NonNull
     @Singular
     private List<Scene> scenes;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneSceneTransitionOverrideResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/scenes/GetSceneSceneTransitionOverrideResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.scenes;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneSceneTransitionOverrideResponse extends RequestResponse<GetSceneSceneTransitionOverrideResponse.SpecificData> {
+  /**
+   * Name of the overridden scene transition, else `null`
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getResponseData().getTransitionName();
+  }
+
+  /**
+   * Duration of the overridden scene transition, else `null`
+   *
+   * @return the transitionDuration
+   */
+  public Number getTransitionDuration() {
+    return getMessageData().getResponseData().getTransitionDuration();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,13 +37,11 @@ public class GetSceneSceneTransitionOverrideResponse extends RequestResponse<Get
     /**
      * Name of the overridden scene transition, else `null`
      */
-    @NonNull
     private String transitionName;
 
     /**
      * Duration of the overridden scene transition, else `null`
      */
-    @NonNull
     private Number transitionDuration;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceActiveResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceActiveResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sources;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,24 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSourceActiveResponse extends RequestResponse<GetSourceActiveResponse.SpecificData> {
+  /**
+   * Whether the source is showing in Program
+   *
+   * @return the videoActive
+   */
+  public Boolean getVideoActive() {
+    return getMessageData().getResponseData().getVideoActive();
+  }
+
+  /**
+   * Whether the source is showing in the UI (Preview, Projector, Properties)
+   *
+   * @return the videoShowing
+   */
+  public Boolean getVideoShowing() {
+    return getMessageData().getResponseData().getVideoShowing();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,13 +37,11 @@ public class GetSourceActiveResponse extends RequestResponse<GetSourceActiveResp
     /**
      * Whether the source is showing in Program
      */
-    @NonNull
     private Boolean videoActive;
 
     /**
      * Whether the source is showing in the UI (Preview, Projector, Properties)
      */
-    @NonNull
     private Boolean videoShowing;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceScreenshotResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/GetSourceScreenshotResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sources;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSourceScreenshotResponse extends RequestResponse<GetSourceScreenshotResponse.SpecificData> {
+  /**
+   * Base64-encoded screenshot
+   *
+   * @return the imageData
+   */
+  public String getImageData() {
+    return getMessageData().getResponseData().getImageData();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetSourceScreenshotResponse extends RequestResponse<GetSourceScreen
     /**
      * Base64-encoded screenshot
      */
-    @NonNull
     private String imageData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/sources/SaveSourceScreenshotResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/sources/SaveSourceScreenshotResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.sources;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class SaveSourceScreenshotResponse extends RequestResponse<SaveSourceScreenshotResponse.SpecificData> {
+  /**
+   * Base64-encoded screenshot
+   *
+   * @return the imageData
+   */
+  public String getImageData() {
+    return getMessageData().getResponseData().getImageData();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class SaveSourceScreenshotResponse extends RequestResponse<SaveSourceScre
     /**
      * Base64-encoded screenshot
      */
-    @NonNull
     private String imageData;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamStatusResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/GetStreamStatusResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.stream;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,78 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetStreamStatusResponse extends RequestResponse<GetStreamStatusResponse.SpecificData> {
+  /**
+   * Whether the output is active
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
+  /**
+   * Whether the output is currently reconnecting
+   *
+   * @return the outputReconnecting
+   */
+  public Boolean getOutputReconnecting() {
+    return getMessageData().getResponseData().getOutputReconnecting();
+  }
+
+  /**
+   * Current formatted timecode string for the output
+   *
+   * @return the outputTimecode
+   */
+  public String getOutputTimecode() {
+    return getMessageData().getResponseData().getOutputTimecode();
+  }
+
+  /**
+   * Current duration in milliseconds for the output
+   *
+   * @return the outputDuration
+   */
+  public Number getOutputDuration() {
+    return getMessageData().getResponseData().getOutputDuration();
+  }
+
+  /**
+   * Congestion of the output
+   *
+   * @return the outputCongestion
+   */
+  public Number getOutputCongestion() {
+    return getMessageData().getResponseData().getOutputCongestion();
+  }
+
+  /**
+   * Number of bytes sent by the output
+   *
+   * @return the outputBytes
+   */
+  public Number getOutputBytes() {
+    return getMessageData().getResponseData().getOutputBytes();
+  }
+
+  /**
+   * Number of frames skipped by the output's process
+   *
+   * @return the outputSkippedFrames
+   */
+  public Number getOutputSkippedFrames() {
+    return getMessageData().getResponseData().getOutputSkippedFrames();
+  }
+
+  /**
+   * Total number of frames delivered by the output's process
+   *
+   * @return the outputTotalFrames
+   */
+  public Number getOutputTotalFrames() {
+    return getMessageData().getResponseData().getOutputTotalFrames();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,49 +91,41 @@ public class GetStreamStatusResponse extends RequestResponse<GetStreamStatusResp
     /**
      * Whether the output is active
      */
-    @NonNull
     private Boolean outputActive;
 
     /**
      * Whether the output is currently reconnecting
      */
-    @NonNull
     private Boolean outputReconnecting;
 
     /**
      * Current formatted timecode string for the output
      */
-    @NonNull
     private String outputTimecode;
 
     /**
      * Current duration in milliseconds for the output
      */
-    @NonNull
     private Number outputDuration;
 
     /**
      * Congestion of the output
      */
-    @NonNull
     private Number outputCongestion;
 
     /**
      * Number of bytes sent by the output
      */
-    @NonNull
     private Number outputBytes;
 
     /**
      * Number of frames skipped by the output's process
      */
-    @NonNull
     private Number outputSkippedFrames;
 
     /**
      * Total number of frames delivered by the output's process
      */
-    @NonNull
     private Number outputTotalFrames;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/stream/ToggleStreamResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/stream/ToggleStreamResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.stream;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class ToggleStreamResponse extends RequestResponse<ToggleStreamResponse.SpecificData> {
+  /**
+   * New state of the stream output
+   *
+   * @return the outputActive
+   */
+  public Boolean getOutputActive() {
+    return getMessageData().getResponseData().getOutputActive();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class ToggleStreamResponse extends RequestResponse<ToggleStreamResponse.S
     /**
      * New state of the stream output
      */
-    @NonNull
     private Boolean outputActive;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentSceneTransitionCursorResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentSceneTransitionCursorResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.transitions;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetCurrentSceneTransitionCursorResponse extends RequestResponse<GetCurrentSceneTransitionCursorResponse.SpecificData> {
+  /**
+   * Cursor position, between 0.0 and 1.0
+   *
+   * @return the transitionCursor
+   */
+  public Number getTransitionCursor() {
+    return getMessageData().getResponseData().getTransitionCursor();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetCurrentSceneTransitionCursorResponse extends RequestResponse<Get
     /**
      * Cursor position, between 0.0 and 1.0
      */
-    @NonNull
     private Number transitionCursor;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentSceneTransitionResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetCurrentSceneTransitionResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,60 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetCurrentSceneTransitionResponse extends RequestResponse<GetCurrentSceneTransitionResponse.SpecificData> {
+  /**
+   * Name of the transition
+   *
+   * @return the transitionName
+   */
+  public String getTransitionName() {
+    return getMessageData().getResponseData().getTransitionName();
+  }
+
+  /**
+   * Kind of the transition
+   *
+   * @return the transitionKind
+   */
+  public String getTransitionKind() {
+    return getMessageData().getResponseData().getTransitionKind();
+  }
+
+  /**
+   * Whether the transition uses a fixed (unconfigurable) duration
+   *
+   * @return the transitionFixed
+   */
+  public Boolean getTransitionFixed() {
+    return getMessageData().getResponseData().getTransitionFixed();
+  }
+
+  /**
+   * Configured transition duration in milliseconds. `null` if transition is fixed
+   *
+   * @return the transitionDuration
+   */
+  public Number getTransitionDuration() {
+    return getMessageData().getResponseData().getTransitionDuration();
+  }
+
+  /**
+   * Whether the transition supports being configured
+   *
+   * @return the transitionConfigurable
+   */
+  public Boolean getTransitionConfigurable() {
+    return getMessageData().getResponseData().getTransitionConfigurable();
+  }
+
+  /**
+   * Object of settings for the transition. `null` if transition is not configurable
+   *
+   * @return the transitionSettings
+   */
+  public JsonObject getTransitionSettings() {
+    return getMessageData().getResponseData().getTransitionSettings();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,37 +74,31 @@ public class GetCurrentSceneTransitionResponse extends RequestResponse<GetCurren
     /**
      * Name of the transition
      */
-    @NonNull
     private String transitionName;
 
     /**
      * Kind of the transition
      */
-    @NonNull
     private String transitionKind;
 
     /**
      * Whether the transition uses a fixed (unconfigurable) duration
      */
-    @NonNull
     private Boolean transitionFixed;
 
     /**
      * Configured transition duration in milliseconds. `null` if transition is fixed
      */
-    @NonNull
     private Number transitionDuration;
 
     /**
      * Whether the transition supports being configured
      */
-    @NonNull
     private Boolean transitionConfigurable;
 
     /**
      * Object of settings for the transition. `null` if transition is not configurable
      */
-    @NonNull
     private JsonObject transitionSettings;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetSceneTransitionListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetSceneTransitionListResponse.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -14,6 +13,33 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetSceneTransitionListResponse extends RequestResponse<GetSceneTransitionListResponse.SpecificData> {
+  /**
+   * Name of the current scene transition. Can be null
+   *
+   * @return the currentSceneTransitionName
+   */
+  public String getCurrentSceneTransitionName() {
+    return getMessageData().getResponseData().getCurrentSceneTransitionName();
+  }
+
+  /**
+   * Kind of the current scene transition. Can be null
+   *
+   * @return the currentSceneTransitionKind
+   */
+  public String getCurrentSceneTransitionKind() {
+    return getMessageData().getResponseData().getCurrentSceneTransitionKind();
+  }
+
+  /**
+   * Array of transitions
+   *
+   * @return the transitions
+   */
+  public JsonObject getTransitions() {
+    return getMessageData().getResponseData().getTransitions();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -21,19 +47,16 @@ public class GetSceneTransitionListResponse extends RequestResponse<GetSceneTran
     /**
      * Name of the current scene transition. Can be null
      */
-    @NonNull
     private String currentSceneTransitionName;
 
     /**
      * Kind of the current scene transition. Can be null
      */
-    @NonNull
     private String currentSceneTransitionKind;
 
     /**
      * Array of transitions
      */
-    @NonNull
     private JsonObject transitions;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionKindListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/transitions/GetTransitionKindListResponse.java
@@ -6,7 +6,6 @@ import io.obswebsocket.community.client.message.response.RequestResponse;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -15,6 +14,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetTransitionKindListResponse extends RequestResponse<GetTransitionKindListResponse.SpecificData> {
+  /**
+   * Array of transition kinds
+   *
+   * @return the transitionKinds
+   */
+  public List<String> getTransitionKinds() {
+    return getMessageData().getResponseData().getTransitionKinds();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -22,7 +30,6 @@ public class GetTransitionKindListResponse extends RequestResponse<GetTransition
     /**
      * Array of transition kinds
      */
-    @NonNull
     @Singular
     private List<String> transitionKinds;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/ui/GetMonitorListResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/ui/GetMonitorListResponse.java
@@ -7,7 +7,6 @@ import io.obswebsocket.community.client.model.Monitor;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -16,6 +15,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetMonitorListResponse extends RequestResponse<GetMonitorListResponse.SpecificData> {
+  /**
+   * a list of detected monitors with some information
+   *
+   * @return the monitors
+   */
+  public List<Monitor> getMonitors() {
+    return getMessageData().getResponseData().getMonitors();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -23,7 +31,6 @@ public class GetMonitorListResponse extends RequestResponse<GetMonitorListRespon
     /**
      * a list of detected monitors with some information
      */
-    @NonNull
     @Singular
     private List<Monitor> monitors;
   }

--- a/client/src/main/java/io/obswebsocket/community/client/message/response/ui/GetStudioModeEnabledResponse.java
+++ b/client/src/main/java/io/obswebsocket/community/client/message/response/ui/GetStudioModeEnabledResponse.java
@@ -5,7 +5,6 @@ package io.obswebsocket.community.client.message.response.ui;
 import io.obswebsocket.community.client.message.response.RequestResponse;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -13,6 +12,15 @@ import lombok.ToString;
     callSuper = true
 )
 public class GetStudioModeEnabledResponse extends RequestResponse<GetStudioModeEnabledResponse.SpecificData> {
+  /**
+   * Whether studio mode is enabled
+   *
+   * @return the studioModeEnabled
+   */
+  public Boolean getStudioModeEnabled() {
+    return getMessageData().getResponseData().getStudioModeEnabled();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -20,7 +28,6 @@ public class GetStudioModeEnabledResponse extends RequestResponse<GetStudioModeE
     /**
      * Whether studio mode is enabled
      */
-    @NonNull
     private Boolean studioModeEnabled;
   }
 }

--- a/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
+++ b/client/src/main/java/io/obswebsocket/community/client/model/Scene.java
@@ -12,5 +12,5 @@ import lombok.ToString;
 public class Scene {
 
   private String sceneName;
-  private Integer sceneItemIndex;
+  private Integer sceneIndex;
 }

--- a/client/src/test/resources/events/scenes/SceneListChanged.json
+++ b/client/src/test/resources/events/scenes/SceneListChanged.json
@@ -7,11 +7,11 @@
       "scenes": [
         {
           "sceneName": "Scene 1",
-          "sceneItemIndex": 0
+          "sceneIndex": 0
         },
         {
           "sceneName": "Scene 2",
-          "sceneItemIndex": 1
+          "sceneIndex": 1
         }
       ]
     }

--- a/client/src/test/resources/responses/scenes/GetSceneListResponse.json
+++ b/client/src/test/resources/responses/scenes/GetSceneListResponse.json
@@ -12,7 +12,7 @@
       "scenes": [
         {
           "sceneName": "Scene Name",
-          "sceneItemIndex": 1
+          "sceneIndex": 1
         }
       ]
     }

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -43,26 +43,27 @@ public class Example {
   }
 
   private void onFirstConnection() {
+    // Send a blocking call (last parameter is a timeout instead of a callback)
+    this.obsRemoteController.setStudioModeEnabled(true, 1000);
+
     // Send a request through a convenience method
     this.obsRemoteController.getSceneList(getSceneListResponse -> {
       if (getSceneListResponse.isSuccessful()) {
         // Print each Scene
-        getSceneListResponse.getMessageData().getResponseData().getScenes()
-            .forEach(System.out::println);
+        getSceneListResponse.getScenes().forEach(System.out::println);
       }
 
+      this.obsRemoteController.setStudioModeEnabled(false, 1000);
       this.disconnectAndReconnect();
     });
   }
 
   private void onSecondConnection() {
-    // Send a Request through  specific Request builder
+    // Send a Request through specific Request builder
     this.obsRemoteController.sendRequest(GetStudioModeEnabledRequest.builder().build(),
-        requestResponse -> {
+        (GetStudioModeEnabledResponse requestResponse) -> {
           if (requestResponse.isSuccessful()) {
-            GetStudioModeEnabledResponse getStudioModeEnabledResponse = (GetStudioModeEnabledResponse) requestResponse;
-            if (getStudioModeEnabledResponse.getMessageData().getResponseData()
-                .getStudioModeEnabled()) {
+            if (requestResponse.getStudioModeEnabled()) {
               System.out.println("Studio mode enabled");
             } else {
               System.out.println("Studio mode not enabled");
@@ -88,6 +89,6 @@ public class Example {
   private void onStudioModeStateChanged(StudioModeStateChangedEvent studioModeStateChangedEvent) {
     System.out.printf(
         "Studio Mode State Changed to: %B%n",
-        studioModeStateChangedEvent.getMessageData().getEventData().getStudioModeEnabled());
+        studioModeStateChangedEvent.getStudioModeEnabled());
   }
 }

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/EventGenerator.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/EventGenerator.java
@@ -46,21 +46,21 @@ public class EventGenerator extends GeneratorBase {
         req.getCategory() + "/" + req.getEventType() + "Event.java");
   }
 
-  void generateEvent(Event request, PrintStream out) throws IOException {
-    String pkg = BASE_PACKAGE + request.getCategory();
-    String className = request.getEventType() + "Event";
+  void generateEvent(Event event, PrintStream out) throws IOException {
+    String pkg = BASE_PACKAGE + event.getCategory();
+    String className = event.getEventType() + "Event";
 
-    TypeSpec specificData = buildSpecificData(request.getEventType(),
-        request.getDataFields(), true);
+    TypeSpec specificData = buildSpecificData(event.getEventType(),
+        event.getDataFields(), true);
 
     TypeSpec.Builder classTypeBuilder = TypeSpec.classBuilder(className).addModifiers(PUBLIC)
         .addAnnotation(Getter.class).addAnnotation(
             AnnotationSpec.builder(ToString.class).addMember("callSuper", "$L", true).build())
-        .addJavadoc(request.getDescription());
+        .addJavadoc(event.getDescription());
 
     classTypeBuilder.addMethod(MethodSpec.constructorBuilder()
         .addModifiers(PROTECTED)
-        .addStatement("super(Intent.$L)", request.getEventSubscription())
+        .addStatement("super(Intent.$L)", event.getEventSubscription())
         .build());
 
     if (specificData != null) {
@@ -73,13 +73,14 @@ public class EventGenerator extends GeneratorBase {
       classTypeBuilder.addMethod(MethodSpec.constructorBuilder()
           .addModifiers(PROTECTED)
           .addParameter(specificDataClass, "data")
-          .addStatement("super(Intent.$L, data)", request.getEventSubscription())
+          .addStatement("super(Intent.$L, data)", event.getEventSubscription())
           .build());
     } else {
       classTypeBuilder.superclass(ParameterizedTypeName.get(
           ClassName.get(io.obswebsocket.community.client.message.event.Event.class),
           ClassName.get("", "Void")));
     }
+    addGetters(MessageClass.Event, event.getEventType(), event.getDataFields(), classTypeBuilder);
     TypeSpec classType = classTypeBuilder.build();
 
     JavaFile javaFile = javaFileBuilder(pkg, classType).build();

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
@@ -74,7 +74,7 @@ public class GeneratorBase {
     fields.forEach(field -> {
       FieldSpec.Builder fldBuilder = FieldSpec.builder(determineType(request, field),
           field.getValueName(), PRIVATE);
-      if (!Boolean.TRUE.equals(field.valueOptional)) {
+      if (!response && !Boolean.TRUE.equals(field.valueOptional)) {
         fldBuilder.addAnnotation(NonNull.class);
       }
       if (field.getValueType().startsWith("Array") && field.getValueName().endsWith("s")) {

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
@@ -87,6 +88,26 @@ public class GeneratorBase {
     });
 
     return specificData.build();
+  }
+
+  protected enum MessageClass {
+    Event, Response
+  }
+
+  protected void addGetters(MessageClass cls, String messageType, List<RequestField> fields, TypeSpec.Builder classTypeBuilder) {
+    fields.forEach(field -> {
+      String valueFirstUc = Character.toUpperCase(field.getValueName().charAt(0)) +
+          field.getValueName().substring(1);
+
+      classTypeBuilder.addMethod(MethodSpec
+          .methodBuilder("get" + valueFirstUc)
+          .addModifiers(PUBLIC)
+          .returns(determineType(messageType, field))
+          .addStatement("return getMessageData().get$LData().get$L()", cls.name(), valueFirstUc)
+          .addJavadoc(field.getValueDescription())
+          .addJavadoc("@return the $L", field.getValueName())
+          .build());
+    });
   }
 
   private static final Pattern ARRAY_PATTERN = Pattern.compile("Array<(.*)>");

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/GeneratorBase.java
@@ -105,7 +105,7 @@ public class GeneratorBase {
           .returns(determineType(messageType, field))
           .addStatement("return getMessageData().get$LData().get$L()", cls.name(), valueFirstUc)
           .addJavadoc(field.getValueDescription())
-          .addJavadoc("@return the $L", field.getValueName())
+          .addJavadoc("\n\n@return the $L", field.getValueName())
           .build());
     });
   }

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/OBSRemoteControllerBaseGenerator.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/OBSRemoteControllerBaseGenerator.java
@@ -86,15 +86,15 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
         .forEach(
             rf -> builder.addParameter(determineType(req.getRequestType(), rf), rf.getValueName()));
 
+    ClassName responseType = ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(),
+        type + "Response");
     if (!blocking) {
       builder.addParameter(
-          ParameterizedTypeName.get(ClassName.get(Consumer.class),
-              ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response")),
+          ParameterizedTypeName.get(ClassName.get(Consumer.class), responseType),
           "callback");
     } else {
       builder.addParameter(TypeName.LONG, "timeout");
-      builder.returns(
-          ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response"));
+      builder.returns(responseType);
     }
 
     // Body
@@ -102,7 +102,7 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
     if (blocking) {
       ParameterizedTypeName blockingConsumer = ParameterizedTypeName.get(
           ClassName.get(OBSRemoteControllerBase.class.getPackage().getName(), "BlockingConsumer"),
-          ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response"));
+          responseType);
       builder.addStatement("$T callback = new $T()", blockingConsumer, blockingConsumer);
     }
 
@@ -128,6 +128,7 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
       builder.addJavadoc("\n@param callback Consumer&lt;$L&gt;", type + "Response");
     } else {
       builder.addJavadoc("\n@param timeout long timeout in ms");
+      builder.addJavadoc("\n@return the $T, null if the request timed out", responseType);
     }
 
     classTypeBuilder.addMethod(builder.build());

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/OBSRemoteControllerBaseGenerator.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/OBSRemoteControllerBaseGenerator.java
@@ -8,6 +8,7 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeSpec.Builder;
 import com.squareup.javapoet.TypeVariableName;
@@ -46,7 +47,10 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
             .addModifiers(PUBLIC, ABSTRACT)
             .addMethod(generateAbstractSendRequest());
 
-    protocol.getRequests().forEach(req -> addMethodFor(classTypeBuilder, req));
+    protocol.getRequests().forEach(req -> {
+      addMethodFor(classTypeBuilder, req, false);
+      addMethodFor(classTypeBuilder, req, true);
+    });
 
     JavaFile javaFile = javaFileBuilder(OBSRemoteControllerBase.class.getPackage().getName(),
         classTypeBuilder.build()).build();
@@ -70,7 +74,8 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
   }
 
   private void addMethodFor(Builder classTypeBuilder,
-      io.obswebsocket.community.generator.model.generated.Request req) {
+      io.obswebsocket.community.generator.model.generated.Request req,
+      boolean blocking) {
 
     String type = req.getRequestType();
     MethodSpec.Builder builder = MethodSpec.methodBuilder(
@@ -81,28 +86,49 @@ public class OBSRemoteControllerBaseGenerator extends GeneratorBase {
         .forEach(
             rf -> builder.addParameter(determineType(req.getRequestType(), rf), rf.getValueName()));
 
-    builder.addParameter(
-        ParameterizedTypeName.get(ClassName.get(Consumer.class),
-            ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response")),
-        "callback");
+    if (!blocking) {
+      builder.addParameter(
+          ParameterizedTypeName.get(ClassName.get(Consumer.class),
+              ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response")),
+          "callback");
+    } else {
+      builder.addParameter(TypeName.LONG, "timeout");
+      builder.returns(
+          ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response"));
+    }
 
     // Body
     CodeBlock.Builder bodyBuilder = CodeBlock.builder();
+    if (blocking) {
+      ParameterizedTypeName blockingConsumer = ParameterizedTypeName.get(
+          ClassName.get(OBSRemoteControllerBase.class.getPackage().getName(), "BlockingConsumer"),
+          ClassName.get(ResponseGenerator.BASE_PACKAGE + req.getCategory(), type + "Response"));
+      builder.addStatement("$T callback = new $T()", blockingConsumer, blockingConsumer);
+    }
+
     bodyBuilder.add("sendRequest(");
     bodyBuilder.add("$T.builder()", ClassName.get(RequestGenerator.BASE_PACKAGE + req.getCategory(),
         req.getRequestType() + "Request"));
     req.getRequestFields()
         .forEach(rf -> bodyBuilder.add(".$L($L)", rf.getValueName(), rf.getValueName()));
-    bodyBuilder.add(".build()");
-    bodyBuilder.add(", callback)");
+    bodyBuilder.add(".build(), callback)");
     builder.addStatement(bodyBuilder.build());
+    if (blocking) {
+      builder.addCode("try { return callback.get(timeout); } catch ($T e) { throw new $T(e); }",
+          ClassName.get(InterruptedException.class), ClassName.get(RuntimeException.class));
+    }
 
     builder.addJavadoc("$L\n", req.getDescription().replace("\\u", "\\\\u"));
     req.getRequestFields()
         .forEach(rf ->
             builder.addJavadoc("\n@param $L $L", rf.getValueName(),
-                rf.getValueDescription().replace("\\u", "\\\\u").replaceAll("<", "&lt;").replaceAll(">", "&gt;")));
-    builder.addJavadoc("\n@param callback Consumer&lt;$L&gt;", type + "Response");
+                rf.getValueDescription().replace("\\u", "\\\\u").replaceAll("<", "&lt;")
+                    .replaceAll(">", "&gt;")));
+    if (!blocking) {
+      builder.addJavadoc("\n@param callback Consumer&lt;$L&gt;", type + "Response");
+    } else {
+      builder.addJavadoc("\n@param timeout long timeout in ms");
+    }
 
     classTypeBuilder.addMethod(builder.build());
   }

--- a/messagegenerator/src/main/java/io/obswebsocket/community/generator/ResponseGenerator.java
+++ b/messagegenerator/src/main/java/io/obswebsocket/community/generator/ResponseGenerator.java
@@ -65,6 +65,9 @@ public class ResponseGenerator extends GeneratorBase {
           ClassName.get(RequestResponse.class),
           ClassName.get("", "Void")));
     }
+
+    addGetters(MessageClass.Response, request.getRequestType(), request.getResponseFields(), classTypeBuilder);
+
     TypeSpec classType = classTypeBuilder.build();
 
     JavaFile javaFile = javaFileBuilder(pkg, classType).build();

--- a/messagegenerator/src/test/resources/EventWithParameters.java
+++ b/messagegenerator/src/test/resources/EventWithParameters.java
@@ -9,7 +9,6 @@ import io.obswebsocket.community.client.model.Scene;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -28,6 +27,69 @@ public class TypeEvent extends Event<TypeEvent.SpecificData> {
     super(Intent.subscription, data);
   }
 
+  /**
+   * stringField description
+   *
+   * @return the stringField
+   */
+  public String getStringField() {
+    return getMessageData().getEventData().getStringField();
+  }
+
+  /**
+   * booleanField description
+   *
+   * @return the booleanField
+   */
+  public Boolean getBooleanField() {
+    return getMessageData().getEventData().getBooleanField();
+  }
+
+  /**
+   * booleanList description
+   *
+   * @return the booleanList
+   */
+  public List<Boolean> getBooleanList() {
+    return getMessageData().getEventData().getBooleanList();
+  }
+
+  /**
+   * stringList description
+   *
+   * @return the stringList
+   */
+  public List<String> getStringList() {
+    return getMessageData().getEventData().getStringList();
+  }
+
+  /**
+   * audioTracks description
+   *
+   * @return the audioTracks
+   */
+  public Input.AudioTracks getAudioTracks() {
+    return getMessageData().getEventData().getAudioTracks();
+  }
+
+  /**
+   * jsonObject description
+   *
+   * @return the jsonObject
+   */
+  public JsonObject getJsonObject() {
+    return getMessageData().getEventData().getJsonObject();
+  }
+
+  /**
+   * sceneList description
+   *
+   * @return the sceneList
+   */
+  public List<Scene> getSceneList() {
+    return getMessageData().getEventData().getSceneList();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -35,43 +97,36 @@ public class TypeEvent extends Event<TypeEvent.SpecificData> {
     /**
      * stringField description
      */
-    @NonNull
     private String stringField;
 
     /**
      * booleanField description
      */
-    @NonNull
     private Boolean booleanField;
 
     /**
      * booleanList description
      */
-    @NonNull
     private List<Boolean> booleanList;
 
     /**
      * stringList description
      */
-    @NonNull
     private List<String> stringList;
 
     /**
      * audioTracks description
      */
-    @NonNull
     private Input.AudioTracks audioTracks;
 
     /**
      * jsonObject description
      */
-    @NonNull
     private JsonObject jsonObject;
 
     /**
      * sceneList description
      */
-    @NonNull
     private List<Scene> sceneList;
   }
 }

--- a/messagegenerator/src/test/resources/OBSRemoteControllerBaseGenerator.java
+++ b/messagegenerator/src/test/resources/OBSRemoteControllerBaseGenerator.java
@@ -31,6 +31,7 @@ public abstract class OBSRemoteControllerBase {
    * Description
    *
    * @param timeout long timeout in ms
+   * @return the SomeTypeResponse, null if the request timed out
    */
   public SomeTypeResponse someType(long timeout) {
     BlockingConsumer<SomeTypeResponse> callback = new BlockingConsumer<SomeTypeResponse>();
@@ -67,6 +68,7 @@ public abstract class OBSRemoteControllerBase {
    * @param jsonObject jsonObject description
    * @param sceneList sceneList description
    * @param timeout long timeout in ms
+   * @return the OtherTypeResponse, null if the request timed out
    */
   public OtherTypeResponse otherType(String stringField, Boolean booleanField,
       List<Boolean> booleanList, List<String> stringList, Input.AudioTracks audioTracks,

--- a/messagegenerator/src/test/resources/OBSRemoteControllerBaseGenerator.java
+++ b/messagegenerator/src/test/resources/OBSRemoteControllerBaseGenerator.java
@@ -28,6 +28,17 @@ public abstract class OBSRemoteControllerBase {
   }
 
   /**
+   * Description
+   *
+   * @param timeout long timeout in ms
+   */
+  public SomeTypeResponse someType(long timeout) {
+    BlockingConsumer<SomeTypeResponse> callback = new BlockingConsumer<SomeTypeResponse>();
+    sendRequest(SomeTypeRequest.builder().build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
+  }
+
+  /**
    * Other description
    *
    * @param stringField stringField description
@@ -43,5 +54,25 @@ public abstract class OBSRemoteControllerBase {
       List<String> stringList, Input.AudioTracks audioTracks, JsonObject jsonObject,
       List<Scene> sceneList, Consumer<OtherTypeResponse> callback) {
     sendRequest(OtherTypeRequest.builder().stringField(stringField).booleanField(booleanField).booleanList(booleanList).stringList(stringList).audioTracks(audioTracks).jsonObject(jsonObject).sceneList(sceneList).build(), callback);
+  }
+
+  /**
+   * Other description
+   *
+   * @param stringField stringField description
+   * @param booleanField booleanField description
+   * @param booleanList booleanList description
+   * @param stringList stringList description
+   * @param audioTracks audioTracks description
+   * @param jsonObject jsonObject description
+   * @param sceneList sceneList description
+   * @param timeout long timeout in ms
+   */
+  public OtherTypeResponse otherType(String stringField, Boolean booleanField,
+      List<Boolean> booleanList, List<String> stringList, Input.AudioTracks audioTracks,
+      JsonObject jsonObject, List<Scene> sceneList, long timeout) {
+    BlockingConsumer<OtherTypeResponse> callback = new BlockingConsumer<OtherTypeResponse>();
+    sendRequest(OtherTypeRequest.builder().stringField(stringField).booleanField(booleanField).booleanList(booleanList).stringList(stringList).audioTracks(audioTracks).jsonObject(jsonObject).sceneList(sceneList).build(), callback);
+    try { return callback.get(timeout); } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
 }

--- a/messagegenerator/src/test/resources/ResponseWithParameters.java
+++ b/messagegenerator/src/test/resources/ResponseWithParameters.java
@@ -9,7 +9,6 @@ import io.obswebsocket.community.client.model.Scene;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
@@ -17,6 +16,69 @@ import lombok.ToString;
     callSuper = true
 )
 public class TypeResponse extends RequestResponse<TypeResponse.SpecificData> {
+  /**
+   * stringField description
+   *
+   * @return the stringField
+   */
+  public String getStringField() {
+    return getMessageData().getResponseData().getStringField();
+  }
+
+  /**
+   * booleanField description
+   *
+   * @return the booleanField
+   */
+  public Boolean getBooleanField() {
+    return getMessageData().getResponseData().getBooleanField();
+  }
+
+  /**
+   * booleanList description
+   *
+   * @return the booleanList
+   */
+  public List<Boolean> getBooleanList() {
+    return getMessageData().getResponseData().getBooleanList();
+  }
+
+  /**
+   * stringList description
+   *
+   * @return the stringList
+   */
+  public List<String> getStringList() {
+    return getMessageData().getResponseData().getStringList();
+  }
+
+  /**
+   * audioTracks description
+   *
+   * @return the audioTracks
+   */
+  public Input.AudioTracks getAudioTracks() {
+    return getMessageData().getResponseData().getAudioTracks();
+  }
+
+  /**
+   * jsonObject description
+   *
+   * @return the jsonObject
+   */
+  public JsonObject getJsonObject() {
+    return getMessageData().getResponseData().getJsonObject();
+  }
+
+  /**
+   * sceneList description
+   *
+   * @return the sceneList
+   */
+  public List<Scene> getSceneList() {
+    return getMessageData().getResponseData().getSceneList();
+  }
+
   @Getter
   @ToString
   @Builder
@@ -24,43 +86,36 @@ public class TypeResponse extends RequestResponse<TypeResponse.SpecificData> {
     /**
      * stringField description
      */
-    @NonNull
     private String stringField;
 
     /**
      * booleanField description
      */
-    @NonNull
     private Boolean booleanField;
 
     /**
      * booleanList description
      */
-    @NonNull
     private List<Boolean> booleanList;
 
     /**
      * stringList description
      */
-    @NonNull
     private List<String> stringList;
 
     /**
      * audioTracks description
      */
-    @NonNull
     private Input.AudioTracks audioTracks;
 
     /**
      * jsonObject description
      */
-    @NonNull
     private JsonObject jsonObject;
 
     /**
      * sceneList description
      */
-    @NonNull
     private List<Scene> sceneList;
   }
 }


### PR DESCRIPTION
Uncommented the e2e tests and fixed the ones I could. There are still a few in there for which I don't know how to fix them.

Also changed the generator a bit to generate more convenient code. Getters are now directly on the response instead of having to go through the messageData.typeData.field.
Also added methods to the OBSRemoteControllerBase for blocking calls which will return the response instead of having to use the callback method. These were helpful in the tests.

Also updated the example to show both types of usage.