### PR TITLE
fix: don't include simplelogger, add simplelogger to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,11 @@ Individual requests will include a status code(SourceNotFound, HotkeyNotFound, e
 The `onError` communicator and controller lifecycle events are reserved for exceptional events (null pointers and other exceptions) and for failure to connect to OBS (for example, if OBS Websocket isn't installed, if OBS isn't running, or it isn't accessible over the network).
 
 ## Logging
-This project ships with SLF4J as the logging facade, and uses SLF4J-Simple as the logging implementation
-by default (logs are printed directly to the console).
+This project ships with SLF4J as the logging facade.
 
-As with any project using SLF4J, you are free to use a different SLF4J logger implementation. There
+As with any project using SLF4J, you are expected to setup a logger implementation. There
 are many examples of how to do this online; for your convenience we demonstrate below how to 
-configure Maven to use Logback instead:
+configure Maven to use Logback:
 ```xml
 <dependencies>
     <dependency>
@@ -142,13 +141,6 @@ configure Maven to use Logback instead:
         <artifactId>client</artifactId>
         <version>...</version>
       </dependency>
-        <!-- Exclude the default logging implementation -->
-        <exclusions>
-            <exclusion>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
     
     <!-- Add your desired logging implementation -->
@@ -163,9 +155,7 @@ configure Maven to use Logback instead:
 Or with Gradle:
 ```groovy
 dependencies {
-    implementation('io.obs-websocket.community:client:2.0.0') {
-      exclude group: 'org.slf4j', module: 'slf4j-simple'
-    }
+    implementation('io.obs-websocket.community:client:2.0.0')
     implementation 'ch.qos.logback:logback-classic:1.1.7'
 }
 ```

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -19,7 +19,7 @@ def localArchiveBaseName = 'client'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    implementation libs.websocket
+    api libs.websocket
     api libs.gson
     implementation libs.sl4j.api
     compileOnly libs.lombok

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation libs.websocket
     api libs.gson
     implementation libs.sl4j.api
-    implementation libs.sl4j.simple
     compileOnly libs.lombok
     annotationProcessor libs.lombok
 
@@ -33,6 +32,7 @@ dependencies {
     testCompileOnly libs.lombok
     testAnnotationProcessor libs.lombok
     testImplementation libs.mockito.core
+    testImplementation libs.sl4j.simple
 }
 
 java {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,4 +7,5 @@ version = rootProject.file('VERSION').text.trim()
 
 dependencies {
     implementation project(':client')
+    implementation libs.sl4j.simple
 }

--- a/example/src/main/java/io/obswebsocket/community/client/example/Example.java
+++ b/example/src/main/java/io/obswebsocket/community/client/example/Example.java
@@ -1,12 +1,16 @@
 package io.obswebsocket.community.client.example;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import io.obswebsocket.community.client.OBSRemoteController;
 import io.obswebsocket.community.client.message.event.ui.StudioModeStateChangedEvent;
 import io.obswebsocket.community.client.message.request.ui.GetStudioModeEnabledRequest;
 import io.obswebsocket.community.client.message.response.ui.GetStudioModeEnabledResponse;
+import org.slf4j.Logger;
 
 public class Example {
 
+  private static final Logger log = getLogger(Example.class);
   private final OBSRemoteController obsRemoteController;
   private boolean isReconnecting = false;
 
@@ -50,7 +54,7 @@ public class Example {
     this.obsRemoteController.getSceneList(getSceneListResponse -> {
       if (getSceneListResponse.isSuccessful()) {
         // Print each Scene
-        getSceneListResponse.getScenes().forEach(System.out::println);
+        getSceneListResponse.getScenes().forEach(scene -> log.info("Scene: {}", scene));
       }
 
       this.obsRemoteController.setStudioModeEnabled(false, 1000);
@@ -64,9 +68,9 @@ public class Example {
         (GetStudioModeEnabledResponse requestResponse) -> {
           if (requestResponse.isSuccessful()) {
             if (requestResponse.getStudioModeEnabled()) {
-              System.out.println("Studio mode enabled");
+              log.info("Studio mode enabled");
             } else {
-              System.out.println("Studio mode not enabled");
+              log.info("Studio mode not enabled");
             }
           }
 
@@ -87,8 +91,8 @@ public class Example {
   }
 
   private void onStudioModeStateChanged(StudioModeStateChangedEvent studioModeStateChangedEvent) {
-    System.out.printf(
-        "Studio Mode State Changed to: %B%n",
+    log.info(
+        "Studio Mode State Changed to: {}",
         studioModeStateChangedEvent.getStudioModeEnabled());
   }
 }


### PR DESCRIPTION
Simplelogger should not be included in libraries, use it as a test-dependency instead (not sure if that is the correct scope for Gradle).