### PR TITLE
Change Websocket client to Jetty 11.0.13

### DIFF
--- a/client/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
+++ b/client/src/main/java/io/obswebsocket/community/client/OBSCommunicator.java
@@ -40,7 +40,7 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 @Slf4j
 @WebSocket(
     maxTextMessageSize = 1024 * 1024,
-    maxIdleTime = 360000000
+    idleTimeout = 360000000
 )
 public class OBSCommunicator {
 
@@ -314,7 +314,7 @@ public class OBSCommunicator {
           null
       ));
     } else {
-      this.session.getRemote().sendStringByFuture(message);
+      this.session.getRemote().sendString(message,null);
     }
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             library('lombok', 'org.projectlombok:lombok:1.18.24')
-            library('websocket', 'org.eclipse.jetty.websocket:websocket-client:9.4.49.v20220914')
+            library('websocket', 'org.eclipse.jetty.websocket:websocket-jetty-client:11.0.13')
             library('gson', 'com.google.code.gson:gson:2.9.0')
             library('sl4j-api', 'org.slf4j:slf4j-api:2.0.3')
             library('sl4j-simple', 'org.slf4j:slf4j-simple:2.0.3')


### PR DESCRIPTION
Update to Jetty Websocket requires minimal changes and does not break any tests.

Closes #162 